### PR TITLE
[T003] Create SunnySunday.Server web project

### DIFF
--- a/specs/002-core-infrastructure/tasks.md
+++ b/specs/002-core-infrastructure/tasks.md
@@ -24,7 +24,7 @@
 
 - [X] T001 Create `src/SunnySunday.slnx` solution file in the `src/` directory with `dotnet new sln -n SunnySunday -o src`
 - [X] T002 Create `src/SunnySunday.Core/SunnySunday.Core.csproj` as a class library targeting `net10.0` (SDK: `Microsoft.NET.Sdk`); add to `src/SunnySunday.slnx`
-- [ ] T003 [P] Create `src/SunnySunday.Server/SunnySunday.Server.csproj` as a web application targeting `net10.0` (SDK: `Microsoft.NET.Sdk.Web`); add to `src/SunnySunday.slnx`
+- [X] T003 [P] Create `src/SunnySunday.Server/SunnySunday.Server.csproj` as a web application targeting `net10.0` (SDK: `Microsoft.NET.Sdk.Web`); add to `src/SunnySunday.slnx`
 - [ ] T004 [P] Create `src/SunnySunday.Cli/SunnySunday.Cli.csproj` as a console app targeting `net10.0` (SDK: `Microsoft.NET.Sdk`)
 - [ ] T005 [P] Create `src/SunnySunday.Tests/SunnySunday.Tests.csproj` as an xUnit test project targeting `net10.0` with packages: `xunit`, `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`
 - [X] T006 ~~Add all four projects to `src/SunnySunday.slnx` via `dotnet sln add`~~ — superseded: each project (T002–T005) adds itself to the solution in its own task

--- a/specs/002-core-infrastructure/tasks.md
+++ b/specs/002-core-infrastructure/tasks.md
@@ -24,7 +24,7 @@
 
 - [X] T001 Create `src/SunnySunday.slnx` solution file in the `src/` directory with `dotnet new sln -n SunnySunday -o src`
 - [X] T002 Create `src/SunnySunday.Core/SunnySunday.Core.csproj` as a class library targeting `net10.0` (SDK: `Microsoft.NET.Sdk`); add to `src/SunnySunday.slnx`
-- [ ] T003 [P] Create `src/SunnySunday.Server/SunnySunday.Server.csproj` as a web application targeting `net10.0` (SDK: `Microsoft.NET.Sdk.Web`)
+- [ ] T003 [P] Create `src/SunnySunday.Server/SunnySunday.Server.csproj` as a web application targeting `net10.0` (SDK: `Microsoft.NET.Sdk.Web`); add to `src/SunnySunday.slnx`
 - [ ] T004 [P] Create `src/SunnySunday.Cli/SunnySunday.Cli.csproj` as a console app targeting `net10.0` (SDK: `Microsoft.NET.Sdk`)
 - [ ] T005 [P] Create `src/SunnySunday.Tests/SunnySunday.Tests.csproj` as an xUnit test project targeting `net10.0` with packages: `xunit`, `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`
 - [X] T006 ~~Add all four projects to `src/SunnySunday.slnx` via `dotnet sln add`~~ — superseded: each project (T002–T005) adds itself to the solution in its own task

--- a/src/SunnySunday.Server/Program.cs
+++ b/src/SunnySunday.Server/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/src/SunnySunday.Server/Properties/launchSettings.json
+++ b/src/SunnySunday.Server/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5102",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7028;http://localhost:5102",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/SunnySunday.Server/appsettings.Development.json
+++ b/src/SunnySunday.Server/appsettings.Development.json
@@ -1,8 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
     }
   }
 }

--- a/src/SunnySunday.Server/appsettings.Development.json
+++ b/src/SunnySunday.Server/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/SunnySunday.Server/appsettings.json
+++ b/src/SunnySunday.Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/SunnySunday.slnx
+++ b/src/SunnySunday.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="SunnySunday.Core/SunnySunday.Core.csproj" />
+  <Project Path="SunnySunday.Server/SunnySunday.Server.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

Creates the \SunnySunday.Server\ ASP.NET Core web project targeting \
et10.0\ and registers it in \src/SunnySunday.slnx\.

- SDK: \Microsoft.NET.Sdk.Web\
- Framework: \
et10.0\
- Nullable and ImplicitUsings enabled
- Added to \src/SunnySunday.slnx\

Closes #5