### PR TITLE
[T004-T010] Scaffold Cli/Tests, project references, NuGet packages

### DIFF
--- a/specs/002-core-infrastructure/tasks.md
+++ b/specs/002-core-infrastructure/tasks.md
@@ -25,8 +25,8 @@
 - [X] T001 Create `src/SunnySunday.slnx` solution file in the `src/` directory with `dotnet new sln -n SunnySunday -o src`
 - [X] T002 Create `src/SunnySunday.Core/SunnySunday.Core.csproj` as a class library targeting `net10.0` (SDK: `Microsoft.NET.Sdk`); add to `src/SunnySunday.slnx`
 - [X] T003 [P] Create `src/SunnySunday.Server/SunnySunday.Server.csproj` as a web application targeting `net10.0` (SDK: `Microsoft.NET.Sdk.Web`); add to `src/SunnySunday.slnx`
-- [ ] T004 [P] Create `src/SunnySunday.Cli/SunnySunday.Cli.csproj` as a console app targeting `net10.0` (SDK: `Microsoft.NET.Sdk`)
-- [ ] T005 [P] Create `src/SunnySunday.Tests/SunnySunday.Tests.csproj` as an xUnit test project targeting `net10.0` with packages: `xunit`, `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`
+- [X] T004 [P] Create `src/SunnySunday.Cli/SunnySunday.Cli.csproj` as a console app targeting `net10.0` (SDK: `Microsoft.NET.Sdk`); add to `src/SunnySunday.slnx`; add stub `Program.cs`
+- [X] T005 [P] Create `src/SunnySunday.Tests/SunnySunday.Tests.csproj` as an xUnit test project targeting `net10.0` with packages: `xunit`, `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`; add to `src/SunnySunday.slnx`
 - [X] T006 ~~Add all four projects to `src/SunnySunday.slnx` via `dotnet sln add`~~ — superseded: each project (T002–T005) adds itself to the solution in its own task
 
 ---
@@ -37,10 +37,10 @@
 
 **⚠️ CRITICAL**: T007–T010 must complete before US1/US2/US3 implementation tasks.
 
-- [ ] T007 Add project reference `SunnySunday.Core` → in `SunnySunday.Server.csproj`
-- [ ] T008 [P] Add project reference `SunnySunday.Core` → in `SunnySunday.Cli.csproj`
-- [ ] T009 Add project references `SunnySunday.Core`, `SunnySunday.Server`, `SunnySunday.Cli` → in `SunnySunday.Tests.csproj`
-- [ ] T010 [P] Add NuGet packages to `SunnySunday.Server.csproj`: `Microsoft.Data.Sqlite`, `Serilog`, `Serilog.Sinks.File`, `Serilog.Sinks.SQLite`, `Serilog.Extensions.Hosting`
+- [X] T007 Add project reference `SunnySunday.Core` → in `SunnySunday.Server.csproj`
+- [X] T008 [P] Add project reference `SunnySunday.Core` → in `SunnySunday.Cli.csproj`
+- [X] T009 Add project references `SunnySunday.Core`, `SunnySunday.Server`, `SunnySunday.Cli` → in `SunnySunday.Tests.csproj`
+- [X] T010 [P] Add NuGet packages to `SunnySunday.Server.csproj`: `Microsoft.Data.Sqlite`, `Serilog`, `Serilog.Sinks.File`, `Serilog.Sinks.SQLite`, `Serilog.Extensions.Hosting`
 
 **Checkpoint**: All project references and packages restored — user story implementation can begin.
 

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -1,0 +1,2 @@
+// Entry point — bootstrapped with Spectre.Console in T016
+return;

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\SunnySunday.Core\SunnySunday.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -1,5 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <ItemGroup>
+    <ProjectReference Include="..\SunnySunday.Core\SunnySunday.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.SQLite" Version="6.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/SunnySunday.Tests/SunnySunday.Tests.csproj
+++ b/src/SunnySunday.Tests/SunnySunday.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SunnySunday.Core\SunnySunday.Core.csproj" />
+    <ProjectReference Include="..\SunnySunday.Server\SunnySunday.Server.csproj" />
+    <ProjectReference Include="..\SunnySunday.Cli\SunnySunday.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SunnySunday.slnx
+++ b/src/SunnySunday.slnx
@@ -1,4 +1,6 @@
 <Solution>
+  <Project Path="SunnySunday.Cli/SunnySunday.Cli.csproj" />
   <Project Path="SunnySunday.Core/SunnySunday.Core.csproj" />
   <Project Path="SunnySunday.Server/SunnySunday.Server.csproj" />
+  <Project Path="SunnySunday.Tests/SunnySunday.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

Completes issues #6–#12 in a single PR.

### Changes

**T004 (#6)** — \src/SunnySunday.Cli\ console project (\
et10.0\), stub \Program.cs\, added to \src/SunnySunday.slnx\
**T005 (#7)** — \src/SunnySunday.Tests\ xUnit project (\
et10.0\), added to \src/SunnySunday.slnx\
**T006 (#8)** — superseded (each project adds itself to the solution in its own task)
**T007 (#9)** — \SunnySunday.Core\ → \SunnySunday.Server\ project reference
**T008 (#10)** — \SunnySunday.Core\ → \SunnySunday.Cli\ project reference
**T009 (#11)** — \SunnySunday.Core\ + \SunnySunday.Server\ + \SunnySunday.Cli\ → \SunnySunday.Tests\ project references
**T010 (#12)** — NuGet packages added to \SunnySunday.Server\: \Microsoft.Data.Sqlite\, \Serilog\, \Serilog.Sinks.File\, \Serilog.Sinks.SQLite\, \Serilog.Extensions.Hosting\

\dotnet build src/SunnySunday.slnx\ → 0 errors, 0 build errors (1 informational RID warning from SQLite package, non-blocking).

Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11
Closes #12