### PR TITLE
ci: add CI pipeline with Docker-based build and test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,334 @@
+### VisualStudio ###
+
+# Tool Runtime Dir
+**/.dotnet/
+**/.packages/
+**/.tools/
+
+# User-specific files
+**/*.suo
+**/*.user
+**/*.userosscache
+**/*.sln.docstates
+
+# Build results
+**/artifacts/
+**/.idea/
+**/[Dd]ebug/
+**/[Dd]ebugPublic/
+**/[Rr]elease/
+**/[Rr]eleases/
+**/bld/
+**/[Bb]in/
+**/[Oo]bj/
+**/msbuild.log
+**/msbuild.err
+**/msbuild.wrn
+**/msbuild.binlog
+**/.deps/
+**/.dirstamp
+**/.libs/
+**/*.lo
+**/*.o
+
+# Cross building rootfs
+**/cross/rootfs/
+**/cross/android-rootfs/
+
+# Visual Studio
+**/.vs/
+
+# Ionide
+**/.ionide/
+
+# MSTest test Results
+**/[Tt]est[Rr]esult*/
+**/[Bb]uild[Ll]og.*
+
+#NUNIT
+**/*.VisualState.xml
+**/TestResult.xml
+
+# Build Results of an ATL Project
+**/[Dd]ebugPS/
+**/[Rr]eleasePS/
+**/dlldata.c
+
+**/*_i.c
+**/*_p.c
+**/*.ilk
+**/*.meta
+**/*.obj
+**/*.pch
+**/*.pdb
+!**/_.pdb
+**/*.pgc
+**/*.pgd
+**/*.rsp
+**/*.sbr
+**/*.tlb
+**/*.tli
+**/*.tlh
+**/*.tmp
+**/*.tmp_proj
+**/*.log
+**/*.vspscc
+**/*.vssscc
+**/.builds
+**/*.pidb
+**/*.svclog
+**/*.scc
+
+# Chutzpah Test files
+**/_Chutzpah*
+
+# Visual C++ cache files
+**/ipch/
+**/*.aps
+**/*.ncb
+**/*.opendb
+**/*.opensdf
+**/*.sdf
+**/*.cachefile
+**/*.VC.db
+
+# Visual Studio profiler
+**/*.psess
+**/*.vsp
+**/*.vspx
+
+# TFS 2012 Local Workspace
+**/$tf/
+
+# Guidance Automation Toolkit
+**/*.gpState
+
+# ReSharper is a .NET coding add-in
+**/_ReSharper*/
+**/*.[Rr]e[Ss]harper
+**/*.DotSettings.user
+
+# JustCode is a .NET coding addin-in
+**/.JustCode
+
+# TeamCity is a build add-in
+**/_TeamCity*
+
+# DotCover is a Code Coverage Tool
+**/*.dotCover
+
+# NCrunch
+**/_NCrunch_*
+**/.*crunch*.local.xml
+
+# MightyMoose
+**/*.mm.*
+**/AutoTest.Net/
+
+# Web workbench (sass)
+**/.sass-cache/
+
+# Installshield output folder
+**/[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+**/DocProject/buildhelp/
+**/DocProject/Help/*.HxT
+**/DocProject/Help/*.HxC
+**/DocProject/Help/*.hhc
+**/DocProject/Help/*.hhk
+**/DocProject/Help/*.hhp
+**/DocProject/Help/Html2
+**/DocProject/Help/html
+
+# Publish Web Output
+**/*.[Pp]ublish.xml
+**/*.azurePubxml
+**/*.pubxml
+**/*.publishproj
+
+# NuGet Packages
+**/*.nupkg
+**/*.nuget.g.props
+**/*.nuget.g.targets
+**/*.nuget.cache
+**/**/packages/*
+**/project.lock.json
+**/project.assets.json
+**/*.nuget.dgspec.json
+
+# Windows Azure Build Output
+**/csx/
+**/*.build.csdef
+
+# Windows Store app package directory
+**/AppPackages/
+
+# Others
+**/*.Cache
+**/ClientBin/
+**/[Ss]tyle[Cc]op.*
+**/~$*
+**/*.dbmdl
+**/*.dbproj.schemaview
+**/*.pfx
+**/*.publishsettings
+**/node_modules/
+**/*.metaproj
+**/*.metaproj.tmp
+**/bin.localpkg/
+
+# RIA/Silverlight projects
+**/Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+**/_UpgradeReport_Files/
+**/Backup*/
+**/UpgradeLog*.XML
+**/UpgradeLog*.htm
+
+# SQL Server files
+**/*.mdf
+**/*.ldf
+
+# Business Intelligence projects
+**/*.rdl.data
+**/*.bim.layout
+**/*.bim_*.settings
+
+# Microsoft Fakes
+**/FakesAssemblies/
+
+# C/C++ extension for Visual Studio Code
+**/browse.VC.db
+# Local settings folder for Visual Studio Code
+**/**/.vscode/**
+!**/**/.vscode/c_cpp_properties.json
+
+### MonoDevelop ###
+
+**/*.pidb
+**/*.userprefs
+
+### Windows ###
+
+# Windows image file caches
+**/Thumbs.db
+**/ehthumbs.db
+
+# Folder config file
+**/Desktop.ini
+
+# Recycle Bin used on file shares
+**/$RECYCLE.BIN/
+
+# Windows Installer files
+**/*.cab
+**/*.msi
+**/*.msm
+**/*.msp
+
+# Windows shortcuts
+**/*.lnk
+
+### Linux ###
+
+**/*~
+
+# KDE directory preferences
+**/.directory
+
+### OSX ###
+
+**/.DS_Store
+**/.AppleDouble
+**/.LSOverride
+
+# Icon must end with two \r
+**/Icon
+
+# Thumbnails
+**/._*
+
+# Files that might appear on external disk
+**/.Spotlight-V100
+**/.Trashes
+
+# Directories potentially created on remote AFP share
+**/.AppleDB
+**/.AppleDesktop
+**/Network Trash Folder
+**/Temporary Items
+**/.apdisk
+
+# vim temporary files
+**/[._]*.s[a-w][a-z]
+**/[._]s[a-w][a-z]
+**/*.un~
+**/Session.vim
+**/.netrwhist
+**/*~
+
+# Visual Studio Code
+**/.vscode/
+
+# Private test configuration and binaries.
+**/config.ps1
+**/**/IISApplications
+
+# VS debug support files
+**/launchSettings.json
+
+# Snapcraft files
+**/.snapcraft
+**/*.snap
+**/parts/
+**/prime/
+**/stage/
+
+# CLR prebuilt generated files
+!**/src/pal/prebuilt/idl/*_i.c
+
+# Valid 'debug' folder, that contains CLR debugging code
+!**/src/**/debug
+
+# Ignore folders created by the CLR test build
+**/TestWrappers_x64_[d|D]ebug
+**/TestWrappers_x64_[c|C]hecked
+**/TestWrappers_x64_[r|R]elease
+**/TestWrappers_x86_[d|D]ebug
+**/TestWrappers_x86_[c|C]hecked
+**/TestWrappers_x86_[r|R]elease
+**/TestWrappers_arm_[d|D]ebug
+**/TestWrappers_arm_[c|C]hecked
+**/TestWrappers_arm_[r|R]elease
+**/TestWrappers_arm64_[d|D]ebug
+**/TestWrappers_arm64_[c|C]hecked
+**/TestWrappers_arm64_[r|R]elease
+**/tests/src/common/test_runtime/project.json
+
+**/Vagrantfile
+**/.vagrant
+
+# CMake files
+**/CMakeFiles/
+**/cmake_install.cmake
+**/CMakeCache.txt
+**/Makefile
+
+# Cross compilation
+**/cross/rootfs/*
+**/cross/android-rootfs/*
+# add x86 as it is ignored in 'Build results'
+!**/cross/x86
+
+#python import files
+**/*.pyc
+
+# JIT32 files
+**/src/jit32
+
+# performance testing sandbox
+**/sandbox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile.ci'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile.ci'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the solution inside the CI image. Layer cache is preserved across runs
+      # via GitHub Actions cache, so only changed layers are rebuilt.
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ci
+          target: build
+          tags: sunny-sunday-ci:latest
+          # Load the image into the local Docker daemon so the next step can run it.
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Run tests inside the built image. Output is written to a bind-mounted directory
+      # so results are available to subsequent steps even when tests fail.
+      - name: Run tests
+        run: |
+          mkdir -p test-results
+          docker run --rm \
+            -v "${{ github.workspace }}/test-results:/test-results" \
+            sunny-sunday-ci:latest \
+            dotnet test /src/SunnySunday.Tests/SunnySunday.Tests.csproj \
+              --no-build \
+              --configuration Release \
+              --logger "trx;LogFileName=results.trx" \
+              --results-directory /test-results
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'Dockerfile.ci'
-      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
     paths:
@@ -21,27 +15,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      # Build the solution inside the CI image. Layer cache is preserved across runs
-      # via GitHub Actions cache, so only changed layers are rebuilt.
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
+          push: false
           context: .
           file: Dockerfile.ci
           target: build
           tags: sunny-sunday-ci:latest
-          # Load the image into the local Docker daemon so the next step can run it.
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Run tests inside the built image. Output is written to a bind-mounted directory
-      # so results are available to subsequent steps even when tests fail.
       - name: Run tests
         run: |
           mkdir -p test-results
@@ -56,8 +46,8 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: test-results/
-          if-no-files-found: ignore
+          if-no-files-found: warn

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,12 @@
+# Dockerfile.ci — used by CI to run tests in a consistent, reproducible environment.
+# Not intended for production deployment (see Dockerfile.server / Dockerfile.cli for that).
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS restore
+WORKDIR /src
+COPY src/ .
+RUN dotnet restore SunnySunday.slnx
+
+FROM restore AS build
+RUN dotnet build SunnySunday.slnx \
+    --no-restore \
+    --configuration Release

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,12 +1,12 @@
 # Dockerfile.ci — used by CI to run tests in a consistent, reproducible environment.
 # Not intended for production deployment (see Dockerfile.server / Dockerfile.cli for that).
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS restore
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS base
 WORKDIR /src
 COPY src/ .
 RUN dotnet restore SunnySunday.slnx
 
-FROM restore AS build
+FROM base AS build
 RUN dotnet build SunnySunday.slnx \
     --no-restore \
     --configuration Release


### PR DESCRIPTION
## What

Adds a CI pipeline that runs on every push/PR to `main` that touches `src/**`, `Dockerfile.ci`, or the workflow file itself.

## How it works

- **`Dockerfile.ci`** — multi-stage image (`restore` → `build`) using `mcr.microsoft.com/dotnet/sdk:10.0`. Keeps the test environment reproducible and independent of the runner.
- **`.github/workflows/ci.yml`** — triggered only on relevant path changes (no noise from docs/README changes):
  1. Build step uses `docker/build-push-action` with GitHub Actions layer cache — only changed layers are rebuilt
  2. Test step runs `dotnet test` inside the built container via `docker run` with a bind-mounted volume, so `.trx` results are always accessible even on failure
  3. Results uploaded as artifact on every run (success and failure)

## Notes

- Currently `SunnySunday.Tests` is empty so CI passes with "No test available". Results artifact will populate once tests are written.
- Path filter is at `src/**` granularity; can be split per-component when independent test suites are added.
