### PR TITLE
[chore] Update Copilot instructions: feature task structure, TDD, ADR, workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+insert_final_newline = true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,82 +1,63 @@
 # Copilot Instructions — Sunny Sunday
 
+> Quick links: [Architecture](../docs/ARCHITECTURE.md) · [DX](../docs/DX.md) · [PRD](../docs/PRD.md)
+
 ## Project overview
 
-Sunny Sunday is a self-hosted, open source tool that delivers periodic recap documents of Kindle highlights directly to the user's Kindle device via Amazon's Send-to-Kindle email service.
+Self-hosted tool that delivers Kindle highlight recaps to the user's Kindle via Send-to-Kindle email. Architecture: `sunny` CLI (client) + `sunny-server` Docker container (server).
 
-Architecture: **client/server**
-- `sunny` — client CLI (single-file .NET binary, macOS/Linux/Windows)
-- `sunny-server` — server (Docker container, always-on)
+**Stack:** C# / .NET 10 · SQLite (`/data/sunny.db`) · Serilog · MailKit · Quartz.NET · Spectre.Console · REST HTTP (no auth, MVP)
 
-## Technology stack
-
-- **Language:** C# / .NET 10
-- **Storage:** SQLite (file in Docker volume at `.data/sunny.db`)
-- **Logging:** Serilog (file sink + SQLite sink)
-- **Email:** MailKit + SMTP
-- **Scheduling:** Quartz.NET
-- **CLI UX:** Spectre.Console
-- **Protocol:** REST HTTP (JSON), no authentication for MVP
-
-## Repository structure
-
-```
-src/
-  SunnySunday.Cli/        # Client CLI
-  SunnySunday.Server/     # Server (REST API + scheduler + email sender)
-  SunnySunday.Core/       # Shared models, interfaces, parsers
-  SunnySunday.Tests/      # Tests
-docs/
-  DX.md                   # Developer Experience design
-  ARCHITECTURE.md         # Architecture overview and data model
-  adr/                    # Architecture Decision Records
-specs/
-  001-sunny-sunday/       # spec-kit specification
-    spec.md
-```
-
-## Key domain concepts
-
-- **Highlight** — a text passage marked by the user on their Kindle, sourced from `My Clippings.txt`
-- **Recap** — a document containing N highlights (default 3, range 1–15), sent to the user's Kindle on a schedule
-- **Spaced repetition** — highlights seen less recently are prioritized; user-defined weights bias selection probability
-- **Exclusion** — a highlight, book, or author excluded from all future recaps; exclusions are reversible via `sunny exclude remove`
-- **Weight** — an integer (1–5) assigned to a highlight; higher weight = higher probability of appearing in a recap
+**Solution:** `src/SunnySunday.slnx` → Core · Server · Cli · Tests
 
 ## Coding conventions
 
-- Follow standard .NET/C# conventions (PascalCase for types, camelCase for variables)
-- Keep the server and client deployable independently
-- All REST endpoints return JSON
-- Errors must be actionable — include what went wrong and how to fix it
-- No config file editing for the user — all settings managed via CLI commands and stored server-side
+- .NET/C# conventions (PascalCase types, camelCase variables)
+- All REST endpoints return JSON; errors are actionable
+- TDD where applicable (e.g. API endpoints, parsers); not required for mechanical changes (e.g. NuGet updates, csproj edits)
+- When adding new .NET projects: `dotnet sln src/SunnySunday.slnx add src/<Project>/<Project>.csproj` in the same PR
+- Diagrams: Mermaid preferred; ASCII only for spatial layouts
 
-## Active Technologies
-- C# / .NET 10 (net10.0 TFM) + Microsoft.Data.Sqlite (schema bootstrap), Serilog + Serilog.Sinks.File + Serilog.Sinks.SQLite (logging), Spectre.Console (CLI host — no commands yet) (002-core-infrastructure)
-- SQLite at `/data/sunny.db` (single file, Docker volume) (002-core-infrastructure)
+## ADR conventions
 
-## Recent Changes
-- 002-core-infrastructure: Added C# / .NET 10 (net10.0 TFM) + Microsoft.Data.Sqlite (schema bootstrap), Serilog + Serilog.Sinks.File + Serilog.Sinks.SQLite (logging), Spectre.Console (CLI host — no commands yet)
+ADRs live in `docs/adr/`. Statuses: `accepted` · `active` (under decision) · `retired` · `superseded`.
+When superseded, both involved ADRs must link to each other.
+Register a new ADR whenever a significant architectural decision is made during spec-kit design.
 
-## Implementation Workflow (per-task conventions)
+## GitHub Project conventions
 
-Each task follows this exact sequence — **no exceptions**:
+**Kanban:** project #2 `PVT_kwHOAHg8ss4BT_OI` · field `PVTSSF_lAHOAHg8ss4BT_OIzhBKY1M`
+Statuses: `Backlog=f75ad846` · `Ready=61e4505c` · `In progress=47fc9ee4` · `In review=df73e18b` · `Done=98236657`
 
-1. **Branch**: `git checkout main && git pull && git checkout -b task/TXXX-short-description`
-2. **Implement**: make the code/file changes for the task
-3. **Update `tasks.md`**: mark the task `[X]` in `specs/<feature>/tasks.md` **on the same branch, before committing**
-4. **Commit & push**: include both the implementation files and `tasks.md` in the same branch but on separated commits
-5. **Ensure issue exists**: every PR must link to a GitHub issue via `Closes #N`. If no issue exists for the work (e.g. chore, hotfix, unplanned task), create one first: `gh issue create --title "..." --body "..." --label "..."`, add it to the kanban project, then use its number in the PR body
-6. **Open PR**: `gh pr create --title "[TXXX] ..." --body "... Closes #N" --label "feature:00X-..." --base main`
-7. **Kanban → In review**: `gh project item-edit --id <ITEM_ID> ... --single-select-option-id df73e18b`
-8. **Wait for merge**: do not start the next task until the PR is merged to main
-9. **After merge**: pull main, move kanban item → Done (`98236657`), then start next task
+### Task structure for spec-kit features
 
-### tasks.md update rules
-- Mark a task `[X]` **as soon as it is implemented**, on the same branch where the work was done
-- Push the `tasks.md` change to the branch so the PR diff always includes the completion marker
-- Never leave a task as `[ ]` on a branch where that task's work has already been committed
+Each feature (e.g. `003-highlight-parser`) has **one parent task** on the kanban with label `feature:00X-name`. The parent task contains:
 
-### .slnx convention
-- When a new dotnet project is created, add it to `src/SunnySunday.slnx` **in the same PR that creates it**
-- Command: `dotnet sln src/SunnySunday.slnx add src/<ProjectName>/<ProjectName>.csproj`
+1. **Design subtask** — runs spec-kit (`/speckit.specify` → `/speckit.plan` → `/speckit.tasks`); produces `specs/00X/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `tasks.md`; implementation subtasks are created here
+2. **Implementation subtasks** — one per phase defined in `tasks.md`; each subtask carries the same label as the parent
+
+For non-feature tasks (e.g. CI/CD pipeline), check existing labels first. If no label matches, ask the user before proceeding.
+
+Task descriptions must be self-contained: an agent must be able to implement a task by reading only the repo docs and the task description.
+
+### PR ↔ Task link rules
+
+- Every PR must close a GitHub issue via `Closes #N` in the body
+- PR labels must match the linked task's label
+- Opening a PR → move task to `In review`
+- Merging a PR → move task to `Done`
+- If no issue exists, create one first, add it to the kanban project, then open the PR
+
+### tasks.md rules
+
+- Mark a task `[X]` on the same branch where the work was done, before pushing
+- Never leave `[ ]` on a branch where that task's work is already committed
+
+## Implementation workflow (per PR)
+
+1. `git checkout main && git pull && git checkout -b task/TXXX-short-description`
+2. Implement; mark `[X]` in `tasks.md`; commit both together
+3. If applicable, update living docs (`ARCHITECTURE.md`, etc.) in the same PR
+4. `gh pr create --title "[TXXX] ..." --body "... Closes #N" --label "..." --base main`
+5. Move kanban → `In review`
+6. After merge: `git pull main`, move kanban → `Done`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,6 +78,6 @@ Task descriptions must be self-contained: an agent must be able to implement a t
 1. `git checkout main && git pull && git checkout -b task/TXXX-short-description`
 2. Implement; mark `[X]` in `tasks.md`; commit both together
 3. If applicable, update living docs (`ARCHITECTURE.md`, etc.) in the same PR
-4. `gh pr create --title "[TXXX] ..." --body "... Closes #N" --label "..." --base main`
+4. `gh pr create --title "<descriptive title, no conventional commit prefix>" --body "... Closes #N" --label "..." --base main`
 5. Move kanban → `In review`
 6. After merge: `git pull main`, move kanban → `Done`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ When asked to start a feature, follow this exact order **before writing any code
 
 1. Create the **Design subtask** issue (label = parent label), add to kanban → move to `In progress`
 2. Create the **Implementation subtask** issue (label = parent label), add to kanban → leave in `Backlog`
-3. Run spec-kit: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks`
+3. Run spec-kit: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks` — **each step requires user involvement**: ask the user for all decisions, feature preferences, constraints, and clarifications before proceeding to the next step; do not make assumptions on scope or design choices
 4. Once `tasks.md` is ready, create **one implementation phase subtask** per phase defined in `tasks.md`; each phase subtask is a child of the Implementation subtask issue (same label); add each to kanban → `Backlog`
 5. Mark Design subtask PR → `In review`; on merge → `Done`; move Implementation subtask → `In progress` and begin phase-by-phase implementation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,16 @@ Each feature (e.g. `003-highlight-parser`) has **one parent task** on the kanban
 1. **Design subtask** — runs spec-kit (`/speckit.specify` → `/speckit.plan` → `/speckit.tasks`); produces `specs/00X/spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `tasks.md`; implementation subtasks are created here
 2. **Implementation subtasks** — one per phase defined in `tasks.md`; each subtask carries the same label as the parent
 
+### Feature start sequence
+
+When asked to start a feature, follow this exact order **before writing any code or spec**:
+
+1. Create the **Design subtask** issue (label = parent label), add to kanban → move to `In progress`
+2. Create the **Implementation subtask** issue (label = parent label), add to kanban → leave in `Backlog`
+3. Run spec-kit: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks`
+4. Once `tasks.md` is ready, create **one implementation phase subtask** per phase defined in `tasks.md`; each phase subtask is a child of the Implementation subtask issue (same label); add each to kanban → `Backlog`
+5. Mark Design subtask PR → `In review`; on merge → `Done`; move Implementation subtask → `In progress` and begin phase-by-phase implementation
+
 For non-feature tasks (e.g. CI/CD pipeline), check existing labels first. If no label matches, ask the user before proceeding.
 
 Task descriptions must be self-contained: an agent must be able to implement a task by reading only the repo docs and the task description.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,9 +12,9 @@ Self-hosted tool that delivers Kindle highlight recaps to the user's Kindle via 
 
 ## Coding conventions
 
-- .NET/C# conventions (PascalCase types, camelCase variables)
-- All REST endpoints return JSON; errors are actionable
-- TDD where applicable (e.g. API endpoints, parsers); not required for mechanical changes (e.g. NuGet updates, csproj edits)
+- .NET/C# conventions (use already installed skills csharp-async, dotnet-best-practices, dotnet-upgrade,etc.)
+- All REST endpoints return JSON; errors are actionable 
+- TDD where applicable (e.g. API endpoints, parsers) using already installed skills csharp-xunit, etc.; not required for mechanical changes (e.g. NuGet updates, csproj edits)
 - When adding new .NET projects: `dotnet sln src/SunnySunday.slnx add src/<Project>/<Project>.csproj` in the same PR
 - Diagrams: Mermaid preferred; ASCII only for spatial layouts
 
@@ -26,8 +26,18 @@ Register a new ADR whenever a significant architectural decision is made during 
 
 ## GitHub Project conventions
 
-**Kanban:** project #2 `PVT_kwHOAHg8ss4BT_OI` · field `PVTSSF_lAHOAHg8ss4BT_OIzhBKY1M`
-Statuses: `Backlog=f75ad846` · `Ready=61e4505c` · `In progress=47fc9ee4` · `In review=df73e18b` · `Done=98236657`
+**Kanban:** project #2 on `Krusty93/sunny-sunday`. Use `gh` CLI to resolve IDs at runtime:
+- Project ID + status field ID: `gh project view 2 --owner Krusty93 --format json`
+- Status option IDs: `gh project field-list 2 --owner Krusty93 --format json`
+- Item ID for an issue: `gh api graphql -f query='{ repository(owner:"Krusty93", name:"sunny-sunday") { issue(number:N) { projectItems(first:1) { nodes { id } } } } }'`
+- Move item: `gh project item-edit --id <ITEM_ID> --project-id <PROJECT_ID> --field-id <FIELD_ID> --single-select-option-id <OPTION_ID>`
+
+Status names: `Backlog` · `Ready` · `In progress` · `In review` · `Done`
+
+### Task lifecycle
+
+**Before starting any task or feature:** move the kanban item to `In progress`, then begin implementation.
+**On PR open:** move to `In review`. **On PR merge:** move to `Done`.
 
 ### Task structure for spec-kit features
 

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,432 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = false
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 4
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Powershell files
+[*.ps1]
+indent_size = 2
+
+# Shell script files
+[*.sh]
+end_of_line = lf
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# Sort using and Import directives with System.* appearing first (currently not working)
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Async methods should have "Async" suffix
+dotnet_naming_rule.async_methods_end_in_async.symbols = any_async_methods
+dotnet_naming_rule.async_methods_end_in_async.style = end_in_async
+dotnet_naming_rule.async_methods_end_in_async.severity = warning
+
+dotnet_naming_symbols.any_async_methods.applicable_kinds = method
+dotnet_naming_symbols.any_async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.any_async_methods.required_modifiers = async
+
+dotnet_naming_style.end_in_async.required_prefix = 
+dotnet_naming_style.end_in_async.required_suffix = Async
+dotnet_naming_style.end_in_async.capitalization = pascal_case
+dotnet_naming_style.end_in_async.word_separator =
+
+# IDE0004: Remove unnecessary cast
+dotnet_diagnostic.IDE0004.severity = warning
+
+# IDE0005: Remove unnecessary import
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0010: Add missing cases to switch statement
+dotnet_diagnostic.IDE0010.severity = none
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0042: Deconstruct variable declaration
+dotnet_diagnostic.IDE0042.severity = none
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0051: Remove unused private member
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0055: Expression level 
+dotnet_diagnostic.IDE0055.severity = warning
+
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
+
+# IDE0063: Use simple 'using' statement
+dotnet_diagnostic.IDE0063.severity = warning
+
+# IDE0070: Use 'System.HashCode.Combine'
+dotnet_diagnostic.IDE0070.severity = suggestion
+
+# IDE0072: Add missing cases to switch expression
+dotnet_diagnostic.IDE0072.severity = suggestion
+
+# IDE0075: Simplify conditional expression
+dotnet_diagnostic.IDE0075.severity = warning
+
+# IDE0082: Convert typeof to nameof
+dotnet_diagnostic.IDE0082.severity = warning
+
+# IDE0100: Remove unnecessary equality operator
+dotnet_diagnostic.IDE0100.severity = warning
+
+# IDE0110: Remove unnecessary discard
+dotnet_diagnostic.IDE0110.severity = warning
+
+# IDE2000: Allow Multiple Blank Lines (experimental)
+dotnet_style_allow_multiple_blank_lines_experimental = false:error
+dotnet_diagnostic.IDE2000.severity = error
+
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = false:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_all_upper.severity = warning
+dotnet_naming_rule.constants_should_be_all_upper.symbols = constants
+dotnet_naming_rule.constants_should_be_all_upper.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = all_upper
+
+# Static fields are camelCase and start with s_
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+dotnet_naming_style.static_field_style.required_prefix = s_
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Public and Protected field are PascalCase
+dotnet_naming_rule.public_or_protected_field_should_be_pascal_case.severity = warning
+dotnet_naming_rule.public_or_protected_field_should_be_pascal_case.symbols = public_or_protected_field
+dotnet_naming_rule.public_or_protected_field_should_be_pascal_case.style = pascal_case
+dotnet_naming_style.public_or_protected_field_style.required_prefix = 
+
+# Public and Protected properties are PascalCase
+dotnet_naming_rule.public_or_protected_property_should_be_pascal_case.severity = warning
+dotnet_naming_rule.public_or_protected_property_should_be_pascal_case.symbols = public_or_protected_property
+dotnet_naming_rule.public_or_protected_property_should_be_pascal_case.style = pascal_case
+dotnet_naming_style.public_or_protected_property_style.required_prefix = 
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Simplify interpolation
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+
+# Code quality rules
+# Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
+
+# Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = warning
+
+# Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = warning
+
+# Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = warning
+
+# Implement IDisposable correctly
+dotnet_diagnostic.CA1063.severity = warning
+
+# Implement IEquatable when overriding Equals
+dotnet_diagnostic.CA1066.severity = warning
+
+# Override Equals when implementing IEquatable
+dotnet_diagnostic.CA1067.severity = warning
+
+# Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = suggestion
+
+# Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = suggestion
+
+# Identifiers should differ by more than case
+dotnet_diagnostic.CA1708.severity = warning
+dotnet_code_quality.CA1708.api_surface = internal
+
+# Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = warning
+dotnet_code_quality.CA1710.api_surface = public
+
+# Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = warning
+
+# Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = suggestion
+
+# Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = suggestion
+
+# Type Names Should Not Match Namespaces
+dotnet_diagnostic.CA1724.severity = warning
+
+# Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# Review unused parameters
+dotnet_diagnostic.CA1801.severity = warning
+
+# Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = warning
+
+# Call GC.SuppressFinalize correctly
+dotnet_diagnostic.CA1816.severity = warning
+
+# Mark members as static
+dotnet_diagnostic.CA1822.severity = warning
+
+# Use Length/Count property instead of Enumerable.Count method
+dotnet_diagnostic.CA1829.severity = warning
+
+# Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = warning
+
+# Disposable fields should be disposed
+dotnet_diagnostic.CA2213.severity = warning
+
+# Do not call overridable methods in constructors
+dotnet_diagnostic.CA2214.severity = warning
+
+# Dispose methods should call base class dispose
+dotnet_diagnostic.CA2215.severity = warning
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = crlf
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# CSharp code style settings:
+[*.cs]
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Whitespace options
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = false:silent
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Blocks are allowed
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Unused variables
+csharp_style_unused_value_assignment_preference = discard_variable:warning
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+[src/**{.UnitTests,/Controllers}/**.cs]
+# Async methods should have "Async" suffix
+dotnet_naming_rule.async_methods_end_in_async.severity = none
+
+[src/P0.**.Functions/**Function.cs]
+# Async methods should have "Async" suffix
+dotnet_naming_rule.async_methods_end_in_async.severity = none
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = none
+
+[src/**{.UnitTests}/**.cs]
+# Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none
+
+[src/**{.Infrastructure}/Repositories/**Repository.cs]
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <AllEnabledByDefault>True</AllEnabledByDefault>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <Authors>Andrea Grillo</Authors>
+    <Copyright>Copyright © Andrea Grillo $([System.DateTime]::Now.ToString('yyyy'))</Copyright>
+    <NeutralLanguage>en</NeutralLanguage>
+    <EnableNETAnalyzer>True</EnableNETAnalyzer>
+    <AnalysisLevel>latest</AnalysisLevel> 
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AllEnabledByDefault>True</AllEnabledByDefault>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Rewrites \.github/copilot-instructions.md\ with the conventions agreed during feature 002 implementation and expanded design discussions.

**Changes:**
- Feature task structure: parent task → design subtask → implementation subtasks (one per phase)
- TDD mandate where applicable; excluded for mechanical changes
- ADR conventions with statuses and superseded links
- Non-feature task label policy (check existing labels, ask if none match)
- Task descriptions must be self-contained
- Living docs (ARCHITECTURE.md etc.) must be updated in the same PR when applicable
- File kept under 150 lines cap

Closes #53