### PR TITLE
Versioning foundation: .versionize, Version tags in .csproj, devcontainer versionize

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 		},
     "ghcr.io/devcontainers-extra/features/uv:1": {}
 	},
-  "postCreateCommand": "uv tool install specify-cli --from git+https://github.com/github/spec-kit.git",
+  "postCreateCommand": "uv tool install specify-cli --from git+https://github.com/github/spec-kit.git && dotnet tool install -g versionize && echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> ~/.bashrc",
   "postStartCommand": {
     "set-workspace-as-safe-dir": "git config --global --add safe.directory ${containerWorkspaceFolder}",
     "dotnet-https-cert": "dotnet dev-certs https"

--- a/.versionize
+++ b/.versionize
@@ -1,0 +1,7 @@
+{
+  "projects": [
+    { "name": "core",   "path": "src/SunnySunday.Core"   },
+    { "name": "cli",    "path": "src/SunnySunday.Cli"     },
+    { "name": "server", "path": "src/SunnySunday.Server"  }
+  ]
+}

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <Version>0.1.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Core/SunnySunday.Core.csproj
+++ b/src/SunnySunday.Core/SunnySunday.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Version>0.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <Version>0.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

- Create `.versionize` at repo root with `core`, `cli`, `server` component paths
- Add `<Version>0.1.0</Version>` to `SunnySunday.Core.csproj`, `SunnySunday.Cli.csproj`, and `SunnySunday.Server.csproj`
- Update `.devcontainer/devcontainer.json` to install `versionize` dotnet global tool in `postCreateCommand`

These are the foundation required by the CI version-bump-check job (issue #57) which reads `.versionize` dynamically and checks `<Version>` in each `.csproj`.

Closes #56
