### PR TITLE
[T022-T024] Wire Serilog structured logging to file and SQLite sinks

### DIFF
--- a/specs/002-core-infrastructure/tasks.md
+++ b/specs/002-core-infrastructure/tasks.md
@@ -81,9 +81,9 @@
 
 **Independent Test**: Start server, make one HTTP request, verify log file exists and `SELECT COUNT(*) FROM Logs` > 0.
 
-- [ ] T022 [US3] Create `src/SunnySunday.Server/Infrastructure/Logging/SerilogConfiguration.cs` — static helper `ConfigureLogging(WebApplicationBuilder builder, string dbPath)` that: (1) calls `Directory.CreateDirectory(".data/logs")` to ensure the log directory exists before Serilog initializes, (2) configures Serilog with file sink (`.data/logs/sunny-.log`, rolling interval daily, minimum level `Information`) and SQLite sink (`dbPath`, table `Logs`, minimum level `Warning`); both paths are hardcoded constants — no env var
-- [ ] T023 [US3] Wire `SerilogConfiguration.ConfigureLogging()` into `src/SunnySunday.Server/Program.cs` — call it as the **first operation** on the host builder, before `SchemaBootstrap.ApplyAsync()`, so that DB initialization errors are captured in both log sinks; use `UseSerilog()` on the host builder
-- [ ] T024 [US3] Emit a startup log entry (`Information` level) in `Program.cs` after schema bootstrap completes: `"Sunny Sunday server started. Database: {DbPath}"` — verifies both sinks are wired before any HTTP request
+- [X] T022 [US3] Create `src/SunnySunday.Server/Infrastructure/Logging/SerilogConfiguration.cs` — static helper `ConfigureLogging(WebApplicationBuilder builder, string dbPath)` that: (1) calls `Directory.CreateDirectory(".data/logs")` to ensure the log directory exists before Serilog initializes, (2) configures Serilog with file sink (`.data/logs/sunny-.log`, rolling interval daily, minimum level `Information`) and SQLite sink (`dbPath`, table `Logs`, minimum level `Warning`); both paths are hardcoded constants — no env var
+- [X] T023 [US3] Wire `SerilogConfiguration.ConfigureLogging()` into `src/SunnySunday.Server/Program.cs` — call it as the **first operation** on the host builder, before `SchemaBootstrap.ApplyAsync()`, so that DB initialization errors are captured in both log sinks; use `UseSerilog()` on the host builder
+- [X] T024 [US3] Emit a startup log entry (`Information` level) in `Program.cs` after schema bootstrap completes: `"Sunny Sunday server started. Database: {DbPath}"` — verifies both sinks are wired before any HTTP request
 
 ---
 

--- a/src/SunnySunday.Server/Infrastructure/Logging/SerilogConfiguration.cs
+++ b/src/SunnySunday.Server/Infrastructure/Logging/SerilogConfiguration.cs
@@ -1,0 +1,28 @@
+using Serilog;
+
+namespace SunnySunday.Server.Infrastructure.Logging;
+
+internal static class SerilogConfiguration
+{
+    private const string LogDirectory = ".data/logs";
+    private const string LogFilePath = ".data/logs/sunny-.log";
+
+    internal static void ConfigureLogging(WebApplicationBuilder builder, string dbPath)
+    {
+        Directory.CreateDirectory(LogDirectory);
+
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.File(
+                LogFilePath,
+                rollingInterval: RollingInterval.Day,
+                restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Information)
+            .WriteTo.SQLite(
+                dbPath,
+                tableName: "Logs",
+                restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Warning)
+            .CreateLogger();
+
+        builder.Host.UseSerilog();
+    }
+}

--- a/src/SunnySunday.Server/Program.cs
+++ b/src/SunnySunday.Server/Program.cs
@@ -1,12 +1,19 @@
+using Serilog;
 using SunnySunday.Server.Infrastructure.Database;
+using SunnySunday.Server.Infrastructure.Logging;
 
 var dbPath = ".data/sunny.db";
 
 var builder = WebApplication.CreateBuilder(args);
+
+SerilogConfiguration.ConfigureLogging(builder, dbPath);
+
 var app = builder.Build();
 
 var schemaBootstrap = new SchemaBootstrap();
 await schemaBootstrap.ApplyAsync(dbPath);
+
+Log.Information("Sunny Sunday server started. Database: {DbPath}", dbPath);
 
 app.MapGet("/", () => "Sunny Sunday server is running.");
 

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Phase 5: User Story 3 — Serilog Writes Structured Logs

Implements T022, T023, T024 from `specs/002-core-infrastructure/tasks.md`.

### Changes

- **T022** — Added `src/SunnySunday.Server/Infrastructure/Logging/SerilogConfiguration.cs`: static helper `ConfigureLogging(WebApplicationBuilder, string)` that creates `.data/logs/` directory, configures file sink (daily rolling, `Information` minimum) and SQLite sink (`Logs` table, `Warning` minimum)
- **T023** — Updated `Program.cs` to call `SerilogConfiguration.ConfigureLogging()` as the **first operation** on the host builder, before schema bootstrap
- **T024** — Added `Log.Information("Sunny Sunday server started. Database: {DbPath}", dbPath)` after schema bootstrap completes

### Verification

`dotnet build` exits 0 with 0 warnings and 0 errors.

Closes #24
Closes #25
Closes #26