### PR TITLE
[T025-T027] Polish: add .data/ to .gitignore, verify tests, mark spec Implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -483,3 +483,6 @@ $RECYCLE.BIN/
 
 # Custom
 *.db
+
+# Local development data directory
+.data/

--- a/specs/002-core-infrastructure/spec.md
+++ b/specs/002-core-infrastructure/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `002-core-infrastructure`
 **Created**: 2026-04-07
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Self-contained .NET 10 solution scaffold for Sunny Sunday: four projects (Core, Server, Cli, Tests), shared domain models (Highlight, Book, Author, User, Settings), SQLite schema creation on server startup, Serilog logging with file and SQLite sinks. No business logic — infrastructure only."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/002-core-infrastructure/tasks.md
+++ b/specs/002-core-infrastructure/tasks.md
@@ -13,8 +13,8 @@
 
 **Purpose**: Ensure the devcontainer runs .NET 10 and the repository has the correct .NET-specific ignore rules before any source file is created.
 
-- [ ] T000a Switch `.devcontainer/devcontainer.json` base image from `mcr.microsoft.com/devcontainers/base:trixie` to `mcr.microsoft.com/devcontainers/dotnet:1-10.0` and set `name` to `Sunny Sunday`; keep all other features and extensions unchanged — rebuild the devcontainer after this change
-- [ ] T000b Generate the standard .NET `.gitignore` at repository root via `dotnet new gitignore` (covers `bin/`, `obj/`, `*.user`, `*.suo`, NuGet fallback folders, etc.)
+- [X] T000a Switch `.devcontainer/devcontainer.json` base image from `mcr.microsoft.com/devcontainers/base:trixie` to `mcr.microsoft.com/devcontainers/dotnet:1-10.0` and set `name` to `Sunny Sunday`; keep all other features and extensions unchanged — rebuild the devcontainer after this change
+- [X] T000b Generate the standard .NET `.gitignore` at repository root via `dotnet new gitignore` (covers `bin/`, `obj/`, `*.user`, `*.suo`, NuGet fallback folders, etc.)
 
 ---
 
@@ -89,9 +89,9 @@
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T025 [P] Add `.data/` to `.gitignore` (local development data directory per `quickstart.md`)
-- [ ] T026 [P] Verify `dotnet test` exits 0 (no test content yet, but project must compile and runner must report 0 failures)
-- [ ] T027 Update `specs/002-core-infrastructure/spec.md` status from `Draft` to `Implemented`
+- [X] T025 [P] Add `.data/` to `.gitignore` (local development data directory per `quickstart.md`)
+- [X] T026 [P] Verify `dotnet test` exits 0 (no test content yet, but project must compile and runner must report 0 failures)
+- [X] T027 Update `specs/002-core-infrastructure/spec.md` status from `Draft` to `Implemented`
 
 ---
 


### PR DESCRIPTION
## Phase 6: Polish & Cross-Cutting Concerns

Implements T025, T026, T027 from `specs/002-core-infrastructure/tasks.md`.

### Changes

- **T025** — Added `.data/` to `.gitignore` (local development data directory per `quickstart.md`)
- **T026** — Verified `dotnet test` exits 0: 1 test passed, 0 failed
- **T027** — Updated `specs/002-core-infrastructure/spec.md` status from `Draft` to `Implemented`

This completes the full 002-core-infrastructure feature (all phases 1–6).

Closes #27
Closes #28
Closes #29