### PR TITLE
Feature 003 Highlight Parser — Design artifacts

### DIFF
--- a/specs/003-highlight-parser/checklists/requirements.md
+++ b/specs/003-highlight-parser/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Highlight Parser
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.plan`.
+- Reasonable defaults were chosen for: deduplication strategy (exact match), bookmark handling (skip), notes treatment (same as highlights), author extraction (parentheses convention), and encoding (UTF-8 with BOM support). These are documented in the Assumptions section.

--- a/specs/003-highlight-parser/data-model.md
+++ b/specs/003-highlight-parser/data-model.md
@@ -1,0 +1,146 @@
+# Data Model: Highlight Parser
+
+**Feature**: 003-highlight-parser
+**Phase**: 1 — Design
+**Date**: 2026-04-17
+
+## Entity Overview
+
+This feature introduces **parser-specific types** that live in `SunnySunday.Core/Parsing/`. These are distinct from the persistence models in `SunnySunday.Core/Models/` — they represent the raw parsed output before any database interaction.
+
+```
+ParseResult
+├── List<ParsedBook>
+│   ├── string Title
+│   ├── string? Author
+│   └── List<ParsedHighlight>
+│       ├── string Text
+│       ├── ClippingType Type
+│       ├── string? Location
+│       └── DateTimeOffset? AddedOn
+└── List<ParseWarning>
+    ├── int EntryIndex
+    ├── string Reason
+    └── string RawExcerpt
+```
+
+---
+
+## Entities
+
+### RawClipping
+
+An intermediate representation of a single entry from `My Clippings.txt`, before deduplication or grouping. Internal to the parser — not exposed in the public API.
+
+| Property | Type | Constraints | Notes |
+|----------|------|-------------|-------|
+| `Title` | `string` | Non-empty | Book title extracted from line 1 |
+| `Author` | `string?` | Nullable | Author from last `(...)` on line 1; null if absent |
+| `Type` | `ClippingType` | Required | Highlight, Note, or Bookmark |
+| `Location` | `string?` | Nullable | Raw location string (e.g., `Location 100-105`) |
+| `AddedOn` | `DateTimeOffset?` | Nullable | Parsed date; null if date parsing fails |
+| `Text` | `string` | May be empty | Highlight/note text; empty for bookmarks |
+
+**Validation rules**:
+- `Title` must be non-empty after trimming
+- `Type` must be a recognized value; unrecognized types cause the entry to be skipped with a warning
+- Bookmarks (`Type = Bookmark`) are filtered out during grouping (they have no text)
+
+---
+
+### ClippingType
+
+Enum representing the type of clipping entry.
+
+| Value | Description |
+|-------|-------------|
+| `Highlight` | Text highlighted by the user |
+| `Note` | User-written annotation attached to a location |
+| `Bookmark` | Position-only marker with no text content |
+
+---
+
+### ParsedHighlight
+
+A single highlight or note in the final output, after deduplication. Immutable.
+
+| Property | Type | Constraints | Notes |
+|----------|------|-------------|-------|
+| `Text` | `string` | Non-empty | The highlight or note text |
+| `Type` | `ClippingType` | `Highlight` or `Note` | Never `Bookmark` (filtered) |
+| `Location` | `string?` | Nullable | Raw location string for informational use |
+| `AddedOn` | `DateTimeOffset?` | Nullable | When the clipping was created on the Kindle |
+
+---
+
+### ParsedBook
+
+A book with its associated highlights, after deduplication and grouping. Immutable.
+
+| Property | Type | Constraints | Notes |
+|----------|------|-------------|-------|
+| `Title` | `string` | Non-empty | Book title |
+| `Author` | `string?` | Nullable | Author name; null if not present in file |
+| `Highlights` | `IReadOnlyList<ParsedHighlight>` | Non-empty | At least one highlight (empty books are not emitted) |
+
+**Invariants**:
+- A `ParsedBook` is never emitted with zero highlights
+- Books are identified by the `(Title, Author)` pair for grouping purposes
+
+---
+
+### ParseWarning
+
+A warning generated when a clipping entry cannot be parsed.
+
+| Property | Type | Constraints | Notes |
+|----------|------|-------------|-------|
+| `EntryIndex` | `int` | >= 1 | 1-based ordinal position in the file |
+| `Reason` | `string` | Non-empty | Human-readable description of why parsing failed |
+| `RawExcerpt` | `string` | Truncated | First 200 characters of the raw entry text |
+
+---
+
+### ParseResult
+
+The top-level output of the parser. Immutable.
+
+| Property | Type | Constraints | Notes |
+|----------|------|-------------|-------|
+| `Books` | `IReadOnlyList<ParsedBook>` | Non-null | May be empty if no valid highlights found |
+| `Warnings` | `IReadOnlyList<ParseWarning>` | Non-null | May be empty if all entries parsed successfully |
+| `TotalEntriesProcessed` | `int` | >= 0 | Total entries encountered (including skipped) |
+| `DuplicatesRemoved` | `int` | >= 0 | Number of duplicate entries removed |
+
+---
+
+## Relationship to Existing Models
+
+The parser types are **separate from** the persistence models in `SunnySunday.Core/Models/`:
+
+| Parser Type | Persistence Model | Mapping (future sync feature) |
+|-------------|-------------------|-------------------------------|
+| `ParsedBook.Title` | `Book.Title` | Direct copy |
+| `ParsedBook.Author` | `Author.Name` | Direct copy; create Author if not exists |
+| `ParsedHighlight.Text` | `Highlight.Text` | Direct copy |
+| `ParsedHighlight.Type` | — | Not stored (all are treated as highlights in DB) |
+| `ParsedHighlight.Location` | — | Not stored in MVP |
+| `ParsedHighlight.AddedOn` | `Highlight.CreatedAt` | Maps to CreatedAt |
+
+The sync feature (future) will be responsible for mapping `ParseResult` → persistence models and inserting into SQLite. This feature does not touch the database.
+
+---
+
+## File Layout
+
+```
+src/SunnySunday.Core/
+└── Parsing/
+    ├── ClippingType.cs        # Enum
+    ├── RawClipping.cs         # Internal intermediate type
+    ├── ParsedHighlight.cs     # Public output type
+    ├── ParsedBook.cs          # Public output type
+    ├── ParseWarning.cs        # Public output type
+    ├── ParseResult.cs         # Public top-level result
+    └── ClippingsParser.cs     # Static parser class
+```

--- a/specs/003-highlight-parser/data-model.md
+++ b/specs/003-highlight-parser/data-model.md
@@ -15,14 +15,13 @@ ParseResult
 │   ├── string? Author
 │   └── List<ParsedHighlight>
 │       ├── string Text
-│       ├── ClippingType Type
 │       ├── string? Location
 │       └── DateTimeOffset? AddedOn
-└── List<ParseWarning>
-    ├── int EntryIndex
-    ├── string Reason
-    └── string RawExcerpt
+├── int TotalEntriesProcessed
+└── int DuplicatesRemoved
 ```
+
+Parse warnings (malformed entries) are logged to the console via Serilog — not collected in the result.
 
 ---
 
@@ -36,38 +35,25 @@ An intermediate representation of a single entry from `My Clippings.txt`, before
 |----------|------|-------------|-------|
 | `Title` | `string` | Non-empty | Book title extracted from line 1 |
 | `Author` | `string?` | Nullable | Author from last `(...)` on line 1; null if absent |
-| `Type` | `ClippingType` | Required | Highlight, Note, or Bookmark |
+| `IsNote` | `bool` | Required | True if the metadata line says "Note"; used to prepend `[my note]` prefix |
 | `Location` | `string?` | Nullable | Raw location string (e.g., `Location 100-105`) |
 | `AddedOn` | `DateTimeOffset?` | Nullable | Parsed date; null if date parsing fails |
 | `Text` | `string` | May be empty | Highlight/note text; empty for bookmarks |
 
 **Validation rules**:
 - `Title` must be non-empty after trimming
-- `Type` must be a recognized value; unrecognized types cause the entry to be skipped with a warning
-- Bookmarks (`Type = Bookmark`) are filtered out during grouping (they have no text)
-
----
-
-### ClippingType
-
-Enum representing the type of clipping entry.
-
-| Value | Description |
-|-------|-------------|
-| `Highlight` | Text highlighted by the user |
-| `Note` | User-written annotation attached to a location |
-| `Bookmark` | Position-only marker with no text content |
+- Bookmarks (detected from metadata line) are filtered out during grouping (they have no text)
+- Notes have `[my note]` prepended to their text before output
 
 ---
 
 ### ParsedHighlight
 
-A single highlight or note in the final output, after deduplication. Immutable.
+A single highlight in the final output, after deduplication. Notes are included as highlights with a `[my note]` prefix on their text. Immutable.
 
 | Property | Type | Constraints | Notes |
 |----------|------|-------------|-------|
-| `Text` | `string` | Non-empty | The highlight or note text |
-| `Type` | `ClippingType` | `Highlight` or `Note` | Never `Bookmark` (filtered) |
+| `Text` | `string` | Non-empty | The highlight text. Notes have `[my note]` prefix. |
 | `Location` | `string?` | Nullable | Raw location string for informational use |
 | `AddedOn` | `DateTimeOffset?` | Nullable | When the clipping was created on the Kindle |
 
@@ -89,18 +75,6 @@ A book with its associated highlights, after deduplication and grouping. Immutab
 
 ---
 
-### ParseWarning
-
-A warning generated when a clipping entry cannot be parsed.
-
-| Property | Type | Constraints | Notes |
-|----------|------|-------------|-------|
-| `EntryIndex` | `int` | >= 1 | 1-based ordinal position in the file |
-| `Reason` | `string` | Non-empty | Human-readable description of why parsing failed |
-| `RawExcerpt` | `string` | Truncated | First 200 characters of the raw entry text |
-
----
-
 ### ParseResult
 
 The top-level output of the parser. Immutable.
@@ -108,9 +82,10 @@ The top-level output of the parser. Immutable.
 | Property | Type | Constraints | Notes |
 |----------|------|-------------|-------|
 | `Books` | `IReadOnlyList<ParsedBook>` | Non-null | May be empty if no valid highlights found |
-| `Warnings` | `IReadOnlyList<ParseWarning>` | Non-null | May be empty if all entries parsed successfully |
 | `TotalEntriesProcessed` | `int` | >= 0 | Total entries encountered (including skipped) |
 | `DuplicatesRemoved` | `int` | >= 0 | Number of duplicate entries removed |
+
+Parse warnings for malformed entries are logged to the console (via `ILogger` / Serilog) during parsing — they are not part of the result structure.
 
 ---
 
@@ -122,8 +97,7 @@ The parser types are **separate from** the persistence models in `SunnySunday.Co
 |-------------|-------------------|-------------------------------|
 | `ParsedBook.Title` | `Book.Title` | Direct copy |
 | `ParsedBook.Author` | `Author.Name` | Direct copy; create Author if not exists |
-| `ParsedHighlight.Text` | `Highlight.Text` | Direct copy |
-| `ParsedHighlight.Type` | — | Not stored (all are treated as highlights in DB) |
+| `ParsedHighlight.Text` | `Highlight.Text` | Direct copy (includes `[my note]` prefix for notes) |
 | `ParsedHighlight.Location` | — | Not stored in MVP |
 | `ParsedHighlight.AddedOn` | `Highlight.CreatedAt` | Maps to CreatedAt |
 
@@ -136,11 +110,9 @@ The sync feature (future) will be responsible for mapping `ParseResult` → pers
 ```
 src/SunnySunday.Core/
 └── Parsing/
-    ├── ClippingType.cs        # Enum
     ├── RawClipping.cs         # Internal intermediate type
     ├── ParsedHighlight.cs     # Public output type
     ├── ParsedBook.cs          # Public output type
-    ├── ParseWarning.cs        # Public output type
     ├── ParseResult.cs         # Public top-level result
     └── ClippingsParser.cs     # Static parser class
 ```

--- a/specs/003-highlight-parser/plan.md
+++ b/specs/003-highlight-parser/plan.md
@@ -5,12 +5,12 @@
 
 ## Summary
 
-Parse Kindle `My Clippings.txt` files into structured highlight data. The parser is a pure function in `SunnySunday.Core/Parsing/` that reads the file line-by-line, extracts book/author/highlight/metadata, deduplicates by exact `(title, author, text)` match, groups highlights by book, and returns an immutable `ParseResult` with warnings for any skipped entries. No database, no HTTP, no side effects.
+Parse Kindle `My Clippings.txt` files into structured highlight data. The parser is a pure function in `SunnySunday.Core/Parsing/` that reads the file line-by-line, extracts book/author/highlight/metadata, deduplicates by exact `(title, author, text)` match, groups highlights by book, and returns an immutable `ParseResult`. Notes are treated as highlights with a `[my note]` prefix. Malformed entries are logged as warnings. No database, no HTTP, no side effects.
 
 ## Technical Context
 
 **Language/Version**: C# / .NET 10 (`net10.0` TFM)
-**Primary Dependencies**: None (pure .NET BCL only — `System.IO`, `System.Globalization`, `System.Text.RegularExpressions`)
+**Primary Dependencies**: Microsoft.Extensions.Logging (for `ILogger<T>` — warning logs for malformed entries)
 **Storage**: N/A — parser is a pure function with no persistence
 **Testing**: xUnit (via `SunnySunday.Tests`)
 **Target Platform**: Cross-platform (.NET 10 runtime)
@@ -61,11 +61,9 @@ src/SunnySunday.Core/
 │   ├── Settings.cs
 │   └── User.cs
 └── Parsing/                   # NEW — parser types and logic
-    ├── ClippingType.cs        # Enum: Highlight, Note, Bookmark
     ├── RawClipping.cs         # Internal intermediate parse result
     ├── ParsedHighlight.cs     # Public: single highlight in output
     ├── ParsedBook.cs          # Public: book with grouped highlights
-    ├── ParseWarning.cs        # Public: warning for skipped entry
     ├── ParseResult.cs         # Public: top-level result container
     └── ClippingsParser.cs     # Public: static parser entry point
 

--- a/specs/003-highlight-parser/plan.md
+++ b/specs/003-highlight-parser/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Highlight Parser
+
+**Branch**: `003-highlight-parser` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-highlight-parser/spec.md`
+
+## Summary
+
+Parse Kindle `My Clippings.txt` files into structured highlight data. The parser is a pure function in `SunnySunday.Core/Parsing/` that reads the file line-by-line, extracts book/author/highlight/metadata, deduplicates by exact `(title, author, text)` match, groups highlights by book, and returns an immutable `ParseResult` with warnings for any skipped entries. No database, no HTTP, no side effects.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10 (`net10.0` TFM)
+**Primary Dependencies**: None (pure .NET BCL only — `System.IO`, `System.Globalization`, `System.Text.RegularExpressions`)
+**Storage**: N/A — parser is a pure function with no persistence
+**Testing**: xUnit (via `SunnySunday.Tests`)
+**Target Platform**: Cross-platform (.NET 10 runtime)
+**Project Type**: Library (shared logic in `SunnySunday.Core`)
+**Performance Goals**: 10,000 clippings parsed, deduplicated, and grouped in < 5 seconds
+**Constraints**: Single-pass streaming, no external dependencies beyond .NET BCL
+**Scale/Scope**: Typical file: 500–5,000 clippings; stress test: 50,000+ clippings
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Client/Server Separation | **PASS** | Parser lives in `Core` (shared); used by CLI, not server |
+| II. CLI-First, No GUI | **PASS** | No UI in this feature; parser is logic-only |
+| III. Zero-Config Onboarding | **PASS** | No configuration required; parser takes a file path |
+| IV. Local Processing Only | **PASS** | Pure local file parsing, no network calls |
+| V. Tests Ship with Code | **PASS** | Unit tests included in implementation plan |
+| VI. Simplicity / YAGNI | **PASS** | No external dependencies, no parser combinator library, no fuzzy matching |
+| Tech: C# / .NET 10 only | **PASS** | All code is C# |
+| Tech: No raw Console.WriteLine | **PASS** | Parser returns data; no console output |
+| Exclusion: No AI summarization | **PASS** | Not applicable |
+
+**Post-design re-check**: All gates still pass. Parser types are plain C# records/classes with no dependencies. No new NuGet packages introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-highlight-parser/
+├── plan.md              # This file
+├── research.md          # My Clippings.txt format analysis & decisions
+├── data-model.md        # Parser-specific type definitions
+├── quickstart.md        # Developer quick-start guide
+└── tasks.md             # Implementation tasks (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/SunnySunday.Core/
+├── Models/                    # Existing persistence models (UNCHANGED)
+│   ├── Author.cs
+│   ├── Book.cs
+│   ├── Highlight.cs
+│   ├── Settings.cs
+│   └── User.cs
+└── Parsing/                   # NEW — parser types and logic
+    ├── ClippingType.cs        # Enum: Highlight, Note, Bookmark
+    ├── RawClipping.cs         # Internal intermediate parse result
+    ├── ParsedHighlight.cs     # Public: single highlight in output
+    ├── ParsedBook.cs          # Public: book with grouped highlights
+    ├── ParseWarning.cs        # Public: warning for skipped entry
+    ├── ParseResult.cs         # Public: top-level result container
+    └── ClippingsParser.cs     # Public: static parser entry point
+
+src/SunnySunday.Tests/
+└── Parsing/                   # NEW — parser unit tests
+    └── ClippingsParserTests.cs
+```
+
+**Structure Decision**: Parser code goes into a new `Parsing/` namespace within the existing `SunnySunday.Core` project. No new .csproj files. Tests go into the existing `SunnySunday.Tests` project under a `Parsing/` folder. This matches the existing project structure and avoids adding a 5th project (YAGNI).
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/003-highlight-parser/quickstart.md
+++ b/specs/003-highlight-parser/quickstart.md
@@ -18,11 +18,9 @@ All parser code lives in `SunnySunday.Core`:
 src/SunnySunday.Core/
 ├── Models/           # Existing persistence models (DO NOT MODIFY)
 └── Parsing/          # NEW — parser types and logic
-    ├── ClippingType.cs
     ├── RawClipping.cs
     ├── ParsedHighlight.cs
     ├── ParsedBook.cs
-    ├── ParseWarning.cs
     ├── ParseResult.cs
     └── ClippingsParser.cs
 
@@ -62,14 +60,9 @@ foreach (var book in result.Books)
     Console.WriteLine($"{book.Title} by {book.Author ?? "Unknown"}");
     foreach (var highlight in book.Highlights)
     {
+        // Notes will have text starting with "[my note] "
         Console.WriteLine($"  - {highlight.Text}");
     }
-}
-
-// Check for warnings
-foreach (var warning in result.Warnings)
-{
-    Console.WriteLine($"Warning at entry {warning.EntryIndex}: {warning.Reason}");
 }
 ```
 
@@ -101,8 +94,9 @@ var result = await ClippingsParser.ParseAsync(reader);
 2. **TextReader input** — accepts `TextReader` for testability; file-path overload is a convenience wrapper
 3. **Async API** — `ParseAsync` uses `ReadLineAsync()` for I/O-bound file reading
 4. **Immutable output** — all result types are immutable records or have read-only collections
-5. **Skip-and-warn** — malformed entries are skipped, never throw; warnings are collected in `ParseResult.Warnings`
+5. **Skip-and-warn** — malformed entries are skipped, never throw; warnings are logged to the console
 6. **Dedup by exact match** — `(Title, Author, Text)` tuple, case-sensitive, using `HashSet`
+7. **Notes as highlights** — notes get a `[my note]` prefix on their text; no separate type
 
 ## What This Feature Does NOT Do
 

--- a/specs/003-highlight-parser/quickstart.md
+++ b/specs/003-highlight-parser/quickstart.md
@@ -1,0 +1,112 @@
+# Quick Start: Highlight Parser
+
+**Feature**: 003-highlight-parser
+**Date**: 2026-04-17
+
+---
+
+## Prerequisites
+
+- .NET 10 SDK installed (`dotnet --version` → `10.x`)
+- Repository cloned and solution builds: `dotnet build src/SunnySunday.slnx`
+
+## Project Structure
+
+All parser code lives in `SunnySunday.Core`:
+
+```
+src/SunnySunday.Core/
+├── Models/           # Existing persistence models (DO NOT MODIFY)
+└── Parsing/          # NEW — parser types and logic
+    ├── ClippingType.cs
+    ├── RawClipping.cs
+    ├── ParsedHighlight.cs
+    ├── ParsedBook.cs
+    ├── ParseWarning.cs
+    ├── ParseResult.cs
+    └── ClippingsParser.cs
+
+src/SunnySunday.Tests/
+└── Parsing/          # NEW — parser unit tests
+    └── ClippingsParserTests.cs
+```
+
+## Build & Test
+
+```bash
+# Build everything
+dotnet build src/SunnySunday.slnx
+
+# Run tests
+dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj
+
+# Run tests with verbose output
+dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --verbosity normal
+```
+
+## Usage Example
+
+```csharp
+using SunnySunday.Core.Parsing;
+
+// From a file path
+var result = await ClippingsParser.ParseAsync("/path/to/My Clippings.txt");
+
+// From a TextReader (useful in tests)
+using var reader = new StringReader(clippingsText);
+var result = await ClippingsParser.ParseAsync(reader);
+
+// Inspect results
+foreach (var book in result.Books)
+{
+    Console.WriteLine($"{book.Title} by {book.Author ?? "Unknown"}");
+    foreach (var highlight in book.Highlights)
+    {
+        Console.WriteLine($"  - {highlight.Text}");
+    }
+}
+
+// Check for warnings
+foreach (var warning in result.Warnings)
+{
+    Console.WriteLine($"Warning at entry {warning.EntryIndex}: {warning.Reason}");
+}
+```
+
+## Test Data
+
+Create test input using the exact Kindle format:
+
+```csharp
+var input = """
+    The Great Gatsby (F. Scott Fitzgerald)
+    - Your Highlight on Location 100-105 | Added on Thursday, January 1, 2026 12:00:00 AM
+
+    In my younger and more vulnerable years my father gave me some advice.
+    ==========
+    1984 (Orwell, George)
+    - Your Highlight on Location 200-210 | Added on Friday, January 2, 2026 1:30:00 PM
+
+    War is peace. Freedom is slavery. Ignorance is strength.
+    ==========
+    """;
+
+using var reader = new StringReader(input);
+var result = await ClippingsParser.ParseAsync(reader);
+```
+
+## Key Design Decisions
+
+1. **Pure function** — `ClippingsParser` is a static class with no state, no dependencies, no side effects
+2. **TextReader input** — accepts `TextReader` for testability; file-path overload is a convenience wrapper
+3. **Async API** — `ParseAsync` uses `ReadLineAsync()` for I/O-bound file reading
+4. **Immutable output** — all result types are immutable records or have read-only collections
+5. **Skip-and-warn** — malformed entries are skipped, never throw; warnings are collected in `ParseResult.Warnings`
+6. **Dedup by exact match** — `(Title, Author, Text)` tuple, case-sensitive, using `HashSet`
+
+## What This Feature Does NOT Do
+
+- No REST API endpoints (separate feature)
+- No CLI commands (separate feature)
+- No database writes (sync feature)
+- No user association (sync feature)

--- a/specs/003-highlight-parser/research.md
+++ b/specs/003-highlight-parser/research.md
@@ -81,6 +81,13 @@ Some Kindle models prepend a UTF-8 BOM (`0xEF 0xBB 0xBF`) to the file. `StreamRe
 
 **Pattern**: `^- Your (?<type>Highlight|Note|Bookmark) on (?<location>.+?) \| Added on (?<date>.+)$`
 
+The `type` capture is used internally during parsing to:
+- **Bookmark**: skip the entry entirely (no text content)
+- **Note**: prepend `[my note]` to the extracted text, then treat as a highlight
+- **Highlight**: use text as-is
+
+No `ClippingType` enum or type field is exposed in the output — notes and highlights are unified in `ParsedHighlight.Text`.
+
 ### Date parsing
 
 The Kindle date format is: `Thursday, January 1, 2026 12:00:00 AM`

--- a/specs/003-highlight-parser/research.md
+++ b/specs/003-highlight-parser/research.md
@@ -1,0 +1,164 @@
+# Research: Highlight Parser
+
+**Feature**: 003-highlight-parser
+**Phase**: 0 — Outline & Research
+**Date**: 2026-04-17
+
+---
+
+## 1. My Clippings.txt Format Analysis
+
+### Decision: Use line-based parsing with `==========` separator
+
+**Rationale**: The Kindle `My Clippings.txt` file has a fixed, well-documented structure that has remained stable across Kindle generations since the Kindle 2 (2009). The format is simple enough to parse with line-based splitting — no grammar or parser combinator library is needed.
+
+**Alternatives considered**:
+- Regex-only parsing — rejected because multi-line content makes pure regex unwieldy and fragile
+- Parser combinator library (e.g., Sprache, Pidgin) — rejected because the format is too simple to justify the dependency; YAGNI per constitution
+
+### Format specification
+
+Each entry in `My Clippings.txt` follows this exact structure:
+
+```
+{Title} ({Author})\r\n
+- Your {Type} on {Location} | Added on {Date}\r\n
+\r\n
+{Content (zero or more lines)}\r\n
+==========\r\n
+```
+
+**Field details**:
+
+| Field | Format | Notes |
+|-------|--------|-------|
+| Title | Free text | May contain parentheses, quotes, Unicode |
+| Author | Inside last `(...)` on title line | May be `Last, First` format; may be absent |
+| Type | `Highlight`, `Note`, or `Bookmark` | Prefixed with `Your` |
+| Location | `Location NNN-NNN` or `page NNN` | Varies by Kindle model |
+| Date | `Added on {DayOfWeek}, {Month} {Day}, {Year} {Time}` | US English locale |
+| Content | Multi-line UTF-8 text | Empty for bookmarks |
+| Separator | `==========` (10 equals signs) | Always on its own line |
+
+### Line endings
+
+Kindle uses `\r\n` (Windows-style) line endings regardless of host OS. The parser must handle both `\r\n` and `\n` to be robust (e.g., if the user opens and re-saves the file on macOS/Linux).
+
+### UTF-8 BOM
+
+Some Kindle models prepend a UTF-8 BOM (`0xEF 0xBB 0xBF`) to the file. `StreamReader` in .NET handles this automatically when using `new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true)` (the default). No special handling needed.
+
+---
+
+## 2. Author Extraction Edge Cases
+
+### Decision: Extract author from the last parenthesized group on the title line
+
+**Rationale**: The Kindle format always places the author inside the last pair of parentheses on the title line. Some book titles legitimately contain parentheses (e.g., `The Art of War (Annotated) (Sun Tzu)`), so we must use the **last** `(...)` group, not the first.
+
+**Alternatives considered**:
+- First parenthesized group — rejected because titles may contain parentheses
+- All text after last `(` — this is effectively what we do, taking the content between the last `(` and the closing `)`
+
+### Edge cases handled
+
+| Scenario | Input | Title | Author |
+|----------|-------|-------|--------|
+| Standard | `The Great Gatsby (F. Scott Fitzgerald)` | `The Great Gatsby` | `F. Scott Fitzgerald` |
+| Last, First | `1984 (Orwell, George)` | `1984` | `Orwell, George` |
+| Title with parens | `The Art of War (Annotated) (Sun Tzu)` | `The Art of War (Annotated)` | `Sun Tzu` |
+| No author | `My Personal Notes` | `My Personal Notes` | `null` / unknown |
+| Empty parens | `Some Book ()` | `Some Book` | `null` / unknown (empty treated as absent) |
+| Unicode author | `道德经 (老子)` | `道德经` | `老子` |
+
+---
+
+## 3. Metadata Line Parsing
+
+### Decision: Regex-based extraction of type, location, and date
+
+**Rationale**: The metadata line has a predictable structure: `- Your {Type} on {Location} | Added on {Date}`. A single regex with named capture groups handles this cleanly.
+
+**Pattern**: `^- Your (?<type>Highlight|Note|Bookmark) on (?<location>.+?) \| Added on (?<date>.+)$`
+
+### Date parsing
+
+The Kindle date format is: `Thursday, January 1, 2026 12:00:00 AM`
+
+This maps to .NET format string: `dddd, MMMM d, yyyy h:mm:ss tt` with `CultureInfo.InvariantCulture`.
+
+**Edge case**: Some Kindle firmware versions use slightly different date formats (e.g., 24-hour time, different locale). The parser should attempt parsing with the known format and fall back gracefully (store raw string if parsing fails, log a warning).
+
+---
+
+## 4. Deduplication Strategy
+
+### Decision: Exact case-sensitive match on (title, author, text) tuple
+
+**Rationale**: Per spec FR-006, deduplication uses exact text matching. This is the simplest approach and avoids false positives. Kindle re-highlights produce exact duplicates, so fuzzy matching is unnecessary for MVP.
+
+**Alternatives considered**:
+- Fuzzy/Levenshtein matching — rejected as over-engineering for MVP; YAGNI
+- Hash-based dedup — considered and adopted as implementation detail: use `HashSet<(string, string, string)>` for O(1) lookup
+- Substring containment (shorter highlight is subset of longer) — rejected per spec acceptance scenario: "both are retained as distinct highlights"
+
+### Implementation approach
+
+Use a `HashSet` keyed on `(BookTitle, AuthorName, HighlightText)` tuple. Process clippings in file order; skip any entry whose key already exists. This preserves the first occurrence (which is the original highlight; re-highlights come later in the file).
+
+---
+
+## 5. Performance Considerations
+
+### Decision: Stream-based parsing with single pass
+
+**Rationale**: The spec requires 10,000 clippings in < 5 seconds. A single-pass streaming approach (read line by line, accumulate per-entry state, emit on separator) is both simple and fast. No need for memory-mapping or parallel processing.
+
+**Alternatives considered**:
+- Read entire file into memory then split — acceptable for typical file sizes (< 50 MB) but streaming is equally simple and uses less memory
+- Parallel parsing — rejected as unnecessary; a single-threaded pass over 10K entries takes milliseconds, well under the 5-second target
+- Memory-mapped files — rejected as over-engineering
+
+### Memory estimate
+
+- Average clipping: ~500 bytes
+- 10,000 clippings: ~5 MB raw text
+- Parsed output (strings are interned per book): ~8-10 MB
+- Well within acceptable memory for a CLI tool
+
+---
+
+## 6. Error Handling & Warnings
+
+### Decision: Skip-and-warn strategy with structured warning objects
+
+**Rationale**: Per spec FR-008 and FR-009, malformed entries must be skipped with warnings. The parser should never throw on bad input — it returns a result containing both the successfully parsed data and a list of warnings.
+
+**Warning information includes**:
+- Entry index (ordinal position in the file, 1-based)
+- Raw text of the failed entry (first N characters, truncated for large entries)
+- Reason for skipping (e.g., "Missing metadata line", "Unrecognized clipping type")
+
+---
+
+## 7. .NET-Specific Best Practices
+
+### String handling
+- Use `StringComparison.Ordinal` for exact matching (deduplication)
+- Use `ReadOnlySpan<char>` or `AsSpan()` for substring operations where allocation matters (metadata parsing)
+- Avoid excessive string allocations in the hot path (line-by-line parsing)
+
+### Stream vs file path
+- Accept `TextReader` as the primary input (testable, flexible)
+- Provide a convenience overload that takes a file path and creates a `StreamReader`
+- In tests, use `StringReader` — no temp files needed
+
+### Async
+- Provide async API (`ParseAsync`) using `StreamReader.ReadLineAsync()`
+- The parser is I/O-bound (file read), so async is appropriate
+- Sync wrapper can be offered for CLI convenience
+
+### Nullable reference types
+- Project already has `<Nullable>enable</Nullable>`
+- Author can be `null` in parsed clipping when no parentheses found
+- All other fields are non-nullable

--- a/specs/003-highlight-parser/spec.md
+++ b/specs/003-highlight-parser/spec.md
@@ -19,7 +19,7 @@ A Kindle user connects their device via USB and runs the `sunny sync` command, p
 
 1. **Given** a standard `My Clippings.txt` file with 50 highlights across 5 books, **When** the parser processes the file, **Then** all 50 highlights are extracted with correct book title, author, and highlight text.
 2. **Given** a clipping entry with a multi-line highlight (text spanning multiple lines), **When** the parser processes the entry, **Then** the full multi-line text is captured as a single highlight.
-3. **Given** a `My Clippings.txt` file containing highlights, notes, and bookmarks, **When** the parser processes the file, **Then** highlights and notes are extracted, and bookmarks (position-only entries with no text) are skipped.
+3. **Given** a `My Clippings.txt` file containing highlights, notes, and bookmarks, **When** the parser processes the file, **Then** highlights are extracted as-is, notes are extracted with a `[my note]` prefix prepended to their text, and bookmarks (position-only entries with no text) are skipped.
 4. **Given** a clipping entry with metadata containing location range and timestamp, **When** the parser processes the entry, **Then** the location and date information are extracted alongside the highlight text.
 
 ---
@@ -59,7 +59,7 @@ After parsing and deduplication, highlights are organized by book. Each book is 
 
 ### User Story 4 — Handle Malformed Entries Gracefully (Priority: P4)
 
-Real-world `My Clippings.txt` files may contain malformed or incomplete entries due to Kindle firmware bugs, file corruption, or manual editing. The parser skips these entries without crashing and reports them as warnings so the user can investigate if needed.
+Real-world `My Clippings.txt` files may contain malformed or incomplete entries due to Kindle firmware bugs, file corruption, or manual editing. The parser skips these entries without crashing and logs a warning so the user can investigate if needed.
 
 **Why this priority**: Robustness is important for user trust, but only after core parsing works correctly. A parser that crashes on unexpected input would be unusable in practice.
 
@@ -67,7 +67,7 @@ Real-world `My Clippings.txt` files may contain malformed or incomplete entries 
 
 **Acceptance Scenarios**:
 
-1. **Given** a file with one malformed entry (missing separator, truncated text) among 10 valid entries, **When** the parser processes the file, **Then** 10 valid highlights are extracted and the malformed entry is skipped with a warning.
+1. **Given** a file with one malformed entry (missing separator, truncated text) among 10 valid entries, **When** the parser processes the file, **Then** 10 valid highlights are extracted and the malformed entry is skipped with a warning logged to the console.
 2. **Given** an empty `My Clippings.txt` file, **When** the parser processes the file, **Then** the result is an empty collection with no errors.
 3. **Given** a file containing only separators and no actual clipping content, **When** the parser processes the file, **Then** the result is an empty collection with no errors.
 4. **Given** a file where a clipping entry is missing the author on the title line, **When** the parser processes the entry, **Then** the entry is parsed with best-effort extraction (title without author), not skipped entirely.
@@ -91,22 +91,22 @@ Real-world `My Clippings.txt` files may contain malformed or incomplete entries 
 - **FR-001**: System MUST parse standard `My Clippings.txt` files using the `==========` separator to split individual clipping entries.
 - **FR-002**: System MUST extract the book title and author from the first line of each clipping entry.
 - **FR-003**: System MUST extract the full highlight or note text, including multi-line content, from each clipping entry.
-- **FR-004**: System MUST extract metadata (clipping type, location range, and date) from the second line of each clipping entry.
-- **FR-005**: System MUST distinguish between highlights, notes, and bookmarks, and extract highlights and notes while skipping bookmarks.
+- **FR-004**: System MUST extract metadata (location range and date) from the second line of each clipping entry. The metadata line is also used internally to detect the entry type (highlight, note, or bookmark) but no type field is exposed in the output.
+- **FR-005**: System MUST skip bookmarks (position-only entries with no text). Notes MUST be treated as highlights with a `[my note]` prefix prepended to their text. There is no separate type or special handling for notes anywhere in CLI or server.
 - **FR-006**: System MUST deduplicate highlights by matching on the combination of book title, author, and highlight text (exact match, case-sensitive).
 - **FR-007**: System MUST group deduplicated highlights by book, where a book is identified by the pair of title and author name.
 - **FR-008**: System MUST skip malformed clipping entries that cannot be parsed and continue processing the remainder of the file.
-- **FR-009**: System MUST report skipped entries as warnings, including the approximate position in the file and the reason for skipping.
-- **FR-010**: System MUST produce an output structure organized by book, where each book contains its title, author name, and list of highlights, suitable for the sync API payload.
+- **FR-009**: System MUST log skipped entries as warnings to the console, including the approximate position in the file and the reason for skipping.
+- **FR-010**: System MUST produce an output structure organized by book, where each book contains its title, author name, and list of highlight texts (notes included with `[my note]` prefix), suitable for the sync API payload.
 - **FR-011**: System MUST handle empty files and files with no valid clippings by returning an empty result without errors.
 
 ### Key Entities
 
 - **Clipping**: A single raw entry from `My Clippings.txt`, containing a title/author line, a metadata line, and content text. Represents the unprocessed input before deduplication.
-- **Highlight**: A parsed, deduplicated piece of text that was highlighted or annotated by the user in a book. Associated with exactly one book.
+- **Highlight**: A parsed, deduplicated piece of text from the user's Kindle. Notes are stored as highlights with a `[my note]` prefix — there is no type distinction. Associated with exactly one book.
 - **Book**: A publication identified by its title and author name. Contains one or more highlights after grouping.
 - **Author**: A person identified by name who wrote one or more books.
-- **Parse Result**: The complete output of the parsing process — a collection of books with their associated highlights, plus any warnings generated during parsing.
+- **Parse Result**: The complete output of the parsing process — a collection of books with their associated highlights.
 
 ## Success Criteria *(mandatory)*
 
@@ -127,7 +127,7 @@ Real-world `My Clippings.txt` files may contain malformed or incomplete entries 
 - Author name appears in parentheses at the end of the title line (e.g., `Book Title (Author Name)`). If parentheses are absent, the entire line is treated as the title with an unknown author.
 - Deduplication uses exact text matching (case-sensitive). Fuzzy matching or near-duplicate detection is out of scope for MVP.
 - Bookmarks (entries with no highlight text, only a position marker) are skipped since they carry no textual content useful for recaps.
-- Notes (user-written annotations) are treated as a type of highlight for parsing purposes — they follow the same extraction and deduplication logic.
+- Notes (user-written annotations) are treated as highlights with a `[my note]` prefix prepended to their text. There is no separate type enum or special handling for notes in CLI or server — they are simply highlights whose text starts with `[my note]`.
 - The parser is a pure function with no side effects: it reads a file or text stream and produces a structured result. It has no dependencies on the server, database, or network.
 - Location and date metadata are extracted for informational purposes but are not used for deduplication or grouping in MVP.
 - Single-user context: the parser does not associate highlights with a specific user ID (user association happens at the sync level).

--- a/specs/003-highlight-parser/spec.md
+++ b/specs/003-highlight-parser/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Highlight Parser
+
+**Feature Branch**: `003-highlight-parser`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "Parse the My Clippings.txt file exported from Kindle and extract structured highlight data. This covers PRD requirements FR-01 (Parse My Clippings.txt and extract highlights and annotations), FR-02 (Deduplicate highlights), and FR-03 (Group highlights by book title and author)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Parse Highlights from My Clippings.txt (Priority: P1)
+
+A Kindle user connects their device via USB and runs the `sunny sync` command, pointing it at the `My Clippings.txt` file. The system reads the file, parses each clipping entry, and extracts structured highlight data including the book title, author, and highlight text. The user sees a summary of how many highlights were successfully parsed.
+
+**Why this priority**: This is the foundational capability. Without parsing, no other feature (deduplication, grouping, sync) can function. It directly addresses PRD FR-01.
+
+**Independent Test**: Can be fully tested by providing a sample `My Clippings.txt` file and verifying that all valid highlights are extracted with correct book/author/text associations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a standard `My Clippings.txt` file with 50 highlights across 5 books, **When** the parser processes the file, **Then** all 50 highlights are extracted with correct book title, author, and highlight text.
+2. **Given** a clipping entry with a multi-line highlight (text spanning multiple lines), **When** the parser processes the entry, **Then** the full multi-line text is captured as a single highlight.
+3. **Given** a `My Clippings.txt` file containing highlights, notes, and bookmarks, **When** the parser processes the file, **Then** highlights and notes are extracted, and bookmarks (position-only entries with no text) are skipped.
+4. **Given** a clipping entry with metadata containing location range and timestamp, **When** the parser processes the entry, **Then** the location and date information are extracted alongside the highlight text.
+
+---
+
+### User Story 2 — Deduplicate Highlights (Priority: P2)
+
+After parsing, the system identifies and removes duplicate highlights. Kindle appends a new entry every time the user re-highlights or extends a highlight, resulting in duplicates. The user expects only unique highlights in the output, with no repeated content for the same book.
+
+**Why this priority**: Deduplication is essential for data quality. Without it, users would receive duplicate highlights in their recaps, degrading the experience. Directly addresses PRD FR-02.
+
+**Independent Test**: Can be tested by providing a file with known duplicates and verifying that the output contains only unique highlights.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file where the same highlight text appears twice for the same book and author, **When** deduplication runs, **Then** only one instance of the highlight is retained.
+2. **Given** two highlights with identical text but from different books, **When** deduplication runs, **Then** both highlights are retained (they are not duplicates).
+3. **Given** two highlights from the same book where one is a substring of the other (e.g., re-highlighted with a wider selection), **When** deduplication runs, **Then** both are retained as distinct highlights (only exact text matches are considered duplicates).
+4. **Given** a file with 100 clippings where 20 are duplicates, **When** deduplication runs, **Then** the output contains exactly 80 unique highlights.
+
+---
+
+### User Story 3 — Group Highlights by Book and Author (Priority: P3)
+
+After parsing and deduplication, highlights are organized by book. Each book is identified by its title and author. The user receives a structured output where highlights are grouped under their respective books, ready for the sync API.
+
+**Why this priority**: Grouping is necessary for the sync API to correctly associate highlights with books and authors in the server database. Directly addresses PRD FR-03.
+
+**Independent Test**: Can be tested by verifying that parsed highlights are correctly grouped under book/author pairs.
+
+**Acceptance Scenarios**:
+
+1. **Given** 30 highlights across 3 books by different authors, **When** grouping runs, **Then** the output contains 3 book groups, each with its correct highlights.
+2. **Given** highlights from two different books by the same author, **When** grouping runs, **Then** the highlights are grouped into two separate book entries (grouped by title + author, not author alone).
+3. **Given** the grouped output, **When** the structure is inspected, **Then** each book group contains the book title, author name, and a list of its associated highlights.
+
+---
+
+### User Story 4 — Handle Malformed Entries Gracefully (Priority: P4)
+
+Real-world `My Clippings.txt` files may contain malformed or incomplete entries due to Kindle firmware bugs, file corruption, or manual editing. The parser skips these entries without crashing and reports them as warnings so the user can investigate if needed.
+
+**Why this priority**: Robustness is important for user trust, but only after core parsing works correctly. A parser that crashes on unexpected input would be unusable in practice.
+
+**Independent Test**: Can be tested by providing a file with intentionally malformed entries mixed with valid ones and verifying that valid highlights are still extracted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file with one malformed entry (missing separator, truncated text) among 10 valid entries, **When** the parser processes the file, **Then** 10 valid highlights are extracted and the malformed entry is skipped with a warning.
+2. **Given** an empty `My Clippings.txt` file, **When** the parser processes the file, **Then** the result is an empty collection with no errors.
+3. **Given** a file containing only separators and no actual clipping content, **When** the parser processes the file, **Then** the result is an empty collection with no errors.
+4. **Given** a file where a clipping entry is missing the author on the title line, **When** the parser processes the entry, **Then** the entry is parsed with best-effort extraction (title without author), not skipped entirely.
+
+---
+
+### Edge Cases
+
+- What happens when the file contains a UTF-8 BOM (byte order mark) at the start?
+- How does the parser handle extremely large files (50,000+ clippings)?
+- What happens when a book title contains special characters (quotes, parentheses, Unicode)?
+- How does the parser handle clippings with empty highlight text (blank content between metadata and separator)?
+- What happens when the title/author line uses unexpected formatting (e.g., missing parentheses around author name, or author name with commas like "Last, First")?
+- How does the parser handle entries in different languages (CJK characters, RTL scripts, diacritics)?
+- What happens when the same highlight text appears for the same book but with different location metadata (re-highlighted at a different page)?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST parse standard `My Clippings.txt` files using the `==========` separator to split individual clipping entries.
+- **FR-002**: System MUST extract the book title and author from the first line of each clipping entry.
+- **FR-003**: System MUST extract the full highlight or note text, including multi-line content, from each clipping entry.
+- **FR-004**: System MUST extract metadata (clipping type, location range, and date) from the second line of each clipping entry.
+- **FR-005**: System MUST distinguish between highlights, notes, and bookmarks, and extract highlights and notes while skipping bookmarks.
+- **FR-006**: System MUST deduplicate highlights by matching on the combination of book title, author, and highlight text (exact match, case-sensitive).
+- **FR-007**: System MUST group deduplicated highlights by book, where a book is identified by the pair of title and author name.
+- **FR-008**: System MUST skip malformed clipping entries that cannot be parsed and continue processing the remainder of the file.
+- **FR-009**: System MUST report skipped entries as warnings, including the approximate position in the file and the reason for skipping.
+- **FR-010**: System MUST produce an output structure organized by book, where each book contains its title, author name, and list of highlights, suitable for the sync API payload.
+- **FR-011**: System MUST handle empty files and files with no valid clippings by returning an empty result without errors.
+
+### Key Entities
+
+- **Clipping**: A single raw entry from `My Clippings.txt`, containing a title/author line, a metadata line, and content text. Represents the unprocessed input before deduplication.
+- **Highlight**: A parsed, deduplicated piece of text that was highlighted or annotated by the user in a book. Associated with exactly one book.
+- **Book**: A publication identified by its title and author name. Contains one or more highlights after grouping.
+- **Author**: A person identified by name who wrote one or more books.
+- **Parse Result**: The complete output of the parsing process — a collection of books with their associated highlights, plus any warnings generated during parsing.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All valid highlights and notes are extracted from a standard `My Clippings.txt` file with 100% accuracy — no valid entry is missed or incorrectly parsed.
+- **SC-002**: Duplicate highlights are reduced to a single entry per unique combination, with zero false positives (no unique highlights incorrectly removed) and zero false negatives (no true duplicates retained).
+- **SC-003**: Highlights are correctly grouped by book, with each book associated with its correct author — verified across files containing 20+ distinct books.
+- **SC-004**: Malformed entries are skipped without affecting the parsing of valid entries — verified by processing files with 10% intentionally corrupted entries and confirming all valid entries are still extracted.
+- **SC-005**: A file with 10,000 clippings is parsed, deduplicated, and grouped within 5 seconds.
+- **SC-006**: The parsed output structure maps directly to the expected sync API payload without additional transformation.
+
+## Assumptions
+
+- `My Clippings.txt` uses UTF-8 encoding, which is standard across all Kindle models. The parser handles an optional UTF-8 BOM at the start of the file.
+- The file format uses `==========` (ten equals signs) on a dedicated line as the separator between clipping entries. This format has been stable across Kindle generations for over a decade.
+- Each clipping entry follows the structure: line 1 = book title and author, line 2 = metadata (type, location, date), line 3 = blank, line 4+ = content text.
+- Author name appears in parentheses at the end of the title line (e.g., `Book Title (Author Name)`). If parentheses are absent, the entire line is treated as the title with an unknown author.
+- Deduplication uses exact text matching (case-sensitive). Fuzzy matching or near-duplicate detection is out of scope for MVP.
+- Bookmarks (entries with no highlight text, only a position marker) are skipped since they carry no textual content useful for recaps.
+- Notes (user-written annotations) are treated as a type of highlight for parsing purposes — they follow the same extraction and deduplication logic.
+- The parser is a pure function with no side effects: it reads a file or text stream and produces a structured result. It has no dependencies on the server, database, or network.
+- Location and date metadata are extracted for informational purposes but are not used for deduplication or grouping in MVP.
+- Single-user context: the parser does not associate highlights with a specific user ID (user association happens at the sync level).
+- The parser is client-side logic used by the CLI during sync — it runs locally on the user's machine, not on the server.

--- a/specs/003-highlight-parser/tasks.md
+++ b/specs/003-highlight-parser/tasks.md
@@ -29,13 +29,11 @@
 
 **⚠️ CRITICAL**: No user story work can begin until all types are defined and the solution builds.
 
-- [ ] T002 [P] Create `ClippingType` enum in `src/SunnySunday.Core/Parsing/ClippingType.cs` with values `Highlight`, `Note`, `Bookmark`. Use `namespace SunnySunday.Core.Parsing;` file-scoped namespace.
-- [ ] T003 [P] Create `RawClipping` internal record in `src/SunnySunday.Core/Parsing/RawClipping.cs` with properties: `string Title`, `string? Author`, `ClippingType Type`, `string? Location`, `DateTimeOffset? AddedOn`, `string Text`. This is an intermediate type not exposed publicly. Mark the class `internal`.
-- [ ] T004 [P] Create `ParsedHighlight` public record in `src/SunnySunday.Core/Parsing/ParsedHighlight.cs` with properties: `string Text`, `ClippingType Type` (only Highlight or Note, never Bookmark), `string? Location`, `DateTimeOffset? AddedOn`. Immutable.
-- [ ] T005 [P] Create `ParsedBook` public record in `src/SunnySunday.Core/Parsing/ParsedBook.cs` with properties: `string Title`, `string? Author`, `IReadOnlyList<ParsedHighlight> Highlights`. A ParsedBook is never emitted with zero highlights.
-- [ ] T006 [P] Create `ParseWarning` public record in `src/SunnySunday.Core/Parsing/ParseWarning.cs` with properties: `int EntryIndex` (1-based), `string Reason`, `string RawExcerpt` (first 200 chars of raw entry).
-- [ ] T007 [P] Create `ParseResult` public record in `src/SunnySunday.Core/Parsing/ParseResult.cs` with properties: `IReadOnlyList<ParsedBook> Books`, `IReadOnlyList<ParseWarning> Warnings`, `int TotalEntriesProcessed`, `int DuplicatesRemoved`.
-- [ ] T008 Verify `dotnet build src/SunnySunday.slnx` succeeds with all six new types. Fix any compilation errors.
+- [ ] T002 [P] Create `RawClipping` internal record in `src/SunnySunday.Core/Parsing/RawClipping.cs` with properties: `string Title`, `string? Author`, `bool IsNote`, `string? Location`, `DateTimeOffset? AddedOn`, `string Text`. This is an intermediate type not exposed publicly. Mark the class `internal`. `IsNote` is true when the metadata line says "Note" — used to prepend `[my note]` prefix.
+- [ ] T003 [P] Create `ParsedHighlight` public record in `src/SunnySunday.Core/Parsing/ParsedHighlight.cs` with properties: `string Text`, `string? Location`, `DateTimeOffset? AddedOn`. Immutable. Notes are stored here with `[my note]` already prepended to `Text` — no type field.
+- [ ] T004 [P] Create `ParsedBook` public record in `src/SunnySunday.Core/Parsing/ParsedBook.cs` with properties: `string Title`, `string? Author`, `IReadOnlyList<ParsedHighlight> Highlights`. A ParsedBook is never emitted with zero highlights.
+- [ ] T005 [P] Create `ParseResult` public record in `src/SunnySunday.Core/Parsing/ParseResult.cs` with properties: `IReadOnlyList<ParsedBook> Books`, `int TotalEntriesProcessed`, `int DuplicatesRemoved`. No warnings collection — malformed entries are logged via `ILogger`.
+- [ ] T006 Verify `dotnet build src/SunnySunday.slnx` succeeds with all four new types. Fix any compilation errors.
 
 **Checkpoint**: All parser types compile. User story implementation can begin.
 
@@ -43,7 +41,7 @@
 
 ## Phase 3: User Story 1 — Parse Highlights from My Clippings.txt (Priority: P1) 🎯 MVP
 
-**Goal**: Parse a standard `My Clippings.txt` file and extract structured highlight data including book title, author, highlight text, clipping type, location, and date. Bookmarks are skipped. Notes are treated as highlights.
+**Goal**: Parse a standard `My Clippings.txt` file and extract structured highlight data including book title, author, highlight text, location, and date. Bookmarks are skipped. Notes are treated as highlights with a `[my note]` prefix on their text.
 
 **Independent Test**: Provide a sample `My Clippings.txt` string via `StringReader` and verify all valid highlights are extracted with correct book/author/text associations.
 
@@ -59,17 +57,17 @@
 - [ ] T009 [P] [US1] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given a standard `My Clippings.txt` input with 3 highlights across 2 books, `ClippingsParser.ParseAsync(TextReader)` returns a `ParseResult` with correct total entry count and highlights extractable from the books list. Use the exact Kindle format: title/author line, metadata line, blank line, content, `==========` separator. See `specs/003-highlight-parser/quickstart.md` for format examples.
 - [ ] T010 [P] [US1] Write test: given a clipping entry with multi-line highlight text (content spanning 3+ lines between blank line and separator), the full text is captured as a single highlight with newlines preserved.
 - [ ] T011 [P] [US1] Write tests for title/author extraction edge cases: (a) standard `Book Title (Author Name)` → title=`Book Title`, author=`Author Name`; (b) author as `Last, First` in parens → author=`Last, First`; (c) title with nested parentheses like `The Art of War (Annotated) (Sun Tzu)` → title=`The Art of War (Annotated)`, author=`Sun Tzu`; (d) no parentheses at all → title=full line, author=`null`; (e) empty parens `Some Book ()` → title=`Some Book`, author=`null`. See `specs/003-highlight-parser/research.md` section 2 for the full edge case table.
-- [ ] T012 [P] [US1] Write tests for metadata line parsing: (a) `- Your Highlight on Location 100-105 | Added on Thursday, January 1, 2026 12:00:00 AM` → type=Highlight, location=`Location 100-105`, date parsed; (b) `- Your Note on ...` → type=Note; (c) `- Your Bookmark on ...` → type=Bookmark. Verify bookmarks are excluded from the final ParseResult.Books highlights (no text content). See `specs/003-highlight-parser/research.md` section 3 for the regex pattern.
+- [ ] T012 [P] [US1] Write tests for metadata line parsing and entry type handling: (a) `- Your Highlight on Location 100-105 | Added on Thursday, January 1, 2026 12:00:00 AM` → location=`Location 100-105`, date parsed, text used as-is; (b) `- Your Note on ...` → text gets `[my note]` prefix prepended; (c) `- Your Bookmark on ...` → entry is excluded from ParseResult.Books entirely. See `specs/003-highlight-parser/research.md` section 3.
 - [ ] T013 [P] [US1] Write test for `ClippingsParser.ParseAsync(string filePath)` overload: create a temp file with valid Kindle content, parse via file path, verify same result as TextReader overload. Clean up temp file after test.
 
 ### Implementation for User Story 1
 
-- [ ] T014 [US1] Create `ClippingsParser` static class in `src/SunnySunday.Core/Parsing/ClippingsParser.cs` with two public static methods: `Task<ParseResult> ParseAsync(TextReader reader)` and `Task<ParseResult> ParseAsync(string filePath)`. The file-path overload creates a `StreamReader` (UTF-8, BOM-detected) and delegates to the TextReader overload. Initial implementation can return an empty `ParseResult`.
+- [ ] T014 [US1] Create `ClippingsParser` static class in `src/SunnySunday.Core/Parsing/ClippingsParser.cs` with two public static methods: `Task<ParseResult> ParseAsync(TextReader reader, ILogger? logger = null)` and `Task<ParseResult> ParseAsync(string filePath, ILogger? logger = null)`. The file-path overload creates a `StreamReader` (UTF-8, BOM-detected) and delegates to the TextReader overload. The optional `ILogger` is used to log warnings for malformed entries. Initial implementation can return an empty `ParseResult`.
 - [ ] T015 [US1] Implement entry splitting in `ParseAsync(TextReader)`: read lines via `ReadLineAsync()`, accumulate lines into a buffer, and split entries on the `==========` separator line. Track a 1-based entry index counter. Each accumulated block of lines between separators is one raw clipping entry.
 - [ ] T016 [US1] Implement title/author extraction: given the first line of an entry, extract the title and author. Author is the content of the **last** parenthesized group `(...)` on the line. If no parentheses are found, the entire line (trimmed) is the title and author is `null`. Empty parentheses `()` should also yield `null` author. Trim both title and author. See `specs/003-highlight-parser/research.md` section 2.
-- [ ] T017 [US1] Implement metadata line parsing: given the second line of an entry, use regex `^- Your (?<type>Highlight|Note|Bookmark) on (?<location>.+?) \| Added on (?<date>.+)$` to extract clipping type, location string, and date string. Parse the date with format `dddd, MMMM d, yyyy h:mm:ss tt` using `CultureInfo.InvariantCulture` into `DateTimeOffset?`; if date parsing fails, store `null` (do not skip the entry). See `specs/003-highlight-parser/research.md` section 3.
+- [ ] T017 [US1] Implement metadata line parsing: given the second line of an entry, use regex `^- Your (?<type>Highlight|Note|Bookmark) on (?<location>.+?) \| Added on (?<date>.+)$` to extract the entry type (internal use only), location string, and date string. Parse the date with format `dddd, MMMM d, yyyy h:mm:ss tt` using `CultureInfo.InvariantCulture` into `DateTimeOffset?`; if date parsing fails, store `null` (do not skip the entry). Set `IsNote = true` when type is "Note". See `specs/003-highlight-parser/research.md` section 3.
 - [ ] T018 [US1] Implement content text extraction: the content starts at line index 3 of the entry (after title, metadata, blank line) and continues until the end of the entry block. Join all content lines with `\n`. Trim the final result. Empty content (bookmarks) yields an empty string.
-- [ ] T019 [US1] Assemble the full parse pipeline: for each entry, build a `RawClipping` from the extracted fields. Filter out entries where `Type == Bookmark`. Convert remaining entries to `ParsedHighlight` objects. For now (before US2/US3), return a `ParseResult` with all highlights grouped into books by `(Title, Author)` pair using a dictionary, populate `TotalEntriesProcessed`, set `DuplicatesRemoved = 0`, and `Warnings` as empty list.
+- [ ] T019 [US1] Assemble the full parse pipeline: for each entry, build a `RawClipping` from the extracted fields. Filter out bookmarks (detected from metadata type). For notes (`IsNote == true`), prepend `[my note] ` to the text. Convert remaining entries to `ParsedHighlight` objects. For now (before US2/US3), return a `ParseResult` with all highlights grouped into books by `(Title, Author)` pair using a dictionary, populate `TotalEntriesProcessed`, and set `DuplicatesRemoved = 0`.
 - [ ] T020 [US1] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1 tests must pass.
 
 **Checkpoint**: Parser can extract highlights from valid `My Clippings.txt` input. This is the MVP — a usable parser even without dedup/error handling.
@@ -125,25 +123,25 @@
 
 ## Phase 6: User Story 4 — Handle Malformed Entries Gracefully (Priority: P4)
 
-**Goal**: Skip malformed or incomplete clipping entries without crashing. Report skipped entries as `ParseWarning` objects with entry index, reason, and a raw excerpt. Valid entries surrounding malformed ones are still parsed correctly.
+**Goal**: Skip malformed or incomplete clipping entries without crashing. Log skipped entries as warnings via `ILogger`. Valid entries surrounding malformed ones are still parsed correctly.
 
-**Independent Test**: Provide input with intentionally malformed entries mixed with valid ones and verify valid highlights are extracted and warnings are generated.
+**Independent Test**: Provide input with intentionally malformed entries mixed with valid ones and verify valid highlights are extracted and warnings are logged.
 
 **Functional Requirements**: FR-008, FR-009, FR-011
 
 ### Tests for User Story 4
 
-- [ ] T032 [P] [US4] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given 10 valid entries and 1 malformed entry (e.g., missing metadata line — only title line then separator), all 10 valid highlights are extracted and `ParseResult.Warnings` contains exactly 1 warning with the correct `EntryIndex` and a descriptive `Reason`.
-- [ ] T033 [P] [US4] Write test: given an empty input (empty string or no content), `ParseResult.Books` is empty, `ParseResult.Warnings` is empty, and no exception is thrown.
-- [ ] T034 [P] [US4] Write test: given input containing only `==========` separators and no actual clipping content, the result is empty books and empty warnings (no valid entries, blank entries silently skipped).
+- [ ] T032 [P] [US4] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given 10 valid entries and 1 malformed entry (e.g., missing metadata line — only title line then separator), all 10 valid highlights are extracted. Use a mock `ILogger` to verify a warning was logged with the correct entry index and a descriptive reason.
+- [ ] T033 [P] [US4] Write test: given an empty input (empty string or no content), `ParseResult.Books` is empty and no exception is thrown.
+- [ ] T034 [P] [US4] Write test: given input containing only `==========` separators and no actual clipping content, the result is empty books (no valid entries, blank entries silently skipped).
 - [ ] T035 [P] [US4] Write test: given a clipping entry where the title line has no parentheses (missing author), the entry is parsed with best-effort: title is the full first line (trimmed) and author is `null`. The entry is NOT skipped — it appears in the result.
-- [ ] T036 [P] [US4] Write test: given a clipping entry with an unrecognized type on the metadata line (e.g., `- Your Clip on Location 50 | Added on ...`), the entry is skipped with a warning. Valid surrounding entries are still parsed.
+- [ ] T036 [P] [US4] Write test: given a clipping entry with an unrecognized type on the metadata line (e.g., `- Your Clip on Location 50 | Added on ...`), the entry is skipped and a warning is logged. Valid surrounding entries are still parsed.
 
 ### Implementation for User Story 4
 
-- [ ] T037 [US4] Implement skip-and-warn logic in `src/SunnySunday.Core/Parsing/ClippingsParser.cs`: wrap per-entry parsing in a try-catch or validation gate. If an entry has fewer than 2 lines, or the metadata line does not match the expected regex, create a `ParseWarning` with the 1-based `EntryIndex`, a descriptive `Reason` (e.g., "Missing metadata line", "Unrecognized clipping type"), and `RawExcerpt` (first 200 characters of the raw entry text, or full text if shorter). Add the warning to the warnings list and continue to the next entry.
+- [ ] T037 [US4] Implement skip-and-log logic in `src/SunnySunday.Core/Parsing/ClippingsParser.cs`: wrap per-entry parsing in a try-catch or validation gate. If an entry has fewer than 2 lines, or the metadata line does not match the expected regex, log a warning via `ILogger` with the 1-based entry index, a descriptive reason (e.g., "Missing metadata line", "Unrecognized clipping type"), and an excerpt of the raw entry text (first 200 characters). Continue to the next entry.
 - [ ] T038 [US4] Implement best-effort parsing for partial entries: if the title line has no author parentheses, still parse the entry with `Author = null` (do not skip). If the date cannot be parsed, still parse the entry with `AddedOn = null`. Only skip entries where the structure is completely unrecognizable (< 2 lines, or metadata regex fails entirely).
-- [ ] T039 [US4] Handle edge cases for empty and whitespace-only entries: blank lines between separators should be silently skipped (no warning generated for completely empty entries). Entries with only whitespace content (no title line) should also be silently skipped.
+- [ ] T039 [US4] Handle edge cases for empty and whitespace-only entries: blank lines between separators should be silently skipped (no warning logged for completely empty entries). Entries with only whitespace content (no title line) should also be silently skipped.
 - [ ] T040 [US4] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1, US2, US3, and US4 tests must pass.
 
 **Checkpoint**: Parser is robust against malformed input. All previous stories still pass.
@@ -156,7 +154,7 @@
 
 - [ ] T041 [P] Write edge case tests in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: (a) input with UTF-8 BOM prefix parses correctly (StreamReader handles BOM automatically, but verify via file-path overload with a BOM-prefixed temp file); (b) book titles and authors with Unicode characters (CJK, diacritics, RTL) parse correctly; (c) highlight text with special characters (quotes, angle brackets, ampersands) is preserved verbatim.
 - [ ] T042 [P] Write performance test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: programmatically generate a `My Clippings.txt` string with 10,000 clipping entries, parse via `StringReader`, and assert completion within 5 seconds (SC-005). Use `[Fact]` with a `Stopwatch` or `[Fact(Timeout = 5000)]`.
-- [ ] T043 [P] Update `docs/ARCHITECTURE.md` to document the `SunnySunday.Core/Parsing/` component: its purpose (pure function parser for My Clippings.txt), public API surface (`ClippingsParser.ParseAsync`), key types (`ParseResult`, `ParsedBook`, `ParsedHighlight`), and design decisions (no dependencies, streaming, skip-and-warn).
+- [ ] T043 [P] Update `docs/ARCHITECTURE.md` to document the `SunnySunday.Core/Parsing/` component: its purpose (pure function parser for My Clippings.txt), public API surface (`ClippingsParser.ParseAsync`), key types (`ParseResult`, `ParsedBook`, `ParsedHighlight`), and design decisions (no dependencies, streaming, skip-and-log, notes as `[my note]`-prefixed highlights).
 - [ ] T044 Run full `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj` — all tests (including existing SchemaBootstrapTests) must pass. Run `dotnet build src/SunnySunday.slnx` clean. Validate that the quickstart.md code examples in `specs/003-highlight-parser/quickstart.md` are consistent with the implemented API.
 
 ---

--- a/specs/003-highlight-parser/tasks.md
+++ b/specs/003-highlight-parser/tasks.md
@@ -1,0 +1,286 @@
+# Tasks: Highlight Parser
+
+**Input**: Design documents from `/specs/003-highlight-parser/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: TDD approach — write tests before or alongside implementation. Tests go in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- All source paths are relative to repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create directory structure for parser code and tests
+
+- [ ] T001 Create directories `src/SunnySunday.Core/Parsing/` and `src/SunnySunday.Tests/Parsing/`, verify `dotnet build src/SunnySunday.slnx` still succeeds
+
+---
+
+## Phase 2: Foundational — Parser Data Types
+
+**Purpose**: Define all parser-specific types that every user story depends on. These types live in `SunnySunday.Core/Parsing/` namespace and are distinct from the persistence models in `SunnySunday.Core/Models/`.
+
+**⚠️ CRITICAL**: No user story work can begin until all types are defined and the solution builds.
+
+- [ ] T002 [P] Create `ClippingType` enum in `src/SunnySunday.Core/Parsing/ClippingType.cs` with values `Highlight`, `Note`, `Bookmark`. Use `namespace SunnySunday.Core.Parsing;` file-scoped namespace.
+- [ ] T003 [P] Create `RawClipping` internal record in `src/SunnySunday.Core/Parsing/RawClipping.cs` with properties: `string Title`, `string? Author`, `ClippingType Type`, `string? Location`, `DateTimeOffset? AddedOn`, `string Text`. This is an intermediate type not exposed publicly. Mark the class `internal`.
+- [ ] T004 [P] Create `ParsedHighlight` public record in `src/SunnySunday.Core/Parsing/ParsedHighlight.cs` with properties: `string Text`, `ClippingType Type` (only Highlight or Note, never Bookmark), `string? Location`, `DateTimeOffset? AddedOn`. Immutable.
+- [ ] T005 [P] Create `ParsedBook` public record in `src/SunnySunday.Core/Parsing/ParsedBook.cs` with properties: `string Title`, `string? Author`, `IReadOnlyList<ParsedHighlight> Highlights`. A ParsedBook is never emitted with zero highlights.
+- [ ] T006 [P] Create `ParseWarning` public record in `src/SunnySunday.Core/Parsing/ParseWarning.cs` with properties: `int EntryIndex` (1-based), `string Reason`, `string RawExcerpt` (first 200 chars of raw entry).
+- [ ] T007 [P] Create `ParseResult` public record in `src/SunnySunday.Core/Parsing/ParseResult.cs` with properties: `IReadOnlyList<ParsedBook> Books`, `IReadOnlyList<ParseWarning> Warnings`, `int TotalEntriesProcessed`, `int DuplicatesRemoved`.
+- [ ] T008 Verify `dotnet build src/SunnySunday.slnx` succeeds with all six new types. Fix any compilation errors.
+
+**Checkpoint**: All parser types compile. User story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Parse Highlights from My Clippings.txt (Priority: P1) 🎯 MVP
+
+**Goal**: Parse a standard `My Clippings.txt` file and extract structured highlight data including book title, author, highlight text, clipping type, location, and date. Bookmarks are skipped. Notes are treated as highlights.
+
+**Independent Test**: Provide a sample `My Clippings.txt` string via `StringReader` and verify all valid highlights are extracted with correct book/author/text associations.
+
+**Functional Requirements**: FR-001, FR-002, FR-003, FR-004, FR-005
+
+### Tests for User Story 1
+
+> **Write these tests FIRST — they must FAIL (or not compile) before implementation begins.**
+> All tests go in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs` using xUnit `[Fact]` / `[Theory]`.
+> Use `StringReader` to provide test input — no temp files needed.
+> Reference quickstart.md for sample Kindle format.
+
+- [ ] T009 [P] [US1] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given a standard `My Clippings.txt` input with 3 highlights across 2 books, `ClippingsParser.ParseAsync(TextReader)` returns a `ParseResult` with correct total entry count and highlights extractable from the books list. Use the exact Kindle format: title/author line, metadata line, blank line, content, `==========` separator. See `specs/003-highlight-parser/quickstart.md` for format examples.
+- [ ] T010 [P] [US1] Write test: given a clipping entry with multi-line highlight text (content spanning 3+ lines between blank line and separator), the full text is captured as a single highlight with newlines preserved.
+- [ ] T011 [P] [US1] Write tests for title/author extraction edge cases: (a) standard `Book Title (Author Name)` → title=`Book Title`, author=`Author Name`; (b) author as `Last, First` in parens → author=`Last, First`; (c) title with nested parentheses like `The Art of War (Annotated) (Sun Tzu)` → title=`The Art of War (Annotated)`, author=`Sun Tzu`; (d) no parentheses at all → title=full line, author=`null`; (e) empty parens `Some Book ()` → title=`Some Book`, author=`null`. See `specs/003-highlight-parser/research.md` section 2 for the full edge case table.
+- [ ] T012 [P] [US1] Write tests for metadata line parsing: (a) `- Your Highlight on Location 100-105 | Added on Thursday, January 1, 2026 12:00:00 AM` → type=Highlight, location=`Location 100-105`, date parsed; (b) `- Your Note on ...` → type=Note; (c) `- Your Bookmark on ...` → type=Bookmark. Verify bookmarks are excluded from the final ParseResult.Books highlights (no text content). See `specs/003-highlight-parser/research.md` section 3 for the regex pattern.
+- [ ] T013 [P] [US1] Write test for `ClippingsParser.ParseAsync(string filePath)` overload: create a temp file with valid Kindle content, parse via file path, verify same result as TextReader overload. Clean up temp file after test.
+
+### Implementation for User Story 1
+
+- [ ] T014 [US1] Create `ClippingsParser` static class in `src/SunnySunday.Core/Parsing/ClippingsParser.cs` with two public static methods: `Task<ParseResult> ParseAsync(TextReader reader)` and `Task<ParseResult> ParseAsync(string filePath)`. The file-path overload creates a `StreamReader` (UTF-8, BOM-detected) and delegates to the TextReader overload. Initial implementation can return an empty `ParseResult`.
+- [ ] T015 [US1] Implement entry splitting in `ParseAsync(TextReader)`: read lines via `ReadLineAsync()`, accumulate lines into a buffer, and split entries on the `==========` separator line. Track a 1-based entry index counter. Each accumulated block of lines between separators is one raw clipping entry.
+- [ ] T016 [US1] Implement title/author extraction: given the first line of an entry, extract the title and author. Author is the content of the **last** parenthesized group `(...)` on the line. If no parentheses are found, the entire line (trimmed) is the title and author is `null`. Empty parentheses `()` should also yield `null` author. Trim both title and author. See `specs/003-highlight-parser/research.md` section 2.
+- [ ] T017 [US1] Implement metadata line parsing: given the second line of an entry, use regex `^- Your (?<type>Highlight|Note|Bookmark) on (?<location>.+?) \| Added on (?<date>.+)$` to extract clipping type, location string, and date string. Parse the date with format `dddd, MMMM d, yyyy h:mm:ss tt` using `CultureInfo.InvariantCulture` into `DateTimeOffset?`; if date parsing fails, store `null` (do not skip the entry). See `specs/003-highlight-parser/research.md` section 3.
+- [ ] T018 [US1] Implement content text extraction: the content starts at line index 3 of the entry (after title, metadata, blank line) and continues until the end of the entry block. Join all content lines with `\n`. Trim the final result. Empty content (bookmarks) yields an empty string.
+- [ ] T019 [US1] Assemble the full parse pipeline: for each entry, build a `RawClipping` from the extracted fields. Filter out entries where `Type == Bookmark`. Convert remaining entries to `ParsedHighlight` objects. For now (before US2/US3), return a `ParseResult` with all highlights grouped into books by `(Title, Author)` pair using a dictionary, populate `TotalEntriesProcessed`, set `DuplicatesRemoved = 0`, and `Warnings` as empty list.
+- [ ] T020 [US1] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1 tests must pass.
+
+**Checkpoint**: Parser can extract highlights from valid `My Clippings.txt` input. This is the MVP — a usable parser even without dedup/error handling.
+
+---
+
+## Phase 4: User Story 2 — Deduplicate Highlights (Priority: P2)
+
+**Goal**: After parsing, remove duplicate highlights. A duplicate is defined as an exact case-sensitive match on the `(Title, Author, Text)` tuple. The first occurrence is kept.
+
+**Independent Test**: Provide input with known duplicates and verify only unique highlights remain in the output.
+
+**Functional Requirements**: FR-006
+
+### Tests for User Story 2
+
+- [ ] T021 [P] [US2] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given input where the same highlight text appears twice for the same book and author, the result contains only one instance of that highlight and `DuplicatesRemoved == 1`.
+- [ ] T022 [P] [US2] Write test: given two highlights with identical text but from different books (different title or author), both highlights are retained — they are not considered duplicates.
+- [ ] T023 [P] [US2] Write test: given two highlights from the same book where one is a substring of the other (e.g., "War is peace" vs "War is peace. Freedom is slavery."), both are retained as distinct highlights. Only exact text matches are duplicates.
+- [ ] T024 [P] [US2] Write test: given 10 clippings where 3 are duplicates, `ParseResult.DuplicatesRemoved == 3` and the total unique highlights across all books equals 7.
+
+### Implementation for User Story 2
+
+- [ ] T025 [US2] Implement deduplication in `src/SunnySunday.Core/Parsing/ClippingsParser.cs`: after building `RawClipping` list and filtering bookmarks, use a `HashSet<(string, string?, string)>` keyed on `(Title, Author, Text)` with `StringComparison.Ordinal` semantics to deduplicate. Keep the first occurrence (file order). Increment a duplicates counter. Wire `DuplicatesRemoved` into the returned `ParseResult`.
+- [ ] T026 [US2] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1 and US2 tests must pass.
+
+**Checkpoint**: Parser now deduplicates highlights. Existing US1 tests still pass (dedup with zero duplicates is a no-op).
+
+---
+
+## Phase 5: User Story 3 — Group Highlights by Book and Author (Priority: P3)
+
+**Goal**: Organize deduplicated highlights into `ParsedBook` objects, each identified by the `(Title, Author)` pair. Each book contains its highlights in file order. Empty books (all bookmarks) are not emitted.
+
+**Independent Test**: Provide multi-book input and verify correct grouping in the output structure.
+
+**Functional Requirements**: FR-007, FR-010
+
+### Tests for User Story 3
+
+- [ ] T027 [P] [US3] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given 6 highlights across 3 books by different authors, `ParseResult.Books` contains exactly 3 `ParsedBook` entries, each with the correct title, author, and highlight count.
+- [ ] T028 [P] [US3] Write test: given highlights from two different books by the same author, the result contains 2 separate `ParsedBook` entries (grouped by title + author pair, not author alone).
+- [ ] T029 [P] [US3] Write test: given a book whose only entries are bookmarks (no highlights or notes), that book does not appear in `ParseResult.Books` (no empty books).
+
+### Implementation for User Story 3
+
+- [ ] T030 [US3] Verify grouping logic in `src/SunnySunday.Core/Parsing/ClippingsParser.cs`: the grouping by `(Title, Author)` should already be implemented from T019. Ensure that: (a) books are emitted in first-seen order; (b) highlights within each book are in file order; (c) books with zero highlights after filtering are excluded. Adjust implementation if needed.
+- [ ] T031 [US3] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1, US2, and US3 tests must pass.
+
+**Checkpoint**: Parser produces correctly grouped output. All previous stories still pass.
+
+---
+
+## Phase 6: User Story 4 — Handle Malformed Entries Gracefully (Priority: P4)
+
+**Goal**: Skip malformed or incomplete clipping entries without crashing. Report skipped entries as `ParseWarning` objects with entry index, reason, and a raw excerpt. Valid entries surrounding malformed ones are still parsed correctly.
+
+**Independent Test**: Provide input with intentionally malformed entries mixed with valid ones and verify valid highlights are extracted and warnings are generated.
+
+**Functional Requirements**: FR-008, FR-009, FR-011
+
+### Tests for User Story 4
+
+- [ ] T032 [P] [US4] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given 10 valid entries and 1 malformed entry (e.g., missing metadata line — only title line then separator), all 10 valid highlights are extracted and `ParseResult.Warnings` contains exactly 1 warning with the correct `EntryIndex` and a descriptive `Reason`.
+- [ ] T033 [P] [US4] Write test: given an empty input (empty string or no content), `ParseResult.Books` is empty, `ParseResult.Warnings` is empty, and no exception is thrown.
+- [ ] T034 [P] [US4] Write test: given input containing only `==========` separators and no actual clipping content, the result is empty books and empty warnings (no valid entries, blank entries silently skipped).
+- [ ] T035 [P] [US4] Write test: given a clipping entry where the title line has no parentheses (missing author), the entry is parsed with best-effort: title is the full first line (trimmed) and author is `null`. The entry is NOT skipped — it appears in the result.
+- [ ] T036 [P] [US4] Write test: given a clipping entry with an unrecognized type on the metadata line (e.g., `- Your Clip on Location 50 | Added on ...`), the entry is skipped with a warning. Valid surrounding entries are still parsed.
+
+### Implementation for User Story 4
+
+- [ ] T037 [US4] Implement skip-and-warn logic in `src/SunnySunday.Core/Parsing/ClippingsParser.cs`: wrap per-entry parsing in a try-catch or validation gate. If an entry has fewer than 2 lines, or the metadata line does not match the expected regex, create a `ParseWarning` with the 1-based `EntryIndex`, a descriptive `Reason` (e.g., "Missing metadata line", "Unrecognized clipping type"), and `RawExcerpt` (first 200 characters of the raw entry text, or full text if shorter). Add the warning to the warnings list and continue to the next entry.
+- [ ] T038 [US4] Implement best-effort parsing for partial entries: if the title line has no author parentheses, still parse the entry with `Author = null` (do not skip). If the date cannot be parsed, still parse the entry with `AddedOn = null`. Only skip entries where the structure is completely unrecognizable (< 2 lines, or metadata regex fails entirely).
+- [ ] T039 [US4] Handle edge cases for empty and whitespace-only entries: blank lines between separators should be silently skipped (no warning generated for completely empty entries). Entries with only whitespace content (no title line) should also be silently skipped.
+- [ ] T040 [US4] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1, US2, US3, and US4 tests must pass.
+
+**Checkpoint**: Parser is robust against malformed input. All previous stories still pass.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge case hardening, performance validation, and documentation
+
+- [ ] T041 [P] Write edge case tests in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: (a) input with UTF-8 BOM prefix parses correctly (StreamReader handles BOM automatically, but verify via file-path overload with a BOM-prefixed temp file); (b) book titles and authors with Unicode characters (CJK, diacritics, RTL) parse correctly; (c) highlight text with special characters (quotes, angle brackets, ampersands) is preserved verbatim.
+- [ ] T042 [P] Write performance test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: programmatically generate a `My Clippings.txt` string with 10,000 clipping entries, parse via `StringReader`, and assert completion within 5 seconds (SC-005). Use `[Fact]` with a `Stopwatch` or `[Fact(Timeout = 5000)]`.
+- [ ] T043 [P] Update `docs/ARCHITECTURE.md` to document the `SunnySunday.Core/Parsing/` component: its purpose (pure function parser for My Clippings.txt), public API surface (`ClippingsParser.ParseAsync`), key types (`ParseResult`, `ParsedBook`, `ParsedHighlight`), and design decisions (no dependencies, streaming, skip-and-warn).
+- [ ] T044 Run full `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj` — all tests (including existing SchemaBootstrapTests) must pass. Run `dotnet build src/SunnySunday.slnx` clean. Validate that the quickstart.md code examples in `specs/003-highlight-parser/quickstart.md` are consistent with the implemented API.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1: Setup ──────────────────────────────► Phase 2: Foundational (Data Types)
+                                                         │
+                                                         ▼
+                                              ┌──────────────────────┐
+                                              │  Phase 3: US1 (P1)   │ 🎯 MVP
+                                              │  Parse Highlights     │
+                                              └──────────┬───────────┘
+                                                         │
+                                          ┌──────────────┼──────────────┐
+                                          ▼              ▼              ▼
+                                   Phase 4: US2   Phase 5: US3   Phase 6: US4
+                                   Deduplicate    Group by Book  Malformed
+                                          │              │              │
+                                          └──────────────┼──────────────┘
+                                                         ▼
+                                              Phase 7: Polish
+```
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — BLOCKS US2, US3, US4
+- **US2 (Phase 4)**: Depends on US1 — can run in parallel with US3 and US4
+- **US3 (Phase 5)**: Depends on US1 — can run in parallel with US2 and US4
+- **US4 (Phase 6)**: Depends on US1 — can run in parallel with US2 and US3
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### Within Each User Story
+
+1. Tests MUST be written and FAIL before implementation begins
+2. Implementation tasks are sequential (each builds on previous)
+3. Final task in each phase is a test-run gate
+
+### Parallel Opportunities
+
+- **Phase 2**: All type definition tasks (T002–T007) can run in parallel — each is a separate file
+- **Phase 3**: All test-writing tasks (T009–T013) can run in parallel — different test methods
+- **Phase 4–6**: US2, US3, US4 phases can run in parallel with each other (different concerns in the same parser file, but different logic sections)
+- **Phase 7**: Edge case tests (T041), perf test (T042), and docs (T043) can run in parallel
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```
+# All type files can be created simultaneously:
+T002: ClippingType.cs
+T003: RawClipping.cs
+T004: ParsedHighlight.cs
+T005: ParsedBook.cs
+T006: ParseWarning.cs
+T007: ParseResult.cs
+# Then verify build:
+T008: dotnet build
+```
+
+## Parallel Example: User Story 1 Tests
+
+```
+# All test methods can be written simultaneously:
+T009: Basic parsing test
+T010: Multi-line highlight test
+T011: Title/author edge cases
+T012: Metadata parsing + bookmark filter
+T013: File-path overload test
+# Then implement sequentially: T014 → T015 → T016 → T017 → T018 → T019 → T020
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational data types
+3. Complete Phase 3: User Story 1 — basic parsing
+4. **STOP and VALIDATE**: Parser extracts highlights from valid input
+5. This is a usable parser even without dedup/grouping refinement/error handling
+
+### Incremental Delivery
+
+1. Setup + Foundational → types compile
+2. US1 → Parser works on valid input (MVP!)
+3. US2 → Duplicates removed → higher data quality
+4. US3 → Highlights grouped by book → ready for sync API
+5. US4 → Robust against malformed input → production-ready
+6. Polish → Edge cases, performance, docs → ship-ready
+
+### Single-Developer Flow
+
+Since all code lives in two files (`ClippingsParser.cs` + `ClippingsParserTests.cs`), the recommended flow is sequential by phase: Phase 1 → 2 → 3 → 4 → 5 → 6 → 7. Within each phase, write all tests first, then implement.
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| **Total tasks** | 44 |
+| **Phase 1 — Setup** | 1 |
+| **Phase 2 — Foundational** | 7 |
+| **Phase 3 — US1 (P1)** | 12 |
+| **Phase 4 — US2 (P2)** | 6 |
+| **Phase 5 — US3 (P3)** | 5 |
+| **Phase 6 — US4 (P4)** | 9 |
+| **Phase 7 — Polish** | 4 |
+| **Parallelizable tasks** | 27 |
+| **Source files created** | 8 (7 in Parsing/, 1 test file) |
+
+## Notes
+
+- All parser code uses `namespace SunnySunday.Core.Parsing;` file-scoped namespace
+- All test code uses `namespace SunnySunday.Tests.Parsing;` file-scoped namespace
+- `RawClipping` is `internal` — only `ClippingsParser` uses it
+- All public output types (`ParsedHighlight`, `ParsedBook`, `ParseWarning`, `ParseResult`) are immutable records
+- No new NuGet packages required — parser uses only .NET BCL (`System.IO`, `System.Text.RegularExpressions`, `System.Globalization`)
+- No changes to existing `SunnySunday.Core/Models/` classes
+- Commit after each completed phase or logical task group


### PR DESCRIPTION
## Design Phase — Feature 003: Highlight Parser

Produces all design artifacts in `specs/003-highlight-parser/`:

- `spec.md` — 4 user stories, 11 functional requirements, 6 success criteria
- `research.md` — My Clippings.txt format analysis, author extraction, metadata regex, dedup strategy
- `data-model.md` — 6 parser-specific types (ClippingType, RawClipping, ParsedHighlight, ParsedBook, ParseWarning, ParseResult)
- `plan.md` — Phased implementation plan, constitution check, project structure
- `quickstart.md` — Developer quick-start guide
- `tasks.md` — 44 atomized tasks across 7 phases
- `checklists/requirements.md` — Quality checklist (16/16 pass)

### Implementation sub-issues created

| Phase | Issue | Scope |
|-------|-------|-------|
| Phase 1 — Setup | #68 | Directory structure |
| Phase 2 — Data Types | #69 | 6 parser type definitions |
| Phase 3 — Parse Highlights (US1 MVP) | #70 | Core parser, TDD |
| Phase 4 — Deduplicate (US2) | #71 | Dedup by exact match |
| Phase 5 — Group by Book (US3) | #72 | Book grouping |
| Phase 6 — Malformed Entries (US4) | #73 | Skip-and-warn |
| Phase 7 — Polish | #74 | Edge cases, perf, docs |

Closes #66
