### PR TITLE
Add parser directory structure and data types (Phase 1+2)

### DIFF
--- a/specs/003-highlight-parser/tasks.md
+++ b/specs/003-highlight-parser/tasks.md
@@ -19,7 +19,7 @@
 
 **Purpose**: Create directory structure for parser code and tests
 
-- [ ] T001 Create directories `src/SunnySunday.Core/Parsing/` and `src/SunnySunday.Tests/Parsing/`, verify `dotnet build src/SunnySunday.slnx` still succeeds
+- [X] T001 Create directories `src/SunnySunday.Core/Parsing/` and `src/SunnySunday.Tests/Parsing/`, verify `dotnet build src/SunnySunday.slnx` still succeeds
 
 ---
 
@@ -29,11 +29,11 @@
 
 **⚠️ CRITICAL**: No user story work can begin until all types are defined and the solution builds.
 
-- [ ] T002 [P] Create `RawClipping` internal record in `src/SunnySunday.Core/Parsing/RawClipping.cs` with properties: `string Title`, `string? Author`, `bool IsNote`, `string? Location`, `DateTimeOffset? AddedOn`, `string Text`. This is an intermediate type not exposed publicly. Mark the class `internal`. `IsNote` is true when the metadata line says "Note" — used to prepend `[my note]` prefix.
-- [ ] T003 [P] Create `ParsedHighlight` public record in `src/SunnySunday.Core/Parsing/ParsedHighlight.cs` with properties: `string Text`, `string? Location`, `DateTimeOffset? AddedOn`. Immutable. Notes are stored here with `[my note]` already prepended to `Text` — no type field.
-- [ ] T004 [P] Create `ParsedBook` public record in `src/SunnySunday.Core/Parsing/ParsedBook.cs` with properties: `string Title`, `string? Author`, `IReadOnlyList<ParsedHighlight> Highlights`. A ParsedBook is never emitted with zero highlights.
-- [ ] T005 [P] Create `ParseResult` public record in `src/SunnySunday.Core/Parsing/ParseResult.cs` with properties: `IReadOnlyList<ParsedBook> Books`, `int TotalEntriesProcessed`, `int DuplicatesRemoved`. No warnings collection — malformed entries are logged via `ILogger`.
-- [ ] T006 Verify `dotnet build src/SunnySunday.slnx` succeeds with all four new types. Fix any compilation errors.
+- [X] T002 [P] Create `RawClipping` internal record in `src/SunnySunday.Core/Parsing/RawClipping.cs` with properties: `string Title`, `string? Author`, `bool IsNote`, `string? Location`, `DateTimeOffset? AddedOn`, `string Text`. This is an intermediate type not exposed publicly. Mark the class `internal`. `IsNote` is true when the metadata line says "Note" — used to prepend `[my note]` prefix.
+- [X] T003 [P] Create `ParsedHighlight` public record in `src/SunnySunday.Core/Parsing/ParsedHighlight.cs` with properties: `string Text`, `string? Location`, `DateTimeOffset? AddedOn`. Immutable. Notes are stored here with `[my note]` already prepended to `Text` — no type field.
+- [X] T004 [P] Create `ParsedBook` public record in `src/SunnySunday.Core/Parsing/ParsedBook.cs` with properties: `string Title`, `string? Author`, `IReadOnlyList<ParsedHighlight> Highlights`. A ParsedBook is never emitted with zero highlights.
+- [X] T005 [P] Create `ParseResult` public record in `src/SunnySunday.Core/Parsing/ParseResult.cs` with properties: `IReadOnlyList<ParsedBook> Books`, `int TotalEntriesProcessed`, `int DuplicatesRemoved`. No warnings collection — malformed entries are logged via `ILogger`.
+- [X] T006 Verify `dotnet build src/SunnySunday.slnx` succeeds with all four new types. Fix any compilation errors.
 
 **Checkpoint**: All parser types compile. User story implementation can begin.
 

--- a/src/SunnySunday.Core/Parsing/ParseResult.cs
+++ b/src/SunnySunday.Core/Parsing/ParseResult.cs
@@ -1,0 +1,9 @@
+namespace SunnySunday.Core.Parsing;
+
+/// <summary>
+/// The complete output of parsing a Kindle clippings file.
+/// </summary>
+public record ParseResult(
+    IReadOnlyList<ParsedBook> Books,
+    int TotalEntriesProcessed,
+    int DuplicatesRemoved);

--- a/src/SunnySunday.Core/Parsing/ParsedBook.cs
+++ b/src/SunnySunday.Core/Parsing/ParsedBook.cs
@@ -1,0 +1,10 @@
+namespace SunnySunday.Core.Parsing;
+
+/// <summary>
+/// A book with its associated highlights, after deduplication and grouping.
+/// A ParsedBook is never emitted with zero highlights.
+/// </summary>
+public record ParsedBook(
+    string Title,
+    string? Author,
+    IReadOnlyList<ParsedHighlight> Highlights);

--- a/src/SunnySunday.Core/Parsing/ParsedHighlight.cs
+++ b/src/SunnySunday.Core/Parsing/ParsedHighlight.cs
@@ -1,0 +1,10 @@
+namespace SunnySunday.Core.Parsing;
+
+/// <summary>
+/// A single parsed highlight or note from a Kindle clippings file.
+/// Notes have their text prefixed with "[my note] ".
+/// </summary>
+public record ParsedHighlight(
+    string Text,
+    string? Location,
+    DateTimeOffset? AddedOn);

--- a/src/SunnySunday.Core/Parsing/RawClipping.cs
+++ b/src/SunnySunday.Core/Parsing/RawClipping.cs
@@ -1,0 +1,9 @@
+namespace SunnySunday.Core.Parsing;
+
+internal record RawClipping(
+    string Title,
+    string? Author,
+    bool IsNote,
+    string? Location,
+    DateTimeOffset? AddedOn,
+    string Text);

--- a/src/SunnySunday.Core/SunnySunday.Core.csproj
+++ b/src/SunnySunday.Core/SunnySunday.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Phase 1 — Setup + Phase 2 — Parser Data Types

Creates the directory structure and foundational data types for the highlight parser feature.

### Changes
- **T001**: Created `src/SunnySunday.Core/Parsing/` and `src/SunnySunday.Tests/Parsing/` directories
- **T002**: `RawClipping` internal record — intermediate parsing type
- **T003**: `ParsedHighlight` public record — output highlight type
- **T004**: `ParsedBook` public record — output book grouping type
- **T005**: `ParseResult` public record — top-level parse output
- **T006**: Verified `dotnet build` succeeds with 0 warnings

### References
- Closes #68
- Closes #69
- Parent: #67