### PR TITLE
Implement US2: Deduplicate highlights (Phase 4)

### DIFF
--- a/specs/003-highlight-parser/tasks.md
+++ b/specs/003-highlight-parser/tasks.md
@@ -84,15 +84,15 @@
 
 ### Tests for User Story 2
 
-- [ ] T021 [P] [US2] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given input where the same highlight text appears twice for the same book and author, the result contains only one instance of that highlight and `DuplicatesRemoved == 1`.
-- [ ] T022 [P] [US2] Write test: given two highlights with identical text but from different books (different title or author), both highlights are retained — they are not considered duplicates.
-- [ ] T023 [P] [US2] Write test: given two highlights from the same book where one is a substring of the other (e.g., "War is peace" vs "War is peace. Freedom is slavery."), both are retained as distinct highlights. Only exact text matches are duplicates.
-- [ ] T024 [P] [US2] Write test: given 10 clippings where 3 are duplicates, `ParseResult.DuplicatesRemoved == 3` and the total unique highlights across all books equals 7.
+- [X] T021 [P] [US2] Write test in `src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs`: given input where the same highlight text appears twice for the same book and author, the result contains only one instance of that highlight and `DuplicatesRemoved == 1`.
+- [X] T022 [P] [US2] Write test: given two highlights with identical text but from different books (different title or author), both highlights are retained — they are not considered duplicates.
+- [X] T023 [P] [US2] Write test: given two highlights from the same book where one is a substring of the other (e.g., "War is peace" vs "War is peace. Freedom is slavery."), both are retained as distinct highlights. Only exact text matches are duplicates.
+- [X] T024 [P] [US2] Write test: given 10 clippings where 3 are duplicates, `ParseResult.DuplicatesRemoved == 3` and the total unique highlights across all books equals 7.
 
 ### Implementation for User Story 2
 
-- [ ] T025 [US2] Implement deduplication in `src/SunnySunday.Cli/Parsing/ClippingsParser.cs`: after building `RawClipping` list and filtering bookmarks, use a `HashSet<(string, string?, string)>` keyed on `(Title, Author, Text)` with `StringComparison.Ordinal` semantics to deduplicate. Keep the first occurrence (file order). Increment a duplicates counter. Wire `DuplicatesRemoved` into the returned `ParseResult`.
-- [ ] T026 [US2] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1 and US2 tests must pass.
+- [X] T025 [US2] Implement deduplication in `src/SunnySunday.Cli/Parsing/ClippingsParser.cs`: after building `RawClipping` list and filtering bookmarks, use a `HashSet<(string, string?, string)>` keyed on `(Title, Author, Text)` with `StringComparison.Ordinal` semantics to deduplicate. Keep the first occurrence (file order). Increment a duplicates counter. Wire `DuplicatesRemoved` into the returned `ParseResult`.
+- [X] T026 [US2] Run `dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj --filter "FullyQualifiedName~Parsing"` — all US1 and US2 tests must pass.
 
 **Checkpoint**: Parser now deduplicates highlights. Existing US1 tests still pass (dedup with zero duplicates is a no-op).
 

--- a/src/SunnySunday.Cli/Parsing/ClippingsParser.cs
+++ b/src/SunnySunday.Cli/Parsing/ClippingsParser.cs
@@ -54,11 +54,28 @@ public static partial class ClippingsParser
         // Filter bookmarks (empty text after trimming means bookmark)
         var highlights = clippings.Where(c => !string.IsNullOrEmpty(c.Text)).ToList();
 
+        // Deduplicate by (Title, Author, Text) — keep first occurrence, count removals
+        var seen = new HashSet<(string, string?, string)>();
+        var duplicatesRemoved = 0;
+        var deduped = new List<RawClipping>(highlights.Count);
+
+        foreach (var clip in highlights)
+        {
+            var key = (clip.Title, clip.Author, clip.IsNote ? NotePrefix + clip.Text : clip.Text);
+            if (!seen.Add(key))
+            {
+                duplicatesRemoved++;
+                continue;
+            }
+
+            deduped.Add(clip);
+        }
+
         // Group by (Title, Author) — preserve first-seen order
         var bookDict = new Dictionary<(string Title, string? Author), List<ParsedHighlight>>();
         var bookOrder = new List<(string Title, string? Author)>();
 
-        foreach (var clip in highlights)
+        foreach (var clip in deduped)
         {
             var key = (clip.Title, clip.Author);
             var text = clip.IsNote ? NotePrefix + clip.Text : clip.Text;
@@ -79,7 +96,7 @@ public static partial class ClippingsParser
             .Where(b => b.Highlights.Count > 0)
             .ToList();
 
-        return new ParseResult(books, entryIndex, DuplicatesRemoved: 0);
+        return new ParseResult(books, entryIndex, duplicatesRemoved);
     }
 
     private static async Task<List<List<string>>> SplitEntriesAsync(TextReader reader)

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs
+++ b/src/SunnySunday.Tests/Parsing/ClippingsParserTests.cs
@@ -262,4 +262,101 @@ public class ClippingsParserTests
     }
 
     #endregion
+
+    #region T021-T024 — Deduplication (US2)
+
+    [Fact]
+    public async Task ParseAsync_DuplicateHighlightSameBook_KeepsOneAndCountsOne()
+    {
+        var input = """
+            1984 (Orwell, George)
+            - Your Highlight on Location 200-210 | Added on Friday, January 2, 2026 1:30:00 PM
+
+            War is peace. Freedom is slavery. Ignorance is strength.
+            ==========
+            1984 (Orwell, George)
+            - Your Highlight on Location 200-210 | Added on Friday, January 2, 2026 1:30:00 PM
+
+            War is peace. Freedom is slavery. Ignorance is strength.
+            ==========
+            """;
+
+        using var reader = new StringReader(input);
+        var result = await ClippingsParser.ParseAsync(reader);
+
+        Assert.Single(result.Books);
+        Assert.Single(result.Books[0].Highlights);
+        Assert.Equal(1, result.DuplicatesRemoved);
+    }
+
+    [Fact]
+    public async Task ParseAsync_SameTextDifferentBooks_BothRetained()
+    {
+        var input = """
+            Book One (Author A)
+            - Your Highlight on Location 10-15 | Added on Thursday, January 1, 2026 12:00:00 AM
+
+            Identical text.
+            ==========
+            Book Two (Author B)
+            - Your Highlight on Location 10-15 | Added on Thursday, January 1, 2026 12:00:00 AM
+
+            Identical text.
+            ==========
+            """;
+
+        using var reader = new StringReader(input);
+        var result = await ClippingsParser.ParseAsync(reader);
+
+        Assert.Equal(2, result.Books.Count);
+        Assert.Equal(0, result.DuplicatesRemoved);
+    }
+
+    [Fact]
+    public async Task ParseAsync_SubstringHighlights_BothRetained()
+    {
+        var input = """
+            1984 (Orwell, George)
+            - Your Highlight on Location 200-205 | Added on Friday, January 2, 2026 1:00:00 PM
+
+            War is peace.
+            ==========
+            1984 (Orwell, George)
+            - Your Highlight on Location 200-210 | Added on Friday, January 2, 2026 1:30:00 PM
+
+            War is peace. Freedom is slavery. Ignorance is strength.
+            ==========
+            """;
+
+        using var reader = new StringReader(input);
+        var result = await ClippingsParser.ParseAsync(reader);
+
+        Assert.Single(result.Books);
+        Assert.Equal(2, result.Books[0].Highlights.Count);
+        Assert.Equal(0, result.DuplicatesRemoved);
+    }
+
+    [Fact]
+    public async Task ParseAsync_TenClippingsThreeDuplicates_ReportsCorrectCounts()
+    {
+        // Build 10 entries: 7 unique + 3 duplicates (entries 8-10 repeat entries 1-3)
+        static string Entry(int i) =>
+            $"Book {i} (Author {i})\n" +
+            $"- Your Highlight on Location {i * 10}-{i * 10 + 5} | Added on Thursday, January 1, 2026 12:00:00 AM\n" +
+            $"\n" +
+            $"Unique highlight number {i}.\n" +
+            "==========\n";
+
+        var input = string.Concat(Enumerable.Range(1, 7).Select(Entry))
+                  + string.Concat(Enumerable.Range(1, 3).Select(Entry));
+
+        using var reader = new StringReader(input);
+        var result = await ClippingsParser.ParseAsync(reader);
+
+        var totalHighlights = result.Books.Sum(b => b.Highlights.Count);
+        Assert.Equal(7, totalHighlights);
+        Assert.Equal(3, result.DuplicatesRemoved);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Phase 4 — User Story 2: Deduplicate Highlights

TDD: 4 tests written first (red), then implementation (green). All US1 tests continue to pass.

### TDD Tests (4 new, 16 total passing)
- **T021**: Duplicate same book → only 1 kept, `DuplicatesRemoved == 1`
- **T022**: Same text different books → both retained (not duplicates)
- **T023**: Substring highlights same book → both retained (only exact matches deduplicated)
- **T024**: 10 entries with 3 duplicates → 7 unique highlights, `DuplicatesRemoved == 3`

### Implementation (T025)
- `HashSet<(Title, Author, Text)>` keyed deduplication after bookmark filter
- First occurrence in file order is kept; subsequent exact matches counted
- `DuplicatesRemoved` wired into `ParseResult` (was hardcoded 0 before)

### Version bump
- `SunnySunday.Cli`: `0.1.1` → `0.1.2`

### References
- Closes #71
- Parent: #67