### PR TITLE
Fix release workflow token usage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Discover Versioned Components
         id: discover
@@ -207,3 +205,4 @@ jobs:
           draft: false
           prerelease: false
           files: artifacts/*
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Update the GitHub Actions release workflow to correctly use the release token for publishing artifacts and trigger downstream workflows.