### PR TITLE
Define feature 005 scheduler recap design artifacts

### DIFF
--- a/specs/005-scheduler-recap-engine/data-model.md
+++ b/specs/005-scheduler-recap-engine/data-model.md
@@ -1,0 +1,319 @@
+# Data Model: Scheduler + Recap Engine
+
+**Feature**: 005-scheduler-recap-engine
+**Phase**: 1 — Design
+**Date**: 2026-04-27
+
+---
+
+## Schema Changes
+
+### 1. Add `timezone` Column to `settings`
+
+The `settings` table acquires a `timezone` column to store the client's IANA timezone identifier (e.g., `"Europe/Rome"`, `"America/New_York"`). The server uses this value to build the Quartz cron trigger that fires at the correct UTC-equivalent of the user's intended local time, including DST handling.
+
+**Migration** (idempotent — applied in `SchemaBootstrap`):
+```sql
+-- Applied only if column does not already exist (checked via pragma_table_info)
+ALTER TABLE settings ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC';
+```
+
+**Idempotency check** (in C# before running `ALTER TABLE`):
+```sql
+SELECT COUNT(*) FROM pragma_table_info('settings') WHERE name = 'timezone'
+```
+Execute `ALTER TABLE` only if the count is 0.
+
+**Updated `settings` schema**:
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `user_id` | INTEGER PK | — | FK → `users` |
+| `schedule` | TEXT | `'daily'` | `'daily'` or `'weekly'` |
+| `delivery_day` | TEXT | NULL | Day name (e.g., `'Monday'`); used when `schedule='weekly'` |
+| `delivery_time` | TEXT | `'18:00'` | Client local time in `HH:mm` format |
+| `count` | INTEGER | `3` | 1–15 |
+| `timezone` | TEXT | `'UTC'` | IANA timezone identifier (**NEW**) |
+
+---
+
+### 2. New `recap_jobs` Table
+
+Tracks one row per scheduled execution slot. Provides deduplication (idempotency anchor for restarts/clock drift), delivery status, and last-recap history exposed via `GET /status`.
+
+```sql
+CREATE TABLE IF NOT EXISTS recap_jobs (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL REFERENCES users(id),
+    scheduled_for TEXT    NOT NULL,   -- UTC ISO 8601 (slot key, e.g. "2026-04-27T16:00:00Z")
+    status        TEXT    NOT NULL DEFAULT 'pending',  -- 'pending' | 'delivered' | 'failed'
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    error_message TEXT    NULL,
+    created_at    TEXT    NOT NULL,   -- UTC ISO 8601
+    delivered_at  TEXT    NULL        -- UTC ISO 8601; NULL until confirmed delivery
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_recap_jobs_user_slot
+    ON recap_jobs(user_id, scheduled_for);
+```
+
+**Status lifecycle**: `'pending'` (row inserted when job starts) → `'delivered'` (SMTP confirmed) or `'failed'` (all retries exhausted).
+
+---
+
+## Domain Models
+
+### Updated: `Settings.cs`
+
+Location: `src/SunnySunday.Server/Models/Settings.cs`
+
+Add `Timezone` property (default `"UTC"`):
+
+```csharp
+public class Settings
+{
+    public int UserId { get; set; }
+    public string Schedule { get; set; } = "daily";
+    public string? DeliveryDay { get; set; }
+    public string DeliveryTime { get; set; } = "18:00";
+    public int Count { get; set; } = 3;
+    public string Timezone { get; set; } = "UTC";   // NEW
+}
+```
+
+### New: `RecapJobRecord.cs`
+
+Location: `src/SunnySunday.Server/Models/RecapJobRecord.cs`
+
+> **Naming note**: Class is `RecapJobRecord` (not `RecapJob`) to avoid collision with the Quartz `IJob` implementation class named `RecapJob`.
+
+```csharp
+public class RecapJobRecord
+{
+    public int Id { get; set; }
+    public int UserId { get; set; }
+    public DateTimeOffset ScheduledFor { get; set; }
+    public string Status { get; set; } = "pending";
+    public int AttemptCount { get; set; }
+    public string? ErrorMessage { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? DeliveredAt { get; set; }
+}
+```
+
+### Internal: `SelectionCandidate`
+
+Not persisted. Used transiently within `HighlightSelectionService` to carry per-highlight computed score before final ranking.
+
+```csharp
+internal sealed record SelectionCandidate(
+    int Id,
+    string Text,
+    string BookTitle,
+    string AuthorName,
+    int Weight,
+    DateTimeOffset? LastSeen,
+    DateTimeOffset CreatedAt,
+    int Score   // age_in_days + weight
+);
+```
+
+---
+
+## API Contract Changes
+
+All changes are to existing types in `src/SunnySunday.Core/Contracts/`. No new contract files are required.
+
+### Updated: `SettingsResponse`
+
+Add `Timezone` property:
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `Schedule` | `string` | *(existing)* |
+| `DeliveryDay` | `string?` | *(existing)* |
+| `DeliveryTime` | `string` | *(existing)* |
+| `Count` | `int` | *(existing)* |
+| `KindleEmail` | `string` | *(existing)* |
+| `Timezone` | `string` | **NEW** — IANA timezone identifier (e.g., `"Europe/Rome"`) |
+
+### Updated: `UpdateSettingsRequest`
+
+Add `Timezone` property:
+
+| Property | Type | Validation | Notes |
+|----------|------|------------|-------|
+| `Schedule` | `string?` | *(existing)* | |
+| `DeliveryDay` | `string?` | *(existing)* | |
+| `DeliveryTime` | `string?` | *(existing)* | |
+| `Count` | `int?` | *(existing)* | |
+| `KindleEmail` | `string?` | *(existing)* | |
+| `Timezone` | `string?` | **NEW** — validated via `TimeZoneInfo.FindSystemTimeZoneById`; 422 if unrecognized | |
+
+### Updated: `StatusResponse`
+
+Add last-recap fields to surface actionable failure reasons (FR-005-14, US-08 alignment):
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `TotalHighlights` | `int` | *(existing)* |
+| `TotalBooks` | `int` | *(existing)* |
+| `TotalAuthors` | `int` | *(existing)* |
+| `ExcludedHighlights` | `int` | *(existing)* |
+| `ExcludedBooks` | `int` | *(existing)* |
+| `ExcludedAuthors` | `int` | *(existing)* |
+| `NextRecap` | `string?` | *(existing)* — UTC ISO 8601; **now populated** by scheduler |
+| `LastRecapStatus` | `string?` | **NEW** — `'delivered'` \| `'failed'` \| null |
+| `LastRecapError` | `string?` | **NEW** — error detail when `LastRecapStatus='failed'`; null otherwise |
+
+---
+
+## SMTP Configuration (Server-Side Only — Not Persisted in DB)
+
+Located: `src/SunnySunday.Server/Infrastructure/Smtp/SmtpSettings.cs`
+
+Bound via `builder.Services.Configure<SmtpSettings>(builder.Configuration.GetSection("Smtp"))`.
+
+```csharp
+public sealed class SmtpSettings
+{
+    public string Host { get; set; } = "smtp.gmail.com";
+    public int Port { get; set; } = 587;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string FromAddress { get; set; } = string.Empty;
+    public bool UseSsl { get; set; } = true;
+}
+```
+
+**Docker environment variable format**:
+```
+Smtp__Host=smtp.gmail.com
+Smtp__Port=587
+Smtp__Username=sender@gmail.com
+Smtp__Password=app-specific-password
+Smtp__FromAddress=sender@gmail.com
+Smtp__UseSsl=true
+```
+
+---
+
+## Service Interfaces
+
+Located: `src/SunnySunday.Server/Services/`
+
+### `IMailDeliveryService`
+
+Abstracts MailKit SMTP delivery. Injected via DI; substitutable in tests.
+
+```csharp
+public interface IMailDeliveryService
+{
+    Task SendAsync(RecapDeliveryPayload payload, CancellationToken ct = default);
+}
+
+public sealed record RecapDeliveryPayload(
+    string ToAddress,
+    string Subject,
+    byte[] EpubBytes,
+    string EpubFilename);
+```
+
+### `IRecapService`
+
+Orchestrates the full recap pipeline (select → compose → deliver → update history).
+
+```csharp
+public interface IRecapService
+{
+    Task ExecuteAsync(int userId, DateTimeOffset scheduledFor, CancellationToken ct = default);
+}
+```
+
+### `ISchedulerService`
+
+Manages Quartz.NET job registration and exposes next fire time for `GET /status`.
+
+```csharp
+public interface ISchedulerService
+{
+    Task ScheduleAsync(Settings settings, CancellationToken ct = default);
+    Task<DateTimeOffset?> GetNextFireTimeAsync(CancellationToken ct = default);
+}
+```
+
+---
+
+## Selection Query
+
+The `RecapRepository.SelectCandidatesAsync` query joins highlights with books and authors to retrieve all data needed for recap composition and score computation.
+
+```sql
+SELECT
+    h.id,
+    h.text,
+    b.title  AS BookTitle,
+    a.name   AS AuthorName,
+    h.weight,
+    h.last_seen   AS LastSeen,
+    h.created_at  AS CreatedAt
+FROM highlights h
+JOIN books b   ON h.book_id   = b.id
+JOIN authors a ON b.author_id = a.id
+WHERE h.user_id = @UserId
+  AND h.excluded = 0
+  AND h.book_id NOT IN (
+      SELECT book_id FROM excluded_books WHERE user_id = @UserId)
+  AND b.author_id NOT IN (
+      SELECT author_id FROM excluded_authors WHERE user_id = @UserId)
+```
+
+Score computation and ranking occur in C# (not SQL), so that the `NeverSeenAge = 3650` sentinel for null `last_seen` and the tiebreak on `created_at DESC` are expressed clearly in code and are testable.
+
+---
+
+## Project Structure Additions
+
+```
+src/SunnySunday.Server/
+├── Program.cs                                ← Updated: Quartz DI, SmtpSettings, new services
+├── Infrastructure/
+│   ├── Database/
+│   │   └── SchemaBootstrap.cs                ← Updated: recap_jobs table + timezone column
+│   └── Smtp/
+│       └── SmtpSettings.cs                   ← NEW: SMTP configuration POCO
+├── Jobs/
+│   └── RecapJob.cs                           ← NEW: Quartz IJob — dedup check + call IRecapService
+├── Services/
+│   ├── IMailDeliveryService.cs               ← NEW: interface + RecapDeliveryPayload
+│   ├── MailDeliveryService.cs                ← NEW: MailKit SmtpClient implementation
+│   ├── EpubComposer.cs                       ← NEW: static class, highlights → EPUB byte[]
+│   ├── HighlightSelectionService.cs          ← NEW: score formula + ranking + tiebreak
+│   ├── IRecapService.cs                      ← NEW: interface
+│   ├── RecapService.cs                       ← NEW: pipeline orchestration + retry loop
+│   ├── ISchedulerService.cs                  ← NEW: interface
+│   └── SchedulerService.cs                   ← NEW: Quartz scheduler wrapper
+├── Data/
+│   ├── RecapRepository.cs                    ← NEW: recap_jobs CRUD + SelectCandidatesAsync
+│   └── StatusRepository.cs                   ← Updated: LastRecapStatus + LastRecapError
+├── Models/
+│   ├── Settings.cs                           ← Updated: +Timezone
+│   └── RecapJobRecord.cs                     ← NEW: domain model
+└── Endpoints/
+    ├── SettingsEndpoints.cs                  ← Updated: Timezone field + SchedulerService call
+    └── StatusEndpoints.cs                    ← Updated: NextRecap from SchedulerService
+
+src/SunnySunday.Core/Contracts/
+├── SettingsResponse.cs                       ← Updated: +Timezone
+├── UpdateSettingsRequest.cs                  ← Updated: +Timezone
+└── StatusResponse.cs                         ← Updated: +LastRecapStatus, +LastRecapError
+
+src/SunnySunday.Tests/
+├── Api/
+│   ├── SettingsEndpointTests.cs              ← Updated: new timezone test cases
+│   └── StatusEndpointTests.cs                ← Updated: new NextRecap + last-recap field tests
+├── Recap/                                    ← NEW
+│   ├── HighlightSelectionServiceTests.cs     ← NEW: score ranking and tiebreak tests
+│   ├── EpubComposerTests.cs                  ← NEW: EPUB structure and content tests
+│   └── RecapServiceTests.cs                  ← NEW: retry + history update tests
+```

--- a/specs/005-scheduler-recap-engine/data-model.md
+++ b/specs/005-scheduler-recap-engine/data-model.md
@@ -188,12 +188,12 @@ public sealed class SmtpSettings
 
 **Docker environment variable format**:
 ```
-Smtp__Host=smtp.gmail.com
-Smtp__Port=587
-Smtp__Username=sender@gmail.com
-Smtp__Password=app-specific-password
-Smtp__FromAddress=sender@gmail.com
-Smtp__UseSsl=true
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=sender@gmail.com
+SMTP_PASSWORD=app-specific-password
+SMTP_FROM_ADDRESS=sender@gmail.com
+SMTP_USE_SSL=true
 ```
 
 ---

--- a/specs/005-scheduler-recap-engine/plan.md
+++ b/specs/005-scheduler-recap-engine/plan.md
@@ -1,0 +1,343 @@
+# Implementation Plan: Scheduler + Recap Engine
+
+**Branch**: `005-scheduler-recap-engine` | **Date**: 2026-04-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/005-scheduler-recap-engine/spec.md`
+
+## Summary
+
+Implement the automated recap pipeline for Sunny Sunday: a Quartz.NET-based scheduler fires daily (or weekly) at the user's configured local time, selects highlights by `score = age_in_days + weight` (tiebreak: most recently added), composes a Kindle-friendly EPUB 2 flat-list document, and delivers it via MailKit SMTP with a 3-attempt exponential retry (1 min, 5 min). Successful delivery updates `last_seen` and `delivery_count` per highlight; permanent failure leaves history unchanged and exposes the error via `GET /status`. All existing endpoints (`PUT /settings`, `GET /status`) are extended in-place — no new routes are added.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10 (`net10.0` TFM)
+**New Dependencies**: `Quartz.Extensions.Hosting` (Quartz.NET), `MailKit`
+**Existing Dependencies**: Dapper, Microsoft.Data.Sqlite, Serilog, Swashbuckle.AspNetCore (all in `SunnySunday.Server.csproj`)
+**Storage**: SQLite at `.data/sunny.db` — existing schema via `SchemaBootstrap`; this feature adds `recap_jobs` table and `timezone` column to `settings`
+**Testing**: xUnit + `WebApplicationFactory` (in-memory SQLite) — existing test infrastructure; `IMailDeliveryService` interface for SMTP substitution
+**Target Platform**: Linux Docker container (server), cross-platform CLI
+**Performance Goals**: Recap generation completes in < 30 seconds for a 10,000-highlight DB (NFR-06)
+**Constraints**: Single-user MVP, no authentication, in-memory Quartz job store (not persistent)
+**Scale/Scope**: Single user, up to ~10,000 highlights; one recap trigger per day or per week
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Client/Server Separation | **PASS** | All scheduling and delivery runs server-side; CLI reads status |
+| II. CLI-First, No GUI | **PASS** | No new UI; settings managed via existing CLI commands |
+| III. Zero-Config Onboarding | **PASS** | Default timezone `"UTC"`, default schedule `daily 18:00` — no setup beyond Kindle email required |
+| IV. Local Processing Only | **PASS** | SMTP is direct server→Amazon; no third-party cloud APIs |
+| V. Tests Ship with Code | **PASS** | Selection, EPUB, retry, and endpoint tests included in same PR |
+| VI. Simplicity / YAGNI | **PASS** | In-memory Quartz store (not persistent), manual retry (not Polly), manual EPUB (not library) |
+| Tech: C# / .NET 10 only | **PASS** | All new code is C# |
+| Tech: SQLite only | **PASS** | `recap_jobs` table in same SQLite file; Quartz uses in-memory store |
+| Tech: Serilog logging | **PASS** | Serilog used for delivery events and error logging |
+| Tech: REST HTTP + JSON | **PASS** | No new endpoints; existing endpoints extended |
+| Tech: Docker distribution | **PASS** | No changes to distribution model; SMTP config via env vars |
+| Tech: Quartz.NET | **PASS** | Explicitly listed in project stack |
+| Tech: MailKit | **PASS** | Explicitly listed in project stack |
+| Exclusion: No web UI | **PASS** | No new UI components |
+| Exclusion: No auth for MVP | **PASS** | No authentication changes |
+
+**Post-design re-check**: All gates pass. Two new NuGet packages (`Quartz.Extensions.Hosting`, `MailKit`) are both in the prescribed stack. No new projects introduced. No EF Core, no Polly, no EPUB library dependencies added.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-scheduler-recap-engine/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Technology decisions and rationale
+├── data-model.md        # Schema changes, domain models, contract updates
+└── quickstart.md        # Developer quick-start guide
+```
+
+### Source Code Changes
+
+```text
+src/SunnySunday.Server/
+├── Program.cs                                ← Updated: Quartz DI, SmtpSettings, new services/repos
+├── Infrastructure/
+│   ├── Database/
+│   │   └── SchemaBootstrap.cs                ← Updated: recap_jobs table + timezone column migration
+│   └── Smtp/
+│       └── SmtpSettings.cs                   ← NEW: SMTP configuration POCO
+├── Jobs/
+│   └── RecapJob.cs                           ← NEW: Quartz IJob (dedup + IRecapService call)
+├── Services/
+│   ├── IMailDeliveryService.cs               ← NEW: interface + RecapDeliveryPayload record
+│   ├── MailDeliveryService.cs                ← NEW: MailKit SmtpClient implementation
+│   ├── EpubComposer.cs                       ← NEW: static class — highlights → EPUB byte[]
+│   ├── HighlightSelectionService.cs          ← NEW: score formula, ranking, tiebreak
+│   ├── IRecapService.cs                      ← NEW: interface
+│   ├── RecapService.cs                       ← NEW: pipeline: select → compose → retry → update
+│   ├── ISchedulerService.cs                  ← NEW: interface
+│   └── SchedulerService.cs                   ← NEW: Quartz scheduler wrapper
+├── Data/
+│   ├── RecapRepository.cs                    ← NEW: recap_jobs CRUD + candidate selection query
+│   └── StatusRepository.cs                   ← Updated: reads last recap job for status fields
+├── Models/
+│   ├── Settings.cs                           ← Updated: +Timezone property
+│   └── RecapJobRecord.cs                     ← NEW: domain model for recap_jobs rows
+└── Endpoints/
+    ├── SettingsEndpoints.cs                  ← Updated: Timezone in GET/PUT + SchedulerService call
+    └── StatusEndpoints.cs                    ← Updated: NextRecap from SchedulerService
+
+src/SunnySunday.Core/Contracts/
+├── SettingsResponse.cs                       ← Updated: +Timezone
+├── UpdateSettingsRequest.cs                  ← Updated: +Timezone
+└── StatusResponse.cs                         ← Updated: +LastRecapStatus, +LastRecapError
+
+src/SunnySunday.Tests/
+├── Api/
+│   ├── SettingsEndpointTests.cs              ← Updated: new timezone test cases
+│   └── StatusEndpointTests.cs                ← Updated: NextRecap + last-recap field test cases
+└── Recap/                                    ← NEW folder
+    ├── HighlightSelectionServiceTests.cs     ← NEW: score ranking, tiebreak, exclusion filtering
+    ├── EpubComposerTests.cs                  ← NEW: EPUB structure and highlight content tests
+    └── RecapServiceTests.cs                  ← NEW: retry behavior + history update tests
+```
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add new NuGet packages required by this feature.
+
+- [ ] T000 Add `Quartz.Extensions.Hosting` NuGet package to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package Quartz.Extensions.Hosting`. This package includes Quartz core, the `ISchedulerFactory` / `IScheduler` abstractions, and the `IHostedService` integration that starts and stops the scheduler with the application host.
+- [ ] T001 [P] Add `MailKit` NuGet package to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package MailKit`. Verify solution builds: `dotnet build src/SunnySunday.slnx`.
+
+---
+
+## Phase 2: Schema, Domain Models, and Contract Updates
+
+**Purpose**: Extend the database schema, domain models, and shared API contracts with all data required by this feature. These changes unblock all subsequent phases.
+
+**⚠️ All later phases depend on this phase being complete.**
+
+- [ ] T002 Update `src/SunnySunday.Server/Infrastructure/Database/SchemaBootstrap.cs`. In `SchemaSql`, append the `CREATE TABLE IF NOT EXISTS recap_jobs` DDL (see data-model.md). Add a new private async helper `MigrateAsync(SqliteConnection connection, CancellationToken ct)` that checks `pragma_table_info('settings')` for the `timezone` column and runs `ALTER TABLE settings ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'` only if absent. Call `MigrateAsync` at the end of `ApplyAsync` after the main schema command. Also add synchronous `Migrate(SqliteConnection connection)` called at the end of the synchronous `Apply` method.
+- [ ] T003 [P] Update `src/SunnySunday.Server/Models/Settings.cs`: add `public string Timezone { get; set; } = "UTC";`.
+- [ ] T004 [P] Create `src/SunnySunday.Server/Models/RecapJobRecord.cs` with properties: `Id`, `UserId`, `ScheduledFor` (DateTimeOffset), `Status` (string, default `"pending"`), `AttemptCount` (int), `ErrorMessage` (string?), `CreatedAt` (DateTimeOffset), `DeliveredAt` (DateTimeOffset?). Namespace `SunnySunday.Server.Models`.
+- [ ] T005 [P] Update `src/SunnySunday.Core/Contracts/SettingsResponse.cs`: add `public string Timezone { get; set; } = string.Empty;` with XML doc comment `/// <summary>IANA timezone identifier for the delivery schedule (e.g., "Europe/Rome").</summary>`.
+- [ ] T006 [P] Update `src/SunnySunday.Core/Contracts/UpdateSettingsRequest.cs`: add `public string? Timezone { get; set; }` with XML doc comment `/// <summary>IANA timezone identifier. Validated via TimeZoneInfo.FindSystemTimeZoneById.</summary>`.
+- [ ] T007 [P] Update `src/SunnySunday.Core/Contracts/StatusResponse.cs`: add `public string? LastRecapStatus { get; set; }` (XML doc: `"delivered" | "failed" | null`) and `public string? LastRecapError { get; set; }` (XML doc: `Error detail when LastRecapStatus is "failed"; null otherwise`). Verify solution builds.
+
+**Checkpoint**: Schema, models, and contracts updated. `dotnet build src/SunnySunday.slnx` passes.
+
+---
+
+## Phase 3: Infrastructure
+
+**Purpose**: SMTP configuration binding, `SettingsRepository` extension, `RecapRepository`, and Quartz DI stub. These are the data-access and configuration foundations that services depend on.
+
+- [ ] T008 Create `src/SunnySunday.Server/Infrastructure/Smtp/SmtpSettings.cs` with properties: `Host` (string, default `"smtp.gmail.com"`), `Port` (int, default `587`), `Username` (string, empty), `Password` (string, empty), `FromAddress` (string, empty), `UseSsl` (bool, default `true`). Namespace `SunnySunday.Server.Infrastructure.Smtp`.
+- [ ] T009 [P] Update `src/SunnySunday.Server/Data/SettingsRepository.cs`. In `GetByUserIdAsync`, add `timezone AS Timezone` to the SELECT column list. In `UpsertAsync`, add `timezone = excluded.timezone` to the ON CONFLICT DO UPDATE SET clause and add `@Timezone` to the INSERT VALUES list. The default (`"UTC"`) is handled by the C# model default, not by a NULL check.
+- [ ] T010 [P] Create `src/SunnySunday.Server/Data/RecapRepository.cs`. Constructor takes `IDbConnection`. Methods:
+  - `SelectCandidatesAsync(int userId)` — executes the candidate selection query (see data-model.md); returns `IReadOnlyList<SelectionCandidate>` where score and ranking are computed in C# by `HighlightSelectionService`, not in SQL. This method returns raw rows before scoring.
+  - `CreateJobAsync(int userId, DateTimeOffset scheduledFor)` — INSERT OR IGNORE into `recap_jobs`; returns the row `id`.
+  - `GetJobBySlotAsync(int userId, DateTimeOffset scheduledFor)` — SELECT by `(user_id, scheduled_for)`.
+  - `UpdateJobDeliveredAsync(int jobId, DateTimeOffset deliveredAt)` — UPDATE `status='delivered'`, `delivered_at`, `attempt_count`.
+  - `UpdateJobFailedAsync(int jobId, string errorMessage, int attemptCount)` — UPDATE `status='failed'`, `error_message`, `attempt_count`.
+  - `GetLastJobAsync(int userId)` — SELECT the most recent job by `created_at DESC LIMIT 1`; returns `RecapJobRecord?`.
+  - `UpdateHighlightSeenAsync(int highlightId, DateTimeOffset seenAt)` — UPDATE `highlights SET last_seen=@seenAt, delivery_count=delivery_count+1 WHERE id=@highlightId`.
+  Namespace `SunnySunday.Server.Data`.
+
+**Checkpoint**: Infrastructure complete. `dotnet build src/SunnySunday.slnx` passes.
+
+---
+
+## Phase 4: Highlight Selection (US-2)
+
+**Purpose**: Implement the scoring, ranking, and tiebreak logic for recap candidate selection.
+
+- [ ] T011 Create `src/SunnySunday.Server/Services/HighlightSelectionService.cs`. Constructor takes `RecapRepository`. Method `SelectAsync(int userId, int count)`:
+  1. Call `RecapRepository.SelectCandidatesAsync(userId)` to get all eligible rows.
+  2. For each row, compute `ageInDays = last_seen.HasValue ? (int)(UtcNow - last_seen.Value).TotalDays : 3650`.
+  3. Compute `score = ageInDays + weight`.
+  4. Sort descending by `score`, then descending by `created_at` (tiebreak: most recently added first).
+  5. Take top `count` items.
+  6. Return `IReadOnlyList<SelectionCandidate>`.
+  If zero candidates remain after filtering (empty DB or all excluded), return empty list (no recap).
+  Namespace `SunnySunday.Server.Services`.
+- [ ] T012 Write `src/SunnySunday.Tests/Recap/HighlightSelectionServiceTests.cs`. Test cases:
+  1. Highlights with different ages and weights → verify ranking order matches `score = age + weight` (higher score first).
+  2. Two highlights with equal score → verify the more recent `created_at` is selected first.
+  3. Excluded highlights, excluded books, excluded authors → verify none are returned.
+  4. `last_seen = null` → verify these highlights rank above any highlight with a non-null `last_seen`.
+  5. `count = 3` with 10 candidates → verify exactly 3 returned.
+  6. Empty eligible set → verify empty list returned (no exception).
+  Use in-memory SQLite with seeded data via the `TestWebApplicationFactory` infrastructure (or a lightweight in-process `IDbConnection`).
+
+**Checkpoint**: Selection logic tested and verified. `dotnet test src/SunnySunday.slnx --filter "FullyQualifiedName~Recap.HighlightSelectionService"` passes.
+
+---
+
+## Phase 5: EPUB Composition (US-4)
+
+**Purpose**: Implement the static EPUB 2 composer that converts a ranked highlight list into a Kindle-compatible EPUB byte array.
+
+- [ ] T013 Create `src/SunnySunday.Server/Services/EpubComposer.cs`. Static class with one public method: `byte[] Compose(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate)`. Produces an EPUB 2 archive in memory using `System.IO.Compression.ZipArchive` over a `MemoryStream`. Files written:
+  - `mimetype` — `application/epub+zip` (stored, not compressed; must be first entry)
+  - `META-INF/container.xml` — points to `OEBPS/content.opf`
+  - `OEBPS/content.opf` — OPF 2.0 package document; title = `"Sunny Sunday Recap — {recapDate:yyyy-MM-dd}"`; unique-identifier based on `recapDate` ticks
+  - `OEBPS/toc.ncx` — minimal NCX with single navPoint
+  - `OEBPS/highlights.xhtml` — XHTML 1.1; body contains `<ul>` where each `<li>` has `<p class="highlight">"…text…"</p>` and `<p class="source">— {author}, {title}</p>`; no grouping by book
+  Namespace `SunnySunday.Server.Services`.
+- [ ] T014 Write `src/SunnySunday.Tests/Recap/EpubComposerTests.cs`. Test cases:
+  1. Compose from 3 known highlights → output is non-empty byte array; opening as a ZIP reveals `mimetype`, `META-INF/container.xml`, `OEBPS/content.opf`, `OEBPS/toc.ncx`, `OEBPS/highlights.xhtml`.
+  2. XHTML content contains all 3 highlight texts and all 3 source labels (author + title).
+  3. Highlights are in the same order as the input list (ranking already applied before composition).
+  4. Compose from empty list → produces valid EPUB with empty `<ul>` (no exception).
+  5. `mimetype` entry is stored (not deflated) — verify `CompressionLevel` is `NoCompression` for that entry.
+
+**Checkpoint**: EPUB composer tested. `dotnet test src/SunnySunday.slnx --filter "FullyQualifiedName~Recap.EpubComposer"` passes.
+
+---
+
+## Phase 6: Email Delivery with Retry (US-3)
+
+**Purpose**: Implement the MailKit SMTP delivery service and the retry loop. The interface decouples the orchestrator from the transport for testability.
+
+- [ ] T015 Create `src/SunnySunday.Server/Services/IMailDeliveryService.cs`. Define:
+  ```csharp
+  public interface IMailDeliveryService
+  {
+      Task SendAsync(RecapDeliveryPayload payload, CancellationToken ct = default);
+  }
+
+  public sealed record RecapDeliveryPayload(
+      string ToAddress,
+      string Subject,
+      byte[] EpubBytes,
+      string EpubFilename);
+  ```
+  Namespace `SunnySunday.Server.Services`.
+- [ ] T016 Create `src/SunnySunday.Server/Services/MailDeliveryService.cs`. Constructor takes `IOptions<SmtpSettings>`. `SendAsync` implementation: build a `MimeMessage` with `From = settings.FromAddress`, `To = payload.ToAddress`, `Subject = payload.Subject`; attach `payload.EpubBytes` as `application/epub+zip` with filename `payload.EpubFilename`. Connect to `settings.Host:settings.Port` using `MailKit.Net.Smtp.SmtpClient`; authenticate; send; disconnect. Throws on SMTP error (caller handles retry). Namespace `SunnySunday.Server.Services`.
+- [ ] T017 Write `src/SunnySunday.Tests/Recap/RecapServiceTests.cs`. For retry behavior, create a `FakeMailDeliveryService` that throws `InvalidOperationException` on the first N calls, then succeeds. Test cases:
+  1. First attempt succeeds → `UpdateHighlightSeenAsync` called once per highlight; job status = `'delivered'`.
+  2. Attempt 1 fails, attempt 2 succeeds → retry fires once; job status = `'delivered'`; history updated.
+  3. All 3 attempts fail → job status = `'failed'`; `error_message` set; `UpdateHighlightSeenAsync` never called.
+  4. No eligible highlights → no EPUB composed, no SMTP attempted, job not created.
+  5. Verify `attempt_count` is incremented correctly on each attempt.
+  Use in-memory SQLite. Wire `RecapService` directly (not through HTTP pipeline) for these tests.
+
+**Checkpoint**: Delivery and retry tested. `dotnet test src/SunnySunday.slnx --filter "FullyQualifiedName~Recap.RecapService"` passes.
+
+---
+
+## Phase 7: Recap Pipeline Orchestration (US-1 + US-2 + US-3 + US-4)
+
+**Purpose**: Wire the full pipeline from Quartz trigger through selection, composition, delivery, and history update.
+
+- [ ] T018 Create `src/SunnySunday.Server/Services/IRecapService.cs` and `RecapService.cs`. `RecapService` constructor takes `HighlightSelectionService`, `EpubComposer` (static — injected as a func or called directly), `IMailDeliveryService`, `RecapRepository`, `UserRepository`, `SettingsRepository`. `ExecuteAsync(int userId, DateTimeOffset scheduledFor)` pipeline:
+  1. Call `RecapRepository.CreateJobAsync(userId, scheduledFor)` → get `jobId` (INSERT OR IGNORE; if row already existed and is `'delivered'`, retrieve it and return early).
+  2. Get `Settings` via `SettingsRepository.GetByUserIdAsync(userId)` — need `Count`.
+  3. Get `User` via `UserRepository.EnsureUserAsync()` — need `kindle_email`.
+  4. Call `HighlightSelectionService.SelectAsync(userId, settings.Count)`.
+  5. If empty → `UpdateJobFailedAsync(jobId, "No eligible highlights.", 0)`, return.
+  6. Call `EpubComposer.Compose(candidates, scheduledFor)`.
+  7. Retry loop (max 3 attempts, waits: 1 min, 5 min between attempts):
+     - Call `IMailDeliveryService.SendAsync(payload, ct)`.
+     - On success: call `RecapRepository.UpdateHighlightSeenAsync` for each delivered highlight, call `UpdateJobDeliveredAsync`, return.
+     - On failure: increment attempt count; if attempts < 3, `await Task.Delay(backoff, ct)`; else `UpdateJobFailedAsync(jobId, ex.Message, 3)`, log error.
+  Namespace `SunnySunday.Server.Services`.
+- [ ] T019 Create `src/SunnySunday.Server/Jobs/RecapJob.cs`. Implements Quartz `IJob`. Constructor takes `IRecapService`, `RecapRepository`, `UserRepository`, `ILogger<RecapJob>`. `Execute(IJobExecutionContext context)`:
+  1. Extract `scheduledFor = context.ScheduledFireTimeUtc?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow`.
+  2. Call `UserRepository.EnsureUserAsync()` → `userId`.
+  3. Check `RecapRepository.GetJobBySlotAsync(userId, scheduledFor)` — if row exists with `status='delivered'`, log warning and return (deduplication guard).
+  4. Call `IRecapService.ExecuteAsync(userId, scheduledFor, context.CancellationToken)`.
+  Namespace `SunnySunday.Server.Jobs`.
+
+---
+
+## Phase 8: Scheduling and Settings/Status Integration (US-1)
+
+**Purpose**: Implement `SchedulerService`, wire it into `PUT /settings` and `GET /status`, and complete the settings timezone handling.
+
+- [ ] T020 Create `src/SunnySunday.Server/Services/ISchedulerService.cs` and `SchedulerService.cs`. Constructor takes `ISchedulerFactory`. `ScheduleAsync(Settings settings)`:
+  - Parse `delivery_time` as `HH:mm` → hour, minute.
+  - Resolve `TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById(settings.Timezone)`.
+  - Build cron expression: daily = `"0 {minute} {hour} * * ?"`, weekly = `"0 {minute} {hour} ? * {dayOfWeek}"`.
+  - Delete existing job with key `"recap-job"` if present.
+  - Define `IJobDetail` for `RecapJob`, `ITrigger` with cron + timezone.
+  - Schedule via `IScheduler.ScheduleJob`.
+  `GetNextFireTimeAsync()`: retrieve trigger by key, return `trigger.GetNextFireTimeUtc()?.ToDateTimeOffset()`.
+  Namespace `SunnySunday.Server.Services`.
+- [ ] T021 Update `src/SunnySunday.Server/Endpoints/SettingsEndpoints.cs`:
+  - In `GET /settings`: map `settings.Timezone` into `SettingsResponse.Timezone`.
+  - In `PUT /settings`: validate `Timezone` if provided — call `TimeZoneInfo.FindSystemTimeZoneById`; catch `TimeZoneNotFoundException`; return `Results.ValidationProblem` with error on `timezone` field if invalid.
+  - After saving updated settings, call `ISchedulerService.ScheduleAsync(updatedSettings)` to re-register the Quartz trigger.
+  - Inject `ISchedulerService` as a parameter in the endpoint handler.
+- [ ] T022 Update `src/SunnySunday.Server/Endpoints/StatusEndpoints.cs`: inject `ISchedulerService`; call `GetNextFireTimeAsync()` and set result as `NextRecap` (UTC ISO 8601 string) in the response.
+- [ ] T023 Update `src/SunnySunday.Server/Data/StatusRepository.cs`: add call to `RecapRepository.GetLastJobAsync(userId)` and populate `LastRecapStatus` and `LastRecapError` on `StatusResponse` from the last job row.
+- [ ] T024 Update `src/SunnySunday.Server/Program.cs`:
+  - Add `builder.Services.Configure<SmtpSettings>(builder.Configuration.GetSection("Smtp"))`.
+  - Add Quartz: `builder.Services.AddQuartz(q => { q.UseMicrosoftDependencyInjectionJobFactory(); })` + `builder.Services.AddQuartzHostedService(opt => opt.WaitForJobsToComplete = true)`.
+  - Register `RecapRepository`, `HighlightSelectionService`, `RecapService`, `MailDeliveryService`, `SchedulerService` as scoped/singleton as appropriate:
+    - Quartz `IJob` implementations must be registered as transient: `services.AddTransient<RecapJob>()`.
+    - `MailDeliveryService`: transient.
+    - `HighlightSelectionService`: scoped.
+    - `RecapService`: scoped.
+    - `SchedulerService`: singleton (owns the ISchedulerFactory reference).
+    - `RecapRepository`: scoped.
+  - After `SchemaBootstrap.ApplyAsync`, read settings and call `SchedulerService.ScheduleAsync(settings)` to register the initial Quartz trigger on startup.
+
+**Checkpoint**: Full pipeline wired. Server starts, Quartz logs next fire time. `dotnet build src/SunnySunday.slnx` passes.
+
+---
+
+## Phase 9: Tests and Polish
+
+**Purpose**: Extend existing endpoint tests, verify full test suite, update architecture docs.
+
+- [ ] T025 Extend `src/SunnySunday.Tests/Api/SettingsEndpointTests.cs`:
+  1. `PUT /settings` with `timezone = "Europe/Rome"` → subsequent `GET /settings` returns `timezone = "Europe/Rome"`.
+  2. `PUT /settings` with `timezone = "invalid/timezone"` → 422 with validation error on `timezone`.
+  3. `PUT /settings` with no `timezone` → existing timezone unchanged.
+  4. Default settings → `timezone = "UTC"`.
+- [ ] T026 Extend `src/SunnySunday.Tests/Api/StatusEndpointTests.cs`:
+  1. After startup with default settings → `nextRecap` is non-null and parses as a valid UTC ISO 8601 datetime.
+  2. `lastRecapStatus` and `lastRecapError` are null when no recap has run.
+  3. Simulate a failed recap job in DB → `lastRecapStatus = "failed"`, `lastRecapError` is non-null.
+  4. Simulate a delivered recap job in DB → `lastRecapStatus = "delivered"`, `lastRecapError = null`.
+- [ ] T027 Update `docs/ARCHITECTURE.md`:
+  - Add recap engine section under "Server (`sunny-server`)" describing: `SchedulerService`, `RecapJob`, `RecapService`, `HighlightSelectionService`, `EpubComposer`, `MailDeliveryService`.
+  - Update the data model table to include `recap_jobs` and the `timezone` column.
+  - Update the core query section to reflect the production selection SQL (with JOINs to books/authors) and the C# scoring formula.
+- [ ] T028 Run full test suite: `dotnet test src/SunnySunday.slnx`. Confirm no regressions in existing infrastructure, parser, and API tests. All new tests pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No prerequisites — start immediately
+- **Phase 2 (Schema & Models)**: Depends on Phase 1 — **BLOCKS all subsequent phases**
+- **Phase 3 (Infrastructure)**: Depends on Phase 2 — unblocks all service phases
+- **Phase 4 (Selection)**: Depends on Phase 3 — parallel with Phases 5 and 6
+- **Phase 5 (EPUB)**: Depends on Phase 2 (uses `SelectionCandidate`) — parallel with Phases 4 and 6
+- **Phase 6 (Delivery)**: Depends on Phase 3 (`IMailDeliveryService`) — parallel with Phases 4 and 5
+- **Phase 7 (Orchestration)**: Depends on Phases 4, 5, 6 — wires them together
+- **Phase 8 (Scheduling + Settings/Status)**: Depends on Phase 7 — finalizes integration
+- **Phase 9 (Tests & Polish)**: Depends on all preceding phases
+
+### Parallel Opportunities
+
+```
+Phase 1 ──► Phase 2 ──┬──► Phase 3 ──┬──► Phase 4 (Selection) ──────┐
+                      │              ├──► Phase 5 (EPUB) ─────────────┼──► Phase 7 ──► Phase 8 ──► Phase 9
+                      │              └──► Phase 6 (Delivery) ─────────┘
+                      │
+                      └──► T003–T007 [P within Phase 2]
+```
+
+Within Phase 2, tasks T003–T007 are all independent file edits and can be parallelized.

--- a/specs/005-scheduler-recap-engine/plan.md
+++ b/specs/005-scheduler-recap-engine/plan.md
@@ -10,7 +10,7 @@ Implement the automated recap pipeline for Sunny Sunday: a Quartz.NET-based sche
 ## Technical Context
 
 **Language/Version**: C# / .NET 10 (`net10.0` TFM)
-**New Dependencies**: `Quartz.Extensions.Hosting` (Quartz.NET), `MailKit`, `Polly`
+**New Dependencies**: `Quartz.Extensions.Hosting` (Quartz.NET), `MailKit`, `Polly` (shared by server and CLI via `src/PackageVersions.props`)
 **Existing Dependencies**: Dapper, Microsoft.Data.Sqlite, Serilog, Swashbuckle.AspNetCore (all in `SunnySunday.Server.csproj`)
 **Storage**: SQLite at `.data/sunny.db` — existing schema via `SchemaBootstrap`; this feature adds `recap_jobs` table and `timezone` column to `settings`
 **Testing**: xUnit + `WebApplicationFactory` (in-memory SQLite) — existing test infrastructure; `IMailDeliveryService` interface for SMTP substitution
@@ -92,6 +92,9 @@ src/SunnySunday.Core/Contracts/
 ├── UpdateSettingsRequest.cs                  ← Updated: +Timezone
 └── StatusResponse.cs                         ← Updated: +LastRecapStatus, +LastRecapError
 
+src/
+├── PackageVersions.props                     ← NEW: shared NuGet version properties
+
 src/SunnySunday.Tests/
 ├── Api/
 │   ├── SettingsEndpointTests.cs              ← Updated: new timezone test cases
@@ -113,7 +116,7 @@ No constitution violations. No complexity justification needed.
 **Purpose**: Add new NuGet packages required by this feature.
 
 - [ ] T000 Add `Quartz.Extensions.Hosting` NuGet package to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package Quartz.Extensions.Hosting`. This package includes Quartz core, the `ISchedulerFactory` / `IScheduler` abstractions, and the `IHostedService` integration that starts and stops the scheduler with the application host.
-- [ ] T001 [P] Add `MailKit` and `Polly` NuGet packages to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package MailKit` and `dotnet add src/SunnySunday.Server package Polly`. Verify solution builds: `dotnet build src/SunnySunday.slnx`.
+- [ ] T001 [P] Add `MailKit` to `src/SunnySunday.Server/SunnySunday.Server.csproj`, add `Polly` package references to both `src/SunnySunday.Server/SunnySunday.Server.csproj` and `src/SunnySunday.Cli/SunnySunday.Cli.csproj`, and create `src/PackageVersions.props` so the `Polly` version is declared once for both projects. Verify solution builds: `dotnet build src/SunnySunday.slnx`.
 
 ---
 

--- a/specs/005-scheduler-recap-engine/plan.md
+++ b/specs/005-scheduler-recap-engine/plan.md
@@ -5,12 +5,12 @@
 
 ## Summary
 
-Implement the automated recap pipeline for Sunny Sunday: a Quartz.NET-based scheduler fires daily (or weekly) at the user's configured local time, selects highlights by `score = age_in_days + weight` (tiebreak: most recently added), composes a Kindle-friendly EPUB 2 flat-list document, and delivers it via MailKit SMTP with a 3-attempt exponential retry (1 min, 5 min). Successful delivery updates `last_seen` and `delivery_count` per highlight; permanent failure leaves history unchanged and exposes the error via `GET /status`. All existing endpoints (`PUT /settings`, `GET /status`) are extended in-place — no new routes are added.
+Implement the automated recap pipeline for Sunny Sunday: a Quartz.NET-based scheduler fires daily (or weekly) at the user's configured local time, selects highlights by `score = age_in_days + weight` (tiebreak: most recently added), composes a Kindle-friendly EPUB 2 flat-list document, and delivers it via MailKit SMTP with Polly-based exponential retry capped at 3 attempts. Successful delivery updates `last_seen` and `delivery_count` per highlight; permanent failure leaves history unchanged and exposes the error via `GET /status`. All existing endpoints (`PUT /settings`, `GET /status`) are extended in-place — no new routes are added.
 
 ## Technical Context
 
 **Language/Version**: C# / .NET 10 (`net10.0` TFM)
-**New Dependencies**: `Quartz.Extensions.Hosting` (Quartz.NET), `MailKit`
+**New Dependencies**: `Quartz.Extensions.Hosting` (Quartz.NET), `MailKit`, `Polly`
 **Existing Dependencies**: Dapper, Microsoft.Data.Sqlite, Serilog, Swashbuckle.AspNetCore (all in `SunnySunday.Server.csproj`)
 **Storage**: SQLite at `.data/sunny.db` — existing schema via `SchemaBootstrap`; this feature adds `recap_jobs` table and `timezone` column to `settings`
 **Testing**: xUnit + `WebApplicationFactory` (in-memory SQLite) — existing test infrastructure; `IMailDeliveryService` interface for SMTP substitution
@@ -30,7 +30,7 @@ Implement the automated recap pipeline for Sunny Sunday: a Quartz.NET-based sche
 | III. Zero-Config Onboarding | **PASS** | Default timezone `"UTC"`, default schedule `daily 18:00` — no setup beyond Kindle email required |
 | IV. Local Processing Only | **PASS** | SMTP is direct server→Amazon; no third-party cloud APIs |
 | V. Tests Ship with Code | **PASS** | Selection, EPUB, retry, and endpoint tests included in same PR |
-| VI. Simplicity / YAGNI | **PASS** | In-memory Quartz store (not persistent), manual retry (not Polly), manual EPUB (not library) |
+| VI. Simplicity / YAGNI | **PASS** | In-memory Quartz store (not persistent), single Polly retry policy, manual EPUB (not library) |
 | Tech: C# / .NET 10 only | **PASS** | All new code is C# |
 | Tech: SQLite only | **PASS** | `recap_jobs` table in same SQLite file; Quartz uses in-memory store |
 | Tech: Serilog logging | **PASS** | Serilog used for delivery events and error logging |
@@ -41,7 +41,7 @@ Implement the automated recap pipeline for Sunny Sunday: a Quartz.NET-based sche
 | Exclusion: No web UI | **PASS** | No new UI components |
 | Exclusion: No auth for MVP | **PASS** | No authentication changes |
 
-**Post-design re-check**: All gates pass. Two new NuGet packages (`Quartz.Extensions.Hosting`, `MailKit`) are both in the prescribed stack. No new projects introduced. No EF Core, no Polly, no EPUB library dependencies added.
+**Post-design re-check**: All gates pass. Three new NuGet packages (`Quartz.Extensions.Hosting`, `MailKit`, `Polly`) remain within the prescribed stack. No new projects introduced. No EF Core or EPUB library dependencies added.
 
 ## Project Structure
 
@@ -113,7 +113,7 @@ No constitution violations. No complexity justification needed.
 **Purpose**: Add new NuGet packages required by this feature.
 
 - [ ] T000 Add `Quartz.Extensions.Hosting` NuGet package to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package Quartz.Extensions.Hosting`. This package includes Quartz core, the `ISchedulerFactory` / `IScheduler` abstractions, and the `IHostedService` integration that starts and stops the scheduler with the application host.
-- [ ] T001 [P] Add `MailKit` NuGet package to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package MailKit`. Verify solution builds: `dotnet build src/SunnySunday.slnx`.
+- [ ] T001 [P] Add `MailKit` and `Polly` NuGet packages to `src/SunnySunday.Server/SunnySunday.Server.csproj`: `dotnet add src/SunnySunday.Server package MailKit` and `dotnet add src/SunnySunday.Server package Polly`. Verify solution builds: `dotnet build src/SunnySunday.slnx`.
 
 ---
 
@@ -138,7 +138,7 @@ No constitution violations. No complexity justification needed.
 
 **Purpose**: SMTP configuration binding, `SettingsRepository` extension, `RecapRepository`, and Quartz DI stub. These are the data-access and configuration foundations that services depend on.
 
-- [ ] T008 Create `src/SunnySunday.Server/Infrastructure/Smtp/SmtpSettings.cs` with properties: `Host` (string, default `"smtp.gmail.com"`), `Port` (int, default `587`), `Username` (string, empty), `Password` (string, empty), `FromAddress` (string, empty), `UseSsl` (bool, default `true`). Namespace `SunnySunday.Server.Infrastructure.Smtp`.
+- [ ] T008 Create `src/SunnySunday.Server/Infrastructure/Smtp/SmtpSettings.cs` with properties: `Host` (string, default `"smtp.gmail.com"`), `Port` (int, default `587`), `Username` (string, empty), `Password` (string, empty), `FromAddress` (string, empty), `UseSsl` (bool, default `true`). Namespace `SunnySunday.Server.Infrastructure.Smtp`. Add configuration mapping so env vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM_ADDRESS`, `SMTP_USE_SSL`) populate this options object.
 - [ ] T009 [P] Update `src/SunnySunday.Server/Data/SettingsRepository.cs`. In `GetByUserIdAsync`, add `timezone AS Timezone` to the SELECT column list. In `UpsertAsync`, add `timezone = excluded.timezone` to the ON CONFLICT DO UPDATE SET clause and add `@Timezone` to the INSERT VALUES list. The default (`"UTC"`) is handled by the C# model default, not by a NULL check.
 - [ ] T010 [P] Create `src/SunnySunday.Server/Data/RecapRepository.cs`. Constructor takes `IDbConnection`. Methods:
   - `SelectCandidatesAsync(int userId)` — executes the candidate selection query (see data-model.md); returns `IReadOnlyList<SelectionCandidate>` where score and ranking are computed in C# by `HighlightSelectionService`, not in SQL. This method returns raw rows before scoring.
@@ -204,7 +204,7 @@ No constitution violations. No complexity justification needed.
 
 ## Phase 6: Email Delivery with Retry (US-3)
 
-**Purpose**: Implement the MailKit SMTP delivery service and the retry loop. The interface decouples the orchestrator from the transport for testability.
+**Purpose**: Implement the MailKit SMTP delivery service and a Polly-based retry policy. The interface decouples the orchestrator from the transport for testability.
 
 - [ ] T015 Create `src/SunnySunday.Server/Services/IMailDeliveryService.cs`. Define:
   ```csharp
@@ -244,10 +244,11 @@ No constitution violations. No complexity justification needed.
   4. Call `HighlightSelectionService.SelectAsync(userId, settings.Count)`.
   5. If empty → `UpdateJobFailedAsync(jobId, "No eligible highlights.", 0)`, return.
   6. Call `EpubComposer.Compose(candidates, scheduledFor)`.
-  7. Retry loop (max 3 attempts, waits: 1 min, 5 min between attempts):
-     - Call `IMailDeliveryService.SendAsync(payload, ct)`.
-     - On success: call `RecapRepository.UpdateHighlightSeenAsync` for each delivered highlight, call `UpdateJobDeliveredAsync`, return.
-     - On failure: increment attempt count; if attempts < 3, `await Task.Delay(backoff, ct)`; else `UpdateJobFailedAsync(jobId, ex.Message, 3)`, log error.
+    7. Polly retry policy (max 3 attempts total, exponential backoff computed by the policy):
+      - Execute `IMailDeliveryService.SendAsync(payload, ct)` through the Polly policy.
+      - On each retry callback, log the attempt number and computed delay.
+      - On success: call `RecapRepository.UpdateHighlightSeenAsync` for each delivered highlight, call `UpdateJobDeliveredAsync`, return.
+      - On final failure after the third attempt: `UpdateJobFailedAsync(jobId, ex.Message, 3)`, log error.
   Namespace `SunnySunday.Server.Services`.
 - [ ] T019 Create `src/SunnySunday.Server/Jobs/RecapJob.cs`. Implements Quartz `IJob`. Constructor takes `IRecapService`, `RecapRepository`, `UserRepository`, `ILogger<RecapJob>`. `Execute(IJobExecutionContext context)`:
   1. Extract `scheduledFor = context.ScheduledFireTimeUtc?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow`.

--- a/specs/005-scheduler-recap-engine/quickstart.md
+++ b/specs/005-scheduler-recap-engine/quickstart.md
@@ -1,0 +1,250 @@
+# Quickstart: Scheduler + Recap Engine
+
+**Feature**: 005-scheduler-recap-engine
+**Date**: 2026-04-27
+
+---
+
+## Prerequisites
+
+- .NET 10 SDK installed (`dotnet --version` → `10.x`)
+- Repository cloned and on branch `005-scheduler-recap-engine` (or `task/TXXX-*` task branch)
+- Solution builds cleanly from `main`: `dotnet build src/SunnySunday.slnx`
+- A configured SMTP account (Gmail app password, Outlook, or any SMTP relay) for manual delivery testing
+
+---
+
+## New Dependencies
+
+### Server project (`SunnySunday.Server.csproj`)
+
+```bash
+dotnet add src/SunnySunday.Server package Quartz.Extensions.Hosting
+dotnet add src/SunnySunday.Server package MailKit
+```
+
+---
+
+## SMTP Configuration
+
+SMTP credentials are **not** stored in the database. Configure them via `appsettings.Development.json` locally or environment variables in Docker.
+
+### Local development (`src/SunnySunday.Server/appsettings.Development.json`)
+
+```json
+{
+  "Smtp": {
+    "Host": "smtp.gmail.com",
+    "Port": 587,
+    "Username": "your-email@gmail.com",
+    "Password": "your-app-specific-password",
+    "FromAddress": "your-email@gmail.com",
+    "UseSsl": true
+  }
+}
+```
+
+> **Note**: For Gmail, generate an [App Password](https://support.google.com/accounts/answer/185833) (requires 2FA). Never commit real credentials to source control.
+
+### Docker (environment variables)
+
+```yaml
+# docker-compose.yml excerpt
+environment:
+  - Smtp__Host=smtp.gmail.com
+  - Smtp__Port=587
+  - Smtp__Username=your-email@gmail.com
+  - Smtp__Password=your-app-specific-password
+  - Smtp__FromAddress=your-email@gmail.com
+  - Smtp__UseSsl=true
+```
+
+---
+
+## Build and Run
+
+```bash
+# Build the entire solution
+dotnet build src/SunnySunday.slnx
+
+# Run the server (Development mode — Swagger UI enabled)
+dotnet run --project src/SunnySunday.Server
+```
+
+On startup the server will:
+1. Apply schema migrations (create `recap_jobs` table; add `timezone` column to `settings` if absent)
+2. Read settings from SQLite
+3. Register the Quartz cron trigger for the configured schedule
+
+Server listens on `http://localhost:5000` by default.
+
+---
+
+## Run Tests
+
+```bash
+# All tests
+dotnet test src/SunnySunday.slnx
+
+# Only recap engine tests (selection, EPUB, retry)
+dotnet test src/SunnySunday.Tests --filter "FullyQualifiedName~Recap"
+
+# Only updated endpoint tests
+dotnet test src/SunnySunday.Tests --filter "FullyQualifiedName~Api"
+```
+
+---
+
+## Manual Testing
+
+### Configure Kindle email and timezone
+
+```bash
+curl -X PUT http://localhost:5000/settings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kindleEmail": "your-kindle-email@kindle.com",
+    "timezone": "Europe/Rome",
+    "deliveryTime": "18:00",
+    "schedule": "daily",
+    "count": 5
+  }'
+```
+
+Expected response (200):
+```json
+{
+  "schedule": "daily",
+  "deliveryDay": null,
+  "deliveryTime": "18:00",
+  "count": 5,
+  "kindleEmail": "your-kindle-email@kindle.com",
+  "timezone": "Europe/Rome"
+}
+```
+
+### Check server status and next recap time
+
+```bash
+curl http://localhost:5000/status
+```
+
+Expected response (200):
+```json
+{
+  "totalHighlights": 42,
+  "totalBooks": 7,
+  "totalAuthors": 5,
+  "excludedHighlights": 0,
+  "excludedBooks": 0,
+  "excludedAuthors": 0,
+  "nextRecap": "2026-04-28T16:00:00Z",
+  "lastRecapStatus": null,
+  "lastRecapError": null
+}
+```
+
+> `nextRecap` is UTC. To display in local time in the CLI, parse it and convert using the stored timezone.
+
+### Verify invalid timezone is rejected
+
+```bash
+curl -X PUT http://localhost:5000/settings \
+  -H "Content-Type: application/json" \
+  -d '{"timezone": "Fake/Zone"}'
+```
+
+Expected response (422):
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 422,
+  "errors": {
+    "timezone": ["Unrecognized timezone identifier 'Fake/Zone'."]
+  }
+}
+```
+
+### Sync some highlights before testing recap
+
+```bash
+curl -X POST http://localhost:5000/sync \
+  -H "Content-Type: application/json" \
+  -d '{
+    "books": [
+      {
+        "title": "Deep Work",
+        "author": "Cal Newport",
+        "highlights": [
+          { "text": "Professional activities performed in a state of distraction-free concentration." },
+          { "text": "Clarity about what matters provides clarity about what does not." },
+          { "text": "The key to developing a deep work habit is to move beyond good intentions." }
+        ]
+      },
+      {
+        "title": "Atomic Habits",
+        "author": "James Clear",
+        "highlights": [
+          { "text": "You do not rise to the level of your goals. You fall to the level of your systems." },
+          { "text": "Every action you take is a vote for the type of person you wish to become." }
+        ]
+      }
+    ]
+  }'
+```
+
+---
+
+## Observing Quartz Scheduling
+
+When the server starts, Serilog logs the Quartz trigger registration:
+
+```
+[INF] Quartz scheduler started. Next recap trigger: 2026-04-28T16:00:00Z (Europe/Rome → 18:00 local)
+```
+
+When a recap fires:
+
+```
+[INF] RecapJob executing for slot 2026-04-28T16:00:00Z, user_id=1
+[INF] Selected 5 highlights. Composing EPUB.
+[INF] EPUB composed (3842 bytes). Delivering to your-kindle-email@kindle.com.
+[INF] Recap delivered successfully. Updated last_seen for 5 highlights.
+```
+
+If delivery fails:
+
+```
+[WRN] Delivery attempt 1 failed: Connection refused. Retrying in 1 minute.
+[WRN] Delivery attempt 2 failed: Authentication failed. Retrying in 5 minutes.
+[ERR] All 3 delivery attempts exhausted. recap_job_id=7, error: Authentication failed.
+```
+
+---
+
+## Verifying the EPUB Locally
+
+To inspect a generated EPUB without sending it to a Kindle device:
+
+1. Write a temporary integration test or tool that calls `EpubComposer.Compose(highlights, date)` and writes the result to disk.
+2. Rename the `.epub` file to `.zip` and open it with any archive manager.
+3. Verify the presence of `mimetype`, `META-INF/container.xml`, `OEBPS/content.opf`, `OEBPS/toc.ncx`, `OEBPS/highlights.xhtml`.
+4. Open `OEBPS/highlights.xhtml` in a browser to preview the flat list rendering.
+
+---
+
+## Resetting Recap History
+
+To reset `last_seen` and `delivery_count` on all highlights during development (forces all highlights to rank as "never seen"):
+
+```bash
+sqlite3 .data/sunny.db "UPDATE highlights SET last_seen = NULL, delivery_count = 0;"
+sqlite3 .data/sunny.db "DELETE FROM recap_jobs;"
+```
+
+---
+
+## Swagger UI
+
+Available in Development at `http://localhost:5000/swagger`. Updated endpoint definitions for `PUT /settings` (new `timezone` field) and `GET /status` (new `lastRecapStatus`, `lastRecapError` fields) are visible here.

--- a/specs/005-scheduler-recap-engine/quickstart.md
+++ b/specs/005-scheduler-recap-engine/quickstart.md
@@ -37,9 +37,7 @@ SMTP credentials are **not** stored in the database. Configure them via `appsett
     "Host": "smtp.gmail.com",
     "Port": 587,
     "Username": "your-email@gmail.com",
-    "Password": "your-app-specific-password",
-    "FromAddress": "your-email@gmail.com",
-    "UseSsl": true
+    "Password": "your-app-specific-password"
   }
 }
 ```
@@ -51,12 +49,10 @@ SMTP credentials are **not** stored in the database. Configure them via `appsett
 ```yaml
 # docker-compose.yml excerpt
 environment:
-  - Smtp__Host=smtp.gmail.com
-  - Smtp__Port=587
-  - Smtp__Username=your-email@gmail.com
-  - Smtp__Password=your-app-specific-password
-  - Smtp__FromAddress=your-email@gmail.com
-  - Smtp__UseSsl=true
+  - SMTP_HOST=smtp.gmail.com
+  - SMTP_PORT=587
+  - SMTP_USER=your-email@gmail.com
+  - SMTP_PASSWORD=your-app-specific-password
 ```
 
 ---
@@ -216,8 +212,8 @@ When a recap fires:
 If delivery fails:
 
 ```
-[WRN] Delivery attempt 1 failed: Connection refused. Retrying in 1 minute.
-[WRN] Delivery attempt 2 failed: Authentication failed. Retrying in 5 minutes.
+[WRN] Delivery attempt 1 failed: Connection refused. Polly scheduled retry 2/3 with exponential backoff.
+[WRN] Delivery attempt 2 failed: Authentication failed. Polly scheduled retry 3/3 with exponential backoff.
 [ERR] All 3 delivery attempts exhausted. recap_job_id=7, error: Authentication failed.
 ```
 

--- a/specs/005-scheduler-recap-engine/research.md
+++ b/specs/005-scheduler-recap-engine/research.md
@@ -1,0 +1,205 @@
+# Research: Scheduler + Recap Engine
+
+**Feature**: 005-scheduler-recap-engine
+**Phase**: 0 — Research
+**Date**: 2026-04-27
+
+---
+
+## Research Tasks & Findings
+
+### 1. Scheduling: Quartz.NET Job Store (In-Memory vs Persistent)
+
+**Decision**: In-memory job store with DB-backed deduplication via the `recap_jobs` table
+
+**Rationale**:
+- Quartz.NET's ADO.NET persistent store requires additional schema setup and configuration. For a single recurring daily job in a single-user MVP, the overhead is unjustified.
+- On server restart, the Quartz scheduler is re-initialized at startup by reading `settings` from SQLite and re-registering the recap trigger. This is simple and reliable.
+- The "duplicate trigger after restart/clock drift" edge case (spec) is handled by the `recap_jobs` table: before executing, the `RecapJob` (Quartz `IJob`) checks for an existing `status = 'delivered'` row for the current slot key (`user_id + scheduled_for`). If found, it exits immediately.
+- A unique index on `(user_id, scheduled_for)` in `recap_jobs` prevents concurrent double-insertion even under pathological conditions.
+- `Quartz.Extensions.Hosting` provides a `IHostedService` integration that starts the scheduler on `IHost` startup and shuts it down cleanly.
+
+**Quartz cron schedule**:
+- Daily: `0 {minute} {hour} * * ?`  (Quartz uses 6-field cron: seconds, minutes, hours, day-of-month, month, day-of-week)
+- Weekly: `0 {minute} {hour} ? * {dayOfWeek}` — day-of-week derived from `settings.delivery_day`
+
+**Alternatives considered**:
+- **ADO.NET persistent store**: survives restarts without re-registration but requires Quartz schema tables in the SQLite DB, more complex initialization, and more NuGet packages. Overkill for one job.
+- **Hangfire**: full-featured background job system with dashboard. Too heavy for a single recurring recap job.
+- **`System.Threading.PeriodicTimer`**: simple but doesn't support timezone-aware cron semantics natively; implementing DST-correct scheduling manually would add significant complexity.
+
+---
+
+### 2. EPUB Generation: Manual ZIP Construction vs Library
+
+**Decision**: Manual EPUB 2 construction using `System.IO.Compression.ZipArchive` — no new NuGet package
+
+**Rationale**:
+- An EPUB file is a ZIP archive with a defined directory structure. For a single-chapter flat-list document (the recap), the total template is under 200 lines across four files.
+- The .NET BCL `System.IO.Compression.ZipArchive` covers all required ZIP operations without any external dependency.
+- All reviewed NuGet EPUB writer libraries (EpubSharp, VersOne.Epub, EpubCore) are primarily reader-focused. Their writer APIs require learning a new object model for a document that is simpler to produce from a template string.
+- The manual approach gives full control over the output, deterministic byte content (important for tests), zero new dependencies, and aligns with constitution principle VI (YAGNI).
+- EPUB 2 (not EPUB 3) is used for maximum Kindle compatibility across all device generations.
+
+**EPUB 2 structure produced**:
+```
+mimetype
+META-INF/container.xml
+OEBPS/content.opf        ← package document: metadata, manifest, spine
+OEBPS/toc.ncx            ← navigation control (required by EPUB 2)
+OEBPS/highlights.xhtml   ← single content file: flat list of highlights
+```
+
+Each highlight item in `highlights.xhtml` renders as:
+```html
+<p class="highlight">"…text…"</p>
+<p class="source">— Author Name, Book Title</p>
+```
+
+**Alternatives considered**:
+- **EpubSharp**: last meaningful commit 2019; not actively maintained; writer support is incomplete.
+- **VersOne.Epub**: solid reader, writer support was added later but is less tested; adds ~300 KB dependency.
+- **EPUB 3**: better semantics but redundant for Kindle which reads EPUB 2 natively on all generations; EPUB 3 adds a `nav.xhtml` navigation document requirement with no practical benefit here.
+
+---
+
+### 3. SMTP Delivery: MailKit Configuration
+
+**Decision**: MailKit `SmtpClient` with configuration from `appsettings.json` / environment variables via `IOptions<SmtpSettings>`
+
+**Rationale**:
+- MailKit is explicitly listed in the project stack (`docs/ARCHITECTURE.md`). It provides full SMTP support including STARTTLS, OAUTH2, and modern authentication — significantly more reliable than the deprecated .NET BCL `SmtpClient`.
+- SMTP credentials (host, port, username, password, from address) are **server-side operational configuration**, not user preferences. They must **not** be stored in the SQLite DB. They belong in `appsettings.json` with environment variable overrides.
+- The Kindle recipient email (`users.kindle_email`) is stored in SQLite — it is user data, not server config.
+- `IOptions<SmtpSettings>` is the standard .NET options pattern; environment variables override with double-underscore separator (`Smtp__Host`) — standard Docker-compose pattern.
+- `IMailDeliveryService` abstracts MailKit for testability. Tests inject a fake implementation; production registers `MailDeliveryService`.
+
+**SmtpSettings configuration keys** (in `appsettings.json` / env vars):
+```
+Smtp:Host         (default: "smtp.gmail.com")
+Smtp:Port         (default: 587)
+Smtp:Username     (required)
+Smtp:Password     (required — use env var in production, never hardcode)
+Smtp:FromAddress  (required)
+Smtp:UseSsl       (default: true)
+```
+
+**Alternatives considered**:
+- **.NET BCL `SmtpClient`**: deprecated since .NET Core 2.0; lacks modern auth support; documented as not recommended by Microsoft.
+- **SendGrid / Mailgun SDK**: external cloud services — violates constitution principle IV (local processing only, no third-party data transmission).
+
+---
+
+### 4. Retry Policy: Polly vs Manual Loop
+
+**Decision**: Manual retry loop with `await Task.Delay(...)` — no new NuGet package
+
+**Rationale**:
+- The retry spec is fixed and simple: 3 total attempts, wait 1 minute between attempt 1 and 2, wait 5 minutes between attempt 2 and 3.
+- A manual loop with `Task.Delay` is approximately 20 lines and carries no library dependency.
+- Polly (or `Microsoft.Extensions.Resilience`) is appropriate when retry rules are configurable, need circuit-breaking, or must be shared across many call sites. None apply here.
+- Constitution principle VI: do not add a library for something achievable in 20 lines.
+
+**Retry schedule**:
+1. Attempt 1 — immediate
+2. Wait 1 minute (`TimeSpan.FromMinutes(1)`)
+3. Attempt 2
+4. Wait 5 minutes (`TimeSpan.FromMinutes(5)`)
+5. Attempt 3
+6. All attempts exhausted → log error, leave `recap_jobs` status as `'failed'`, leave `last_seen`/`delivery_count` unchanged
+
+**Success**: At any attempt, on confirmed SMTP success → set `recap_jobs.status = 'delivered'`, update `last_seen` and `delivery_count` on each delivered highlight.
+
+**Alternatives considered**:
+- **Polly / `Microsoft.Extensions.Resilience`**: excellent libraries, but unjustified for a fixed 3-attempt sequential retry with known delays.
+- **Quartz retry trigger**: reschedule the failed job as a new Quartz trigger. Unnecessarily complex; blurs the line between scheduling and delivery retry.
+
+---
+
+### 5. Score Formula: Age Unit
+
+**Decision**: Age measured in **whole days** (floor of elapsed time since `last_seen`)
+
+**Rationale**:
+- The spec defines `score = antiquity (time since last_seen) + weight`.
+- `weight` ranges 1–5. If age is measured in hours: a 24-hour-old highlight has age 24, and weight contributes only ~4–17% of the score — essentially irrelevant.
+- With age in days: a 1-day-old highlight scores between `1 + 1 = 2` and `1 + 5 = 6`. Weight contributes 14–83% in the first week, making the weight setting genuinely useful.
+- `last_seen = null` is treated as a "never seen" age of **3,650 days** (10 years). This ensures never-seen highlights always rank above any seen highlight regardless of weight.
+- Tiebreak (equal score): `created_at DESC` — the most recently **added** highlight wins.
+
+**Formula**:
+```csharp
+const int NeverSeenAge = 3650;
+var ageInDays = highlight.LastSeen.HasValue
+    ? (int)(now - highlight.LastSeen.Value).TotalDays
+    : NeverSeenAge;
+var score = ageInDays + highlight.Weight;
+```
+
+**Alternatives considered**:
+- **Hours**: score dominated by age alone; weight setting becomes practically meaningless.
+- **Fractional days**: adds floating-point complexity; whole-day granularity is sufficient for a daily schedule.
+- **Configurable unit**: YAGNI — the formula is clearly specified and can be revisited if needed.
+
+---
+
+### 6. Timezone Handling
+
+**Decision**: Store `timezone` (IANA identifier) alongside `delivery_time` (HH:mm) in `settings`; Quartz fires in the server's UTC using a timezone-aware trigger; all DB timestamps stored as UTC ISO 8601
+
+**Rationale**:
+- Storing only a UTC offset would break during Daylight Saving Time transitions: the stored offset would drift from the user's intended local time. IANA identifiers (e.g., `"Europe/Rome"`) correctly represent DST-aware zones.
+- `TimeZoneInfo.FindSystemTimeZoneById(ianaId)` works on .NET 10 on Linux/macOS (IANA natively) and Windows (via `TimeZoneConverter` or .NET 6+ built-in IANA support on Windows). Since the server runs on Linux (Docker), IANA works natively.
+- The server stores `delivery_time` as `HH:mm` in the user's local time and `timezone` as IANA string. At scheduling time, these two values are combined with `TimeZoneInfo` to build the Quartz trigger in the correct UTC-equivalent cron expression.
+- The client sends `timezone` via `PUT /settings`; the server validates it with `TimeZoneInfo.FindSystemTimeZoneById`.
+- All `DateTimeOffset` values in the DB are stored as UTC ISO 8601 strings (consistent with existing schema).
+
+**Quartz timezone configuration**:
+```csharp
+var tz = TimeZoneInfo.FindSystemTimeZoneById(settings.Timezone); // e.g., "Europe/Rome"
+var trigger = TriggerBuilder.Create()
+    .WithCronSchedule($"0 {minute} {hour} * * ?",
+        x => x.InTimeZone(tz))
+    .Build();
+```
+
+**FR alignment**: FR-005-16 ("persist UTC values") is satisfied by persisting all execution timestamps (`scheduled_for`, `delivered_at`) as UTC in `recap_jobs`. The user's schedule preference itself is stored as a local-time intent (`delivery_time` + `timezone`), which is the canonical representation.
+
+**Alternatives considered**:
+- **Convert to UTC offset and store**: breaks on DST change; user's intended "18:00" becomes wrong time.
+- **Store UTC HH:mm**: same problem — UTC HH:mm drifts from local intent across DST.
+- **Client sends full UTC datetime**: requires the client to know the server's scheduling logic; not appropriate.
+
+---
+
+### 7. recap_jobs Table Design
+
+**Decision**: Dedicated `recap_jobs` table with unique index on `(user_id, scheduled_for)` for idempotency
+
+**Rationale**:
+- Provides the deduplication anchor for "duplicate trigger after restart or clock drift" (spec edge case).
+- Acts as the recap history store for `GET /status` (`LastRecapStatus`, `LastRecapError`, `NextRecap` derivation).
+- Pre-flight check: before executing, `RecapJob` queries for `status = 'delivered'` on the current slot. If found, it skips execution. If a `'pending'` row exists (previous run crashed mid-execution), it proceeds (idempotent re-execution is safe because history updates only occur post-delivery).
+- A unique index on `(user_id, scheduled_for)` prevents double-insertion.
+- Minimal column set: `id`, `user_id`, `scheduled_for`, `status`, `attempt_count`, `error_message`, `created_at`, `delivered_at`.
+
+**Alternatives considered**:
+- **In-memory set of executed slots**: lost on restart — does not solve the restart race condition.
+- **Quartz persistent store misfire handling**: handles missed triggers but doesn't provide a clean user-visible history; adds complexity.
+
+---
+
+### 8. Testing Strategy
+
+**Decision**: Unit tests for selection service and EPUB composer; `WebApplicationFactory`-based integration tests for settings/status endpoint changes; `IMailDeliveryService` interface for SMTP substitution in tests
+
+**Rationale**:
+- **Selection**: deterministic algorithm + DB interaction → integration test using in-memory SQLite (same `TestWebApplicationFactory` pattern as feature 004); seed known data, verify score ranking and tiebreak.
+- **EPUB**: pure function (highlights → byte[]) → unit tests; verify ZIP structure, required EPUB files, and highlight/source text content.
+- **Delivery + retry**: `IMailDeliveryService` interface allows injecting a fake that throws on the first N calls, then succeeds; verify attempt count and history update behavior.
+- **Scheduler**: verify `GetNextFireTimeAsync` returns a value close to the expected UTC slot after `ScheduleAsync` is called; avoid testing actual Quartz clock firing (brittle).
+- **Settings/Status endpoints**: extend existing `SettingsEndpointTests` / `StatusEndpointTests` in `SunnySunday.Tests` with new test cases for `timezone` and `LastRecapStatus`/`LastRecapError` fields.
+
+**Alternatives considered**:
+- **Testing actual Quartz firing**: requires wall-clock waiting or virtual-time injection; too brittle for CI.
+- **MailKit test server**: MailKit provides a `MockSmtpClient` in its test utilities, but the `IMailDeliveryService` abstraction is simpler and sufficient.

--- a/specs/005-scheduler-recap-engine/research.md
+++ b/specs/005-scheduler-recap-engine/research.md
@@ -71,7 +71,7 @@ Each highlight item in `highlights.xhtml` renders as:
 - MailKit is explicitly listed in the project stack (`docs/ARCHITECTURE.md`). It provides full SMTP support including STARTTLS, OAUTH2, and modern authentication — significantly more reliable than the deprecated .NET BCL `SmtpClient`.
 - SMTP credentials (host, port, username, password, from address) are **server-side operational configuration**, not user preferences. They must **not** be stored in the SQLite DB. They belong in `appsettings.json` with environment variable overrides.
 - The Kindle recipient email (`users.kindle_email`) is stored in SQLite — it is user data, not server config.
-- `IOptions<SmtpSettings>` is the standard .NET options pattern; environment variables override with double-underscore separator (`Smtp__Host`) — standard Docker-compose pattern.
+- `IOptions<SmtpSettings>` remains the binding target, while startup code maps variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM_ADDRESS`, `SMTP_USE_SSL`) into the options model.
 - `IMailDeliveryService` abstracts MailKit for testability. Tests inject a fake implementation; production registers `MailDeliveryService`.
 
 **SmtpSettings configuration keys** (in `appsettings.json` / env vars):
@@ -84,6 +84,16 @@ Smtp:FromAddress  (required)
 Smtp:UseSsl       (default: true)
 ```
 
+**Compatible environment variable names**:
+```
+SMTP_HOST
+SMTP_PORT
+SMTP_USER
+SMTP_PASSWORD
+SMTP_FROM_ADDRESS
+SMTP_USE_SSL
+```
+
 **Alternatives considered**:
 - **.NET BCL `SmtpClient`**: deprecated since .NET Core 2.0; lacks modern auth support; documented as not recommended by Microsoft.
 - **SendGrid / Mailgun SDK**: external cloud services — violates constitution principle IV (local processing only, no third-party data transmission).
@@ -92,26 +102,23 @@ Smtp:UseSsl       (default: true)
 
 ### 4. Retry Policy: Polly vs Manual Loop
 
-**Decision**: Manual retry loop with `await Task.Delay(...)` — no new NuGet package
+**Decision**: Polly retry policy with exponential backoff and a maximum of 3 attempts total
 
 **Rationale**:
-- The retry spec is fixed and simple: 3 total attempts, wait 1 minute between attempt 1 and 2, wait 5 minutes between attempt 2 and 3.
-- A manual loop with `Task.Delay` is approximately 20 lines and carries no library dependency.
-- Polly (or `Microsoft.Extensions.Resilience`) is appropriate when retry rules are configurable, need circuit-breaking, or must be shared across many call sites. None apply here.
-- Constitution principle VI: do not add a library for something achievable in 20 lines.
+- The retry requirement explicitly calls for exponential behavior without hardcoded wait values in application code.
+- Polly expresses retry concerns declaratively, computes exponential delays inside the policy, and keeps the orchestration flow focused on delivery success/failure handling.
+- A single local retry policy is still small in scope and avoids open-coded delay math scattered through the recap service.
+- This keeps room for logging the computed delay per attempt without coupling the implementation to fixed literal schedules in the spec.
 
-**Retry schedule**:
-1. Attempt 1 — immediate
-2. Wait 1 minute (`TimeSpan.FromMinutes(1)`)
-3. Attempt 2
-4. Wait 5 minutes (`TimeSpan.FromMinutes(5)`)
-5. Attempt 3
-6. All attempts exhausted → log error, leave `recap_jobs` status as `'failed'`, leave `last_seen`/`delivery_count` unchanged
+**Retry behavior**:
+1. Attempt 1 starts immediately.
+2. Attempts 2 and 3 are governed by Polly exponential backoff.
+3. After the third failed attempt, log error, leave `recap_jobs` status as `'failed'`, and leave `last_seen`/`delivery_count` unchanged.
 
 **Success**: At any attempt, on confirmed SMTP success → set `recap_jobs.status = 'delivered'`, update `last_seen` and `delivery_count` on each delivered highlight.
 
 **Alternatives considered**:
-- **Polly / `Microsoft.Extensions.Resilience`**: excellent libraries, but unjustified for a fixed 3-attempt sequential retry with known delays.
+- **Manual retry loop with `Task.Delay`**: would require the service to own delay calculation and pushes exponential timing details into application code.
 - **Quartz retry trigger**: reschedule the failed job as a new Quartz trigger. Unnecessarily complex; blurs the line between scheduling and delivery retry.
 
 ---

--- a/specs/005-scheduler-recap-engine/spec.md
+++ b/specs/005-scheduler-recap-engine/spec.md
@@ -91,7 +91,7 @@ A user receives a Kindle-friendly EPUB recap rendered as a flat list of highligh
 - **FR-005-08**: System MUST render recap as a flat list where each item contains highlight text and source metadata.
 - **FR-005-09**: System MUST send recap via configured SMTP pipeline.
 - **FR-005-10**: System MUST apply automatic retries on failed delivery attempts.
-- **FR-005-11**: System MUST use retry policy: maximum 3 attempts total, exponential backoff (1m, 5m).
+- **FR-005-11**: System MUST use Polly retry policy with a maximum of 3 attempts total and exponential backoff computed by the policy rather than fixed delay values in application code.
 - **FR-005-12**: System MUST update `last_seen` and `delivery_count` only after confirmed successful delivery.
 - **FR-005-13**: System MUST NOT update recap history when delivery fails permanently.
 - **FR-005-14**: System MUST expose actionable failure reasons for exhausted retries (US-08 alignment).

--- a/specs/005-scheduler-recap-engine/tasks.md
+++ b/specs/005-scheduler-recap-engine/tasks.md
@@ -1,0 +1,207 @@
+# Tasks: Scheduler + Recap Engine
+
+**Input**: Design documents from `/specs/005-scheduler-recap-engine/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included — xUnit service tests and ASP.NET integration tests are part of this feature per the design docs and repository conventions.
+
+**Organization**: Tasks are grouped by user story so each slice stays independently testable after the shared foundation is in place.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: Which user story the task belongs to (`US1`, `US2`, `US3`, `US4`)
+- All file paths are relative to the repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add the shared and server-side dependencies needed for scheduling, SMTP delivery, and retries.
+
+- [ ] T001 Create `src/PackageVersions.props` to declare `Polly` once for both client and server, then update `src/SunnySunday.Cli/SunnySunday.Cli.csproj` and `src/SunnySunday.Server/SunnySunday.Server.csproj` to consume that shared `Polly` version while adding `Quartz.Extensions.Hosting` and `MailKit` to the server; verify the solution still builds from `src/SunnySunday.slnx`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared schema, contracts, configuration, and test-harness changes required by every user story.
+
+**⚠️ CRITICAL**: No user story work should start until this phase is complete.
+
+- [ ] T002 Update `src/SunnySunday.Server/Infrastructure/Database/SchemaBootstrap.cs` to add the `recap_jobs` table and unique slot index, plus an idempotent `timezone` migration for the `settings` table in both sync and async bootstrap paths.
+- [ ] T003 [P] Update `src/SunnySunday.Server/Models/Settings.cs` and `src/SunnySunday.Server/Data/SettingsRepository.cs` to persist `Timezone` with a default of `UTC` alongside the existing schedule fields.
+- [ ] T004 [P] Create `src/SunnySunday.Server/Models/RecapJobRecord.cs`, `src/SunnySunday.Server/Services/SelectionCandidate.cs`, and `src/SunnySunday.Server/Data/RecapRepository.cs` for recap slot persistence, last-job lookup, candidate reads, and post-delivery highlight history updates.
+- [ ] T005 [P] Update `src/SunnySunday.Core/Contracts/SettingsResponse.cs`, `src/SunnySunday.Core/Contracts/UpdateSettingsRequest.cs`, and `src/SunnySunday.Core/Contracts/StatusResponse.cs` to add `Timezone`, `LastRecapStatus`, and `LastRecapError` contract fields.
+- [ ] T006 [P] Create `src/SunnySunday.Server/Infrastructure/Smtp/SmtpSettings.cs` and update `src/SunnySunday.Server/appsettings.json` plus `src/SunnySunday.Server/appsettings.Development.json` with `Smtp` settings for `Host`, `Port`, `Username`, `Password`, `FromAddress`, and `UseSsl` so `FromAddress` remains explicit in server configuration.
+- [ ] T007 Update `src/SunnySunday.Server/Program.cs` to bind `SmtpSettings` from configuration and map the README-source environment variables `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM_ADDRESS`, and `SMTP_USE_SSL` onto that options model before feature service registration.
+- [ ] T008 Update `src/SunnySunday.Tests/Api/SunnyTestApplicationFactory.cs` to apply the new schema shape in-memory and support replacing recap pipeline services during scheduler and delivery integration tests.
+
+**Checkpoint**: Schema, contracts, SMTP config binding, and shared test plumbing are ready. User stories can now proceed in dependency order.
+
+---
+
+## Phase 3: User Story 1 - Automatic Recap Scheduling (Priority: P1)
+
+**Goal**: Persist schedule timezone data, compute the next recap deterministically, and trigger the recap pipeline exactly once per scheduled slot.
+
+**Independent Test**: Configure daily and weekly settings with a valid timezone, verify `GET /status` returns the next UTC recap time, and execute the Quartz job against a fake recap service to confirm one pipeline invocation per slot.
+
+### Tests for User Story 1
+
+- [ ] T009 [P] [US1] Extend `src/SunnySunday.Tests/Api/SettingsEndpointTests.cs` and `src/SunnySunday.Tests/Api/StatusEndpointTests.cs` to cover timezone persistence, timezone validation failures, and UTC `nextRecap` serialization.
+- [ ] T010 [P] [US1] Create `src/SunnySunday.Tests/Recap/SchedulerServiceTests.cs` to verify daily and weekly next-fire calculations, rescheduling after settings changes, and duplicate-slot behavior with deterministic inputs.
+
+### Implementation for User Story 1
+
+- [ ] T011 [P] [US1] Create `src/SunnySunday.Server/Services/IRecapService.cs` and `src/SunnySunday.Server/Jobs/RecapJob.cs` so Quartz can invoke the recap pipeline and skip slots already marked delivered in `recap_jobs`.
+- [ ] T012 [P] [US1] Create `src/SunnySunday.Server/Services/ISchedulerService.cs` and `src/SunnySunday.Server/Services/SchedulerService.cs` to translate `Settings` cadence, delivery time, and timezone into Quartz UTC triggers and expose the next fire time.
+- [ ] T013 [US1] Update `src/SunnySunday.Server/Endpoints/SettingsEndpoints.cs` and `src/SunnySunday.Server/Endpoints/StatusEndpoints.cs` to validate `Timezone`, reschedule on `PUT /settings`, and serialize `NextRecap` in UTC.
+- [ ] T014 [US1] Update `src/SunnySunday.Server/Program.cs` to register Quartz, `SchedulerService`, and `RecapJob`, and to schedule the initial trigger from persisted settings during server startup.
+
+**Checkpoint**: Scheduling is functional and independently testable with a fake recap pipeline.
+
+---
+
+## Phase 4: User Story 2 - Weighted Spaced-Repetition Selection (Priority: P1)
+
+**Goal**: Select recap candidates from non-excluded highlights using `score = age + weight`, with recent highlights winning score ties.
+
+**Independent Test**: Seed highlights with different `last_seen`, `created_at`, exclusions, and weights, run selection with a fixed clock, and verify ranking plus count capping.
+
+### Tests for User Story 2
+
+- [ ] T015 [P] [US2] Create `src/SunnySunday.Tests/Recap/HighlightSelectionServiceTests.cs` to cover age-plus-weight scoring, `last_seen = null` handling, recent-first tie breaks, exclusion filtering, and `count` limits.
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Create `src/SunnySunday.Server/Services/HighlightSelectionService.cs` to compute `ageInDays`, rank `SelectionCandidate` records from `RecapRepository.SelectCandidatesAsync`, and return the top configured highlights.
+
+**Checkpoint**: Candidate ranking is deterministic, tested, and ready for recap composition.
+
+---
+
+## Phase 5: User Story 4 - EPUB Recap Composition (Priority: P1)
+
+**Goal**: Compose a Kindle-friendly EPUB 2 document that renders recap highlights as one flat list with source metadata.
+
+**Independent Test**: Generate an EPUB from a known ordered selection and verify the ZIP structure, XHTML content, and item ordering without involving SMTP.
+
+### Tests for User Story 4
+
+- [ ] T017 [P] [US4] Create `src/SunnySunday.Tests/Recap/EpubComposerTests.cs` to verify EPUB structure, uncompressed `mimetype`, flat-list XHTML output, and source metadata rendering in input order.
+
+### Implementation for User Story 4
+
+- [ ] T018 [US4] Create `src/SunnySunday.Server/Services/EpubComposer.cs` to build an EPUB 2 archive in memory with `mimetype`, `META-INF/container.xml`, `OEBPS/content.opf`, `OEBPS/toc.ncx`, and `OEBPS/highlights.xhtml` containing a flat `<ul>` of highlights.
+
+**Checkpoint**: EPUB generation is deterministic and validated independently from scheduling and SMTP.
+
+---
+
+## Phase 6: User Story 3 - Reliable Delivery with Retries (Priority: P1)
+
+**Goal**: Deliver recap EPUBs via SMTP with Polly exponential backoff, update recap history only after confirmed success, and expose actionable failure details.
+
+**Independent Test**: Run the recap pipeline with a fake mail service that fails and succeeds in controlled patterns, then verify retry counts, final job status, and highlight history updates.
+
+### Tests for User Story 3
+
+- [ ] T019 [P] [US3] Create `src/SunnySunday.Tests/Recap/RecapServiceTests.cs` to cover immediate success, transient retry then success, exhausted retries, no-eligible-highlight skips, and single history updates after confirmed delivery.
+
+### Implementation for User Story 3
+
+- [ ] T020 [P] [US3] Create `src/SunnySunday.Server/Services/IMailDeliveryService.cs` and `src/SunnySunday.Server/Services/MailDeliveryService.cs` to send recap EPUB attachments through MailKit using `SmtpSettings.FromAddress` and the mapped SMTP environment variables.
+- [ ] T021 [P] [US3] Create `src/SunnySunday.Server/Infrastructure/Resilience/RecapDeliveryPolicy.cs` to define a Polly exponential backoff policy capped at 3 total attempts, with delay computation owned by the policy helper rather than hardcoded waits in application services.
+- [ ] T022 [US3] Create `src/SunnySunday.Server/Services/RecapService.cs` to orchestrate candidate selection, EPUB composition, `recap_jobs` persistence, SMTP delivery through the Polly policy, and post-success `last_seen` plus `delivery_count` updates.
+- [ ] T023 [US3] Update `src/SunnySunday.Server/Program.cs` and `src/SunnySunday.Server/Data/StatusRepository.cs` to register `IMailDeliveryService` and `RecapService`, and to expose `LastRecapStatus` plus `LastRecapError` from `recap_jobs` in status responses.
+
+**Checkpoint**: End-to-end recap generation and delivery are reliable, retry-aware, and auditable.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Align repo docs with the implemented behavior and verify the full feature set.
+
+- [ ] T024 [P] Update `README.md`, `docs/DX.md`, and `docs/ARCHITECTURE.md` to document the recap pipeline, `recap_jobs`, timezone-aware scheduling, and the authoritative SMTP variables `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM_ADDRESS`, and `SMTP_USE_SSL`.
+- [ ] T025 [P] Reconcile `specs/005-scheduler-recap-engine/quickstart.md` with the shipped configuration shape so local-development and Docker examples include the final SMTP settings and UTC scheduling expectations.
+- [ ] T026 Validate the feature against `specs/005-scheduler-recap-engine/quickstart.md` and run the regression suite from `src/SunnySunday.slnx`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies.
+- **Phase 2 (Foundational)**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3 (US1 Scheduling)**: Depends on Phase 2.
+- **Phase 4 (US2 Selection)**: Depends on Phase 2.
+- **Phase 5 (US4 EPUB Composition)**: Depends on Phase 2.
+- **Phase 6 (US3 Delivery + Retry)**: Depends on Phases 2, 4, and 5; it integrates with Phase 3 for live scheduled execution.
+- **Phase 7 (Polish)**: Depends on all story phases.
+
+### User Story Dependencies
+
+- **US1**: Can start as soon as the shared foundation is done; it only requires a recap-service interface, not the final delivery implementation.
+- **US2**: Can start after the foundation and is independent from scheduling and SMTP.
+- **US4**: Can start after the foundation and is independent from Quartz and SMTP when fed deterministic `SelectionCandidate` input.
+- **US3**: Requires US2 and US4 because it consumes ranked candidates and EPUB bytes; it then plugs into the US1 scheduler path.
+
+### Within Each User Story
+
+- Write or extend the story tests first.
+- Add the story-specific interfaces or models next.
+- Implement the core service behavior.
+- Finish with endpoint, DI, or orchestration wiring.
+
+### Parallel Opportunities
+
+- `T003`, `T004`, `T005`, and `T006` can run in parallel once `T002` lands.
+- `US1`, `US2`, and `US4` can proceed in parallel after Phase 2.
+- Within `US1`, `T009` and `T010` can run in parallel, then `T011` and `T012` can run in parallel before the endpoint and startup wiring.
+- Within `US3`, `T019`, `T020`, and `T021` can run in parallel before `T022` integrates them.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+T009 ──┐
+       ├──► T011 ──┐
+T010 ──┘           ├──► T013 ───► T014
+T012 ──────────────┘
+```
+
+## Parallel Example: User Story 3
+
+```text
+T019 ──┐
+T020 ──┼──► T022 ───► T023
+T021 ──┘
+```
+
+---
+
+## Implementation Strategy
+
+### Incremental Delivery
+
+1. Complete Setup and Foundational work to unblock all later slices.
+2. Land US1 with a fake recap-service dependency to prove scheduler correctness and status exposure.
+3. Land US2 and US4 in either order to finish deterministic selection and EPUB generation.
+4. Land US3 to make recap delivery live with retry semantics and history updates.
+5. Finish with doc alignment and full quickstart plus regression validation.
+
+### Suggested MVP Scope
+
+For this feature, the smallest demonstrable increment is **Phase 1 + Phase 2 + US1** for scheduler correctness. The smallest end-to-end recap-delivery slice is **US1 + US2 + US4 + US3** because all four stories are required for an actual delivered recap.
+
+---
+
+## Notes
+
+- All SMTP configuration work should preserve `FromAddress` inside `SmtpSettings`; it is not derived from `Username`.
+- The README-style environment variable names are the source of truth for server config mapping.
+- Retry logic must use Polly exponential backoff with a maximum of 3 total attempts and no inline fixed-delay waits in application code.


### PR DESCRIPTION
Adds the complete design artifact set for feature 005, covering the scheduler and recap engine scope before implementation begins.

- add the feature specification, research, data model, implementation plan, quickstart, and task breakdown under `specs/005-scheduler-recap-engine/`
- align the design with explicit SMTP sender configuration, README-style SMTP environment variables, and Polly-based retry behavior
- capture implementation-ready user stories and dependency-ordered tasks for the follow-up execution work

Closes #101