### PR TITLE
[Feature 006] Implement config count command (US3)

### DIFF
--- a/specs/006-client-cli/tasks.md
+++ b/specs/006-client-cli/tasks.md
@@ -125,12 +125,12 @@
 
 ### Tests for User Story 3
 
-- [ ] T019 [P] [US3] Add count tests to `src/SunnySunday.Tests/Cli/ConfigCommandTests.cs` covering: `config count 10` sends correct PUT, `config count 0` triggers validation error, `config count 20` triggers validation error, `config count show` fetches current count.
+- [X] T019 [P] [US3] Add count tests to `src/SunnySunday.Tests/Cli/ConfigCommandTests.cs` covering: `config count 10` sends correct PUT, `config count 0` triggers validation error, `config count 20` triggers validation error, `config count show` fetches current count.
 
 ### Implementation for User Story 3
 
-- [ ] T020 [US3] Create `src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs` as `AsyncCommand<Settings>`: validate count is integer 1–15, handle "show" subpath, send `PUT /settings` with `Count`, display confirmation.
-- [ ] T021 [US3] Register `count` subcommand under the `config` branch in `src/SunnySunday.Cli/Program.cs`.
+- [X] T020 [US3] Create `src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs` as `AsyncCommand<Settings>`: validate count is integer 1–15, handle "show" subpath, send `PUT /settings` with `Count`, display confirmation.
+- [X] T021 [US3] Register `count` subcommand under the `config` branch in `src/SunnySunday.Cli/Program.cs`.
 
 **Checkpoint**: Count configuration works with range validation. Tests pass.
 

--- a/src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;

--- a/src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Cli.Commands.Config;
+
+/// <summary>
+/// Configures the number of highlights per recap on the server.
+/// Usage: sunny config count &lt;value&gt;   (1–15)
+///        sunny config count show
+/// </summary>
+public sealed class ConfigCountCommand(SunnyHttpClient client, ILogger<ConfigCountCommand> logger)
+    : AsyncCommand<ConfigCountCommand.Settings>
+{
+    public sealed class Settings : LogCommandSettings
+    {
+        [CommandArgument(0, "<value>")]
+        [Description("Number of highlights per recap (1–15), or 'show' to display current count.")]
+        public string Value { get; set; } = string.Empty;
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        if (settings.Value.Equals("show", StringComparison.OrdinalIgnoreCase))
+        {
+            return await ShowCountAsync(cancellation);
+        }
+
+        return await SetCountAsync(settings, cancellation);
+    }
+
+    private async Task<int> ShowCountAsync(CancellationToken cancellation)
+    {
+        logger.LogDebug("Fetching current highlight count from server");
+
+        SettingsResponse response;
+        try
+        {
+            response = await client.GetSettingsAsync(cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        AnsiConsole.MarkupLine($"Highlights per recap: [bold]{response.Count}[/]");
+        return 0;
+    }
+
+    private async Task<int> SetCountAsync(Settings settings, CancellationToken cancellation)
+    {
+        if (!int.TryParse(settings.Value, out var count))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] [yellow]{settings.Value}[/] is not a valid number.");
+            return 1;
+        }
+
+        if (count < 1 || count > 15)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Count must be between [green]1[/] and [green]15[/] (got [yellow]{count}[/]).");
+            return 1;
+        }
+
+        logger.LogDebug("Setting highlight count to {Count}", count);
+
+        var request = new UpdateSettingsRequest { Count = count };
+
+        SettingsResponse response;
+        try
+        {
+            response = await client.PutSettingsAsync(request, cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        AnsiConsole.MarkupLine($"[green]✓[/] Highlights per recap set to [bold]{response.Count}[/]");
+        return 0;
+    }
+
+    private int HandleServerError(HttpRequestException ex)
+    {
+        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
+        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
+        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
+        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
+        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
+        return 1;
+    }
+}

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -66,6 +66,8 @@ app.Configure(config =>
         cfg.SetDescription("Manage server settings.");
         cfg.AddCommand<ConfigScheduleCommand>("schedule")
             .WithDescription("Configure recap schedule (cadence and time).");
+        cfg.AddCommand<ConfigCountCommand>("count")
+            .WithDescription("Configure number of highlights per recap.");
     });
 });
 

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/ConfigCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/ConfigCommandTests.cs
@@ -116,4 +116,95 @@ public sealed class ConfigCommandTests : IDisposable
         var fullArgs = new[] { "config", "schedule" }.Concat(args).ToArray();
         return await app.RunAsync(fullArgs);
     }
+
+    [Fact]
+    public async Task ConfigCount_ValidCount_SendsPut()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Respond("application/json", """
+                {"schedule":"daily","deliveryDay":null,"deliveryTime":"08:00","count":10,"kindleEmail":"test@kindle.com","timezone":"Europe/Rome"}
+                """);
+
+        var exitCode = await RunConfigCountCommand("10");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ConfigCount_Zero_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Respond("application/json", "{}");
+
+        var exitCode = await RunConfigCountCommand("0");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ConfigCount_TwentyExceedsMax_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Respond("application/json", "{}");
+
+        var exitCode = await RunConfigCountCommand("20");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ConfigCount_Show_FetchesCurrentCount()
+    {
+        var handler = _mockHttp.When(HttpMethod.Get, "http://localhost:5000/settings")
+            .Respond("application/json", """
+                {"schedule":"daily","deliveryDay":null,"deliveryTime":"08:00","count":5,"kindleEmail":"test@kindle.com","timezone":"Europe/Rome"}
+                """);
+
+        var exitCode = await RunConfigCountCommand("show");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ConfigCount_ServerUnreachable_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var exitCode = await RunConfigCountCommand("10");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    private async Task<int> RunConfigCountCommand(params string[] args)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddTransient(_ =>
+        {
+            var httpClient = _mockHttp.ToHttpClient();
+            httpClient.BaseAddress = new Uri("http://localhost:5000");
+            return new SunnyHttpClient(httpClient);
+        });
+
+        var registrar = new TypeRegistrar(services);
+        var app = new CommandApp(registrar);
+
+        app.Configure(config =>
+        {
+            config.SetApplicationName("sunny");
+            config.AddBranch("config", cfg =>
+            {
+                cfg.AddCommand<ConfigCountCommand>("count");
+            });
+        });
+
+        var fullArgs = new[] { "config", "count" }.Concat(args).ToArray();
+        return await app.RunAsync(fullArgs);
+    }
 }


### PR DESCRIPTION
## Summary

Implements US3 (Configure Highlight Count) from the Client CLI feature.

### `sunny config count`
- `sunny config count <1-15>` — validates range locally, sends PUT /settings with count
- `sunny config count show` — fetches and displays current highlight count
- Out-of-range or non-numeric values rejected before any HTTP call
- Structured logging via `ILogger<ConfigCountCommand>`

### Tests (5 new)
- Valid count (10) sends PUT
- Zero returns exit 1 without HTTP call
- Twenty returns exit 1 without HTTP call
- Show fetches settings via GET
- Server unreachable returns exit 1

**116 tests pass** (111 existing + 5 new).

Closes #129