### PR TITLE
[Feature 006] Implement exclude commands (US5)

### DIFF
--- a/specs/006-client-cli/tasks.md
+++ b/specs/006-client-cli/tasks.md
@@ -163,14 +163,14 @@
 
 ### Tests for User Story 5
 
-- [ ] T025 [P] [US5] Create `src/SunnySunday.Tests/Cli/ExcludeCommandTests.cs` covering: `exclude highlight 5` sends POST, `exclude remove book 3` sends DELETE, `exclude list` displays grouped table, server 404 displays not-found error.
+- [X] T025 [P] [US5] Create `src/SunnySunday.Tests/Cli/ExcludeCommandTests.cs` covering: `exclude highlight 5` sends POST, `exclude remove book 3` sends DELETE, `exclude list` displays grouped table, server 404 displays not-found error.
 
 ### Implementation for User Story 5
 
-- [ ] T026 [P] [US5] Create `src/SunnySunday.Cli/Commands/Exclude/ExcludeAddCommand.cs` as `AsyncCommand<Settings>`: validate type (highlight/book/author), parse id, call `PostExcludeAsync`, handle 404, display confirmation.
-- [ ] T027 [P] [US5] Create `src/SunnySunday.Cli/Commands/Exclude/ExcludeRemoveCommand.cs` as `AsyncCommand<Settings>`: validate type, parse id, call `DeleteExcludeAsync`, display confirmation or error.
-- [ ] T028 [P] [US5] Create `src/SunnySunday.Cli/Commands/Exclude/ExcludeListCommand.cs` as `AsyncCommand`: call `GetExclusionsAsync`, display three grouped tables (Highlights, Books, Authors) with "None" for empty groups.
-- [ ] T029 [US5] Register exclude commands in the command tree: `exclude` branch with default add, `remove` subcommand, and `list` subcommand in `src/SunnySunday.Cli/Program.cs`.
+- [X] T026 [P] [US5] Create `src/SunnySunday.Cli/Commands/Exclude/ExcludeAddCommand.cs` as `AsyncCommand<Settings>`: validate type (highlight/book/author), parse id, call `PostExcludeAsync`, handle 404, display confirmation.
+- [X] T027 [P] [US5] Create `src/SunnySunday.Cli/Commands/Exclude/ExcludeRemoveCommand.cs` as `AsyncCommand<Settings>`: validate type, parse id, call `DeleteExcludeAsync`, display confirmation or error.
+- [X] T028 [P] [US5] Create `src/SunnySunday.Cli/Commands/Exclude/ExcludeListCommand.cs` as `AsyncCommand`: call `GetExclusionsAsync`, display three grouped tables (Highlights, Books, Authors) with "None" for empty groups.
+- [X] T029 [US5] Register exclude commands in the command tree: `exclude` branch with default add, `remove` subcommand, and `list` subcommand in `src/SunnySunday.Cli/Program.cs`.
 
 **Checkpoint**: Exclude commands work. Tests pass.
 

--- a/src/SunnySunday.Cli/Commands/Exclude/ExcludeAddCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Exclude/ExcludeAddCommand.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Cli.Commands.Exclude;
+
+/// <summary>
+/// Excludes a highlight, book, or author from future recaps.
+/// Usage: sunny exclude highlight|book|author &lt;id&gt;
+/// </summary>
+public sealed class ExcludeAddCommand(SunnyHttpClient client, ILogger<ExcludeAddCommand> logger)
+    : AsyncCommand<ExcludeAddCommand.Settings>
+{
+    private static readonly string[] ValidTypes = ["highlight", "book", "author"];
+
+    public sealed class Settings : LogCommandSettings
+    {
+        [CommandArgument(0, "<type>")]
+        [Description("Entity type to exclude: highlight, book, or author.")]
+        public string Type { get; set; } = string.Empty;
+
+        [CommandArgument(1, "<id>")]
+        [Description("ID of the entity to exclude.")]
+        public int Id { get; set; }
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var type = settings.Type.ToLowerInvariant();
+
+        if (!ValidTypes.Contains(type))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Invalid type [yellow]{settings.Type}[/]. Use [green]highlight[/], [green]book[/], or [green]author[/].");
+            return 1;
+        }
+
+        logger.LogDebug("Excluding {Type} with ID {Id}", type, settings.Id);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.PostExcludeAsync(type, settings.Id, cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {type} with ID [yellow]{settings.Id}[/] not found.");
+            return 1;
+        }
+
+        response.EnsureSuccessStatusCode();
+        AnsiConsole.MarkupLine($"[green]✓[/] Excluded {type} [bold]{settings.Id}[/] from future recaps.");
+        return 0;
+    }
+
+    private int HandleServerError(HttpRequestException ex)
+    {
+        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
+        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
+        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
+        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
+        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
+        return 1;
+    }
+}

--- a/src/SunnySunday.Cli/Commands/Exclude/ExcludeListCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Exclude/ExcludeListCommand.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Cli.Commands.Exclude;
+
+/// <summary>
+/// Lists all current exclusions grouped by type.
+/// Usage: sunny exclude list
+/// </summary>
+public sealed class ExcludeListCommand(SunnyHttpClient client, ILogger<ExcludeListCommand> logger)
+    : AsyncCommand<ExcludeListCommand.Settings>
+{
+    public sealed class Settings : LogCommandSettings;
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        logger.LogDebug("Fetching exclusions from server");
+
+        Core.Contracts.ExclusionsResponse response;
+        try
+        {
+            response = await client.GetExclusionsAsync(cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
+            logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
+            AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
+            AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
+            AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine("[bold]Excluded Highlights[/]");
+        if (response.Highlights.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]None[/]");
+        }
+        else
+        {
+            var table = new Table().Border(TableBorder.Rounded);
+            table.AddColumn("ID");
+            table.AddColumn("Text");
+            table.AddColumn("Book");
+            foreach (var h in response.Highlights)
+                table.AddRow(h.Id.ToString(), Markup.Escape(h.Text), Markup.Escape(h.BookTitle));
+            AnsiConsole.Write(table);
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[bold]Excluded Books[/]");
+        if (response.Books.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]None[/]");
+        }
+        else
+        {
+            var table = new Table().Border(TableBorder.Rounded);
+            table.AddColumn("ID");
+            table.AddColumn("Title");
+            table.AddColumn("Author");
+            table.AddColumn("Highlights");
+            foreach (var b in response.Books)
+                table.AddRow(b.Id.ToString(), Markup.Escape(b.Title), Markup.Escape(b.AuthorName), b.HighlightCount.ToString());
+            AnsiConsole.Write(table);
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[bold]Excluded Authors[/]");
+        if (response.Authors.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]None[/]");
+        }
+        else
+        {
+            var table = new Table().Border(TableBorder.Rounded);
+            table.AddColumn("ID");
+            table.AddColumn("Name");
+            table.AddColumn("Books");
+            foreach (var a in response.Authors)
+                table.AddRow(a.Id.ToString(), Markup.Escape(a.Name), a.BookCount.ToString());
+            AnsiConsole.Write(table);
+        }
+
+        return 0;
+    }
+}

--- a/src/SunnySunday.Cli/Commands/Exclude/ExcludeRemoveCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Exclude/ExcludeRemoveCommand.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Cli.Commands.Exclude;
+
+/// <summary>
+/// Removes an exclusion so the entity appears in future recaps again.
+/// Usage: sunny exclude remove highlight|book|author &lt;id&gt;
+/// </summary>
+public sealed class ExcludeRemoveCommand(SunnyHttpClient client, ILogger<ExcludeRemoveCommand> logger)
+    : AsyncCommand<ExcludeRemoveCommand.Settings>
+{
+    private static readonly string[] ValidTypes = ["highlight", "book", "author"];
+
+    public sealed class Settings : LogCommandSettings
+    {
+        [CommandArgument(0, "<type>")]
+        [Description("Entity type to un-exclude: highlight, book, or author.")]
+        public string Type { get; set; } = string.Empty;
+
+        [CommandArgument(1, "<id>")]
+        [Description("ID of the entity to un-exclude.")]
+        public int Id { get; set; }
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var type = settings.Type.ToLowerInvariant();
+
+        if (!ValidTypes.Contains(type))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Invalid type [yellow]{settings.Type}[/]. Use [green]highlight[/], [green]book[/], or [green]author[/].");
+            return 1;
+        }
+
+        logger.LogDebug("Removing exclusion for {Type} with ID {Id}", type, settings.Id);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.DeleteExcludeAsync(type, settings.Id, cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {type} with ID [yellow]{settings.Id}[/] not found.");
+            return 1;
+        }
+
+        response.EnsureSuccessStatusCode();
+        AnsiConsole.MarkupLine($"[green]✓[/] Removed exclusion for {type} [bold]{settings.Id}[/].");
+        return 0;
+    }
+
+    private int HandleServerError(HttpRequestException ex)
+    {
+        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
+        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
+        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
+        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
+        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
+        return 1;
+    }
+}

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -6,6 +6,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using SunnySunday.Cli.Commands;
 using SunnySunday.Cli.Commands.Config;
+using SunnySunday.Cli.Commands.Exclude;
 using SunnySunday.Cli.Infrastructure;
 
 var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER");
@@ -70,6 +71,17 @@ app.Configure(config =>
             .WithDescription("Configure number of highlights per recap.");
         cfg.AddCommand<ConfigShowCommand>("show")
             .WithDescription("Display all current settings.");
+    });
+
+    config.AddBranch("exclude", exc =>
+    {
+        exc.SetDescription("Manage exclusions from recaps.");
+        exc.AddCommand<ExcludeAddCommand>("add")
+            .WithDescription("Exclude a highlight, book, or author from recaps.");
+        exc.AddCommand<ExcludeRemoveCommand>("remove")
+            .WithDescription("Remove an exclusion.");
+        exc.AddCommand<ExcludeListCommand>("list")
+            .WithDescription("List all current exclusions.");
     });
 });
 

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/ExcludeCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/ExcludeCommandTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using RichardSzalay.MockHttp;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Commands.Exclude;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Tests.Cli;
+
+public sealed class ExcludeCommandTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _mockHttp = new();
+
+    public void Dispose() => _mockHttp.Dispose();
+
+    [Fact]
+    public async Task ExcludeAdd_Highlight_SendsPost()
+    {
+        var handler = _mockHttp.When(HttpMethod.Post, "http://localhost:5000/highlights/5/exclude")
+            .Respond(HttpStatusCode.OK);
+
+        var exitCode = await RunExcludeCommand("add", "highlight", "5");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ExcludeAdd_InvalidType_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Post, "*")
+            .Respond(HttpStatusCode.OK);
+
+        var exitCode = await RunExcludeCommand("add", "chapter", "5");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ExcludeAdd_NotFound_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Post, "http://localhost:5000/highlights/999/exclude")
+            .Respond(HttpStatusCode.NotFound);
+
+        var exitCode = await RunExcludeCommand("add", "highlight", "999");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task ExcludeRemove_Book_SendsDelete()
+    {
+        var handler = _mockHttp.When(HttpMethod.Delete, "http://localhost:5000/books/3/exclude")
+            .Respond(HttpStatusCode.OK);
+
+        var exitCode = await RunExcludeCommand("remove", "book", "3");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ExcludeRemove_NotFound_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Delete, "http://localhost:5000/authors/99/exclude")
+            .Respond(HttpStatusCode.NotFound);
+
+        var exitCode = await RunExcludeCommand("remove", "author", "99");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task ExcludeList_DisplaysGroupedTables()
+    {
+        var handler = _mockHttp.When(HttpMethod.Get, "http://localhost:5000/exclusions")
+            .Respond("application/json", """
+                {
+                    "highlights": [{"id":1,"text":"Some highlight","bookTitle":"Clean Code"}],
+                    "books": [{"id":2,"title":"Bad Book","authorName":"Unknown","highlightCount":5}],
+                    "authors": []
+                }
+                """);
+
+        var exitCode = await RunExcludeCommand("list");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task ExcludeList_ServerUnreachable_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Get, "http://localhost:5000/exclusions")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var exitCode = await RunExcludeCommand("list");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task ExcludeAdd_ServerUnreachable_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Post, "http://localhost:5000/highlights/5/exclude")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var exitCode = await RunExcludeCommand("add", "highlight", "5");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    private async Task<int> RunExcludeCommand(params string[] args)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddTransient(_ =>
+        {
+            var httpClient = _mockHttp.ToHttpClient();
+            httpClient.BaseAddress = new Uri("http://localhost:5000");
+            return new SunnyHttpClient(httpClient);
+        });
+
+        var registrar = new TypeRegistrar(services);
+        var app = new CommandApp(registrar);
+
+        app.Configure(config =>
+        {
+            config.SetApplicationName("sunny");
+            config.AddBranch("exclude", exc =>
+            {
+                exc.AddCommand<ExcludeAddCommand>("add");
+                exc.AddCommand<ExcludeRemoveCommand>("remove");
+                exc.AddCommand<ExcludeListCommand>("list");
+            });
+        });
+
+        var fullArgs = new[] { "exclude" }.Concat(args).ToArray();
+        return await app.RunAsync(fullArgs);
+    }
+}


### PR DESCRIPTION
## Summary

Implements US5 (Manage Exclusions) from the Client CLI feature.

### Commands
- `sunny exclude add highlight|book|author <id>` — POST to exclusion endpoint, validates type, handles 404
- `sunny exclude remove highlight|book|author <id>` — DELETE exclusion, validates type, handles 404
- `sunny exclude list` — GET /exclusions, displays 3 grouped Spectre tables (Highlights, Books, Authors) with "None" for empty groups

All commands use `LogCommandSettings` + `ILogger<T>` for structured logging. User content is escaped via `Markup.Escape()`.

### Tests (8 new)
- Add highlight sends POST
- Invalid type returns exit 1 without HTTP call
- Add 404 returns exit 1
- Remove book sends DELETE
- Remove 404 returns exit 1
- List displays grouped tables
- List server unreachable returns exit 1
- Add server unreachable returns exit 1

**126 tests pass** (118 existing + 8 new).

Closes #131