### PR TITLE
Refactor: extract HandleServerError into ServerCommand<T> base class

### DIFF
--- a/src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigCountCommand.cs
@@ -13,8 +13,10 @@ namespace SunnySunday.Cli.Commands.Config;
 ///        sunny config count show
 /// </summary>
 public sealed class ConfigCountCommand(SunnyHttpClient client, ILogger<ConfigCountCommand> logger)
-    : AsyncCommand<ConfigCountCommand.Settings>
+    : ServerCommand<ConfigCountCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     public sealed class Settings : LogCommandSettings
     {
         [CommandArgument(0, "<value>")]
@@ -82,13 +84,4 @@ public sealed class ConfigCountCommand(SunnyHttpClient client, ILogger<ConfigCou
         return 0;
     }
 
-    private int HandleServerError(HttpRequestException ex)
-    {
-        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-        return 1;
-    }
 }

--- a/src/SunnySunday.Cli/Commands/Config/ConfigScheduleCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigScheduleCommand.cs
@@ -14,8 +14,10 @@ namespace SunnySunday.Cli.Commands.Config;
 ///        sunny config schedule show
 /// </summary>
 public sealed partial class ConfigScheduleCommand(SunnyHttpClient client, ILogger<ConfigScheduleCommand> logger)
-    : AsyncCommand<ConfigScheduleCommand.Settings>
+    : ServerCommand<ConfigScheduleCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     private static readonly string[] ValidCadences = ["daily", "weekly"];
 
     public sealed class Settings : LogCommandSettings
@@ -111,16 +113,6 @@ public sealed partial class ConfigScheduleCommand(SunnyHttpClient client, ILogge
 
         AnsiConsole.MarkupLine($"[green]✓[/] Schedule set to [bold]{response.Schedule}[/] at [bold]{response.DeliveryTime}[/] ({response.Timezone})");
         return 0;
-    }
-
-    private int HandleServerError(HttpRequestException ex)
-    {
-        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-        return 1;
     }
 
     [GeneratedRegex(@"^(?:[01]\d|2[0-3]):[0-5]\d$")]

--- a/src/SunnySunday.Cli/Commands/Config/ConfigShowCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigShowCommand.cs
@@ -11,8 +11,10 @@ namespace SunnySunday.Cli.Commands.Config;
 /// Usage: sunny config show
 /// </summary>
 public sealed class ConfigShowCommand(SunnyHttpClient client, ILogger<ConfigShowCommand> logger)
-    : AsyncCommand<ConfigShowCommand.Settings>
+    : ServerCommand<ConfigShowCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     public sealed class Settings : LogCommandSettings;
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
@@ -26,12 +28,7 @@ public sealed class ConfigShowCommand(SunnyHttpClient client, ILogger<ConfigShow
         }
         catch (HttpRequestException ex)
         {
-            var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-            logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-            AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-            AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-            AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-            return 1;
+            return HandleServerError(ex);
         }
 
         var table = new Table().Border(TableBorder.Rounded);

--- a/src/SunnySunday.Cli/Commands/Exclude/ExcludeAddCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Exclude/ExcludeAddCommand.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -11,8 +11,10 @@ namespace SunnySunday.Cli.Commands.Exclude;
 /// Usage: sunny exclude highlight|book|author &lt;id&gt;
 /// </summary>
 public sealed class ExcludeAddCommand(SunnyHttpClient client, ILogger<ExcludeAddCommand> logger)
-    : AsyncCommand<ExcludeAddCommand.Settings>
+    : ServerCommand<ExcludeAddCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     private static readonly string[] ValidTypes = ["highlight", "book", "author"];
 
     public sealed class Settings : LogCommandSettings
@@ -59,13 +61,4 @@ public sealed class ExcludeAddCommand(SunnyHttpClient client, ILogger<ExcludeAdd
         return 0;
     }
 
-    private int HandleServerError(HttpRequestException ex)
-    {
-        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-        return 1;
-    }
 }

--- a/src/SunnySunday.Cli/Commands/Exclude/ExcludeListCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Exclude/ExcludeListCommand.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using SunnySunday.Cli.Infrastructure;
@@ -10,8 +10,10 @@ namespace SunnySunday.Cli.Commands.Exclude;
 /// Usage: sunny exclude list
 /// </summary>
 public sealed class ExcludeListCommand(SunnyHttpClient client, ILogger<ExcludeListCommand> logger)
-    : AsyncCommand<ExcludeListCommand.Settings>
+    : ServerCommand<ExcludeListCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     public sealed class Settings : LogCommandSettings;
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
@@ -25,12 +27,7 @@ public sealed class ExcludeListCommand(SunnyHttpClient client, ILogger<ExcludeLi
         }
         catch (HttpRequestException ex)
         {
-            var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-            logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-            AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-            AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-            AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-            return 1;
+            return HandleServerError(ex);
         }
 
         AnsiConsole.MarkupLine("[bold]Excluded Highlights[/]");

--- a/src/SunnySunday.Cli/Commands/Exclude/ExcludeRemoveCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Exclude/ExcludeRemoveCommand.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -11,8 +11,10 @@ namespace SunnySunday.Cli.Commands.Exclude;
 /// Usage: sunny exclude remove highlight|book|author &lt;id&gt;
 /// </summary>
 public sealed class ExcludeRemoveCommand(SunnyHttpClient client, ILogger<ExcludeRemoveCommand> logger)
-    : AsyncCommand<ExcludeRemoveCommand.Settings>
+    : ServerCommand<ExcludeRemoveCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     private static readonly string[] ValidTypes = ["highlight", "book", "author"];
 
     public sealed class Settings : LogCommandSettings
@@ -59,13 +61,4 @@ public sealed class ExcludeRemoveCommand(SunnyHttpClient client, ILogger<Exclude
         return 0;
     }
 
-    private int HandleServerError(HttpRequestException ex)
-    {
-        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-        logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-        return 1;
-    }
 }

--- a/src/SunnySunday.Cli/Commands/ServerCommand.cs
+++ b/src/SunnySunday.Cli/Commands/ServerCommand.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Cli.Commands;
+
+/// <summary>
+/// Base class for commands that communicate with the sunny-server.
+/// Provides shared error handling for HTTP failures.
+/// </summary>
+public abstract class ServerCommand<TSettings> : AsyncCommand<TSettings>
+    where TSettings : LogCommandSettings
+{
+    protected abstract ILogger Logger { get; }
+
+    protected int HandleServerError(HttpRequestException ex)
+    {
+        var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
+        Logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
+        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
+        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
+        AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
+        return 1;
+    }
+}

--- a/src/SunnySunday.Cli/Commands/SyncCommand.cs
+++ b/src/SunnySunday.Cli/Commands/SyncCommand.cs
@@ -11,8 +11,10 @@ namespace SunnySunday.Cli.Commands;
 /// <summary>
 /// Parses a Kindle clippings file and syncs highlights to the server.
 /// </summary>
-public sealed class SyncCommand(SunnyHttpClient client, ILogger<SyncCommand> logger) : AsyncCommand<SyncCommand.Settings>
+public sealed class SyncCommand(SunnyHttpClient client, ILogger<SyncCommand> logger) : ServerCommand<SyncCommand.Settings>
 {
+    protected override ILogger Logger => logger;
+
     public sealed class Settings : LogCommandSettings
     {
         [CommandArgument(0, "[path]")]
@@ -68,12 +70,7 @@ public sealed class SyncCommand(SunnyHttpClient client, ILogger<SyncCommand> log
         }
         catch (HttpRequestException ex)
         {
-            var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER") ?? "unknown";
-            logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-            AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-            AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-            AnsiConsole.MarkupLine("[grey]Check that the server is running and SUNNY_SERVER is correct.[/]");
-            return 1;
+            return HandleServerError(ex);
         }
 
         DisplaySummary(parseResult, response);

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/ExcludeCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/ExcludeCommandTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using RichardSzalay.MockHttp;
 using Spectre.Console.Cli;


### PR DESCRIPTION
## Summary

`HandleServerError` was duplicated verbatim in all 7 CLI commands. Extracted once into a new `ServerCommand<TSettings>` abstract base class.

### Changes
- New `src/SunnySunday.Cli/Commands/ServerCommand.cs`: abstract base inheriting `AsyncCommand<TSettings>`, with `abstract ILogger Logger` and shared `HandleServerError`
- All 7 commands (Sync, ConfigSchedule, ConfigCount, ConfigShow, ExcludeAdd, ExcludeRemove, ExcludeList) now inherit from `ServerCommand<TSettings>` and expose `Logger` via property override
- Local `HandleServerError` copies removed

### Verification
Build: 0 warnings, 0 errors. Tests: 126/126 pass.

Closes #140