### PR TITLE
[Feature 006] Implement weight commands (US6)

### DIFF
--- a/specs/006-client-cli/tasks.md
+++ b/specs/006-client-cli/tasks.md
@@ -184,13 +184,13 @@
 
 ### Tests for User Story 6
 
-- [ ] T030 [P] [US6] Create `src/SunnySunday.Tests/Cli/WeightCommandTests.cs` covering: `weight set 5 3` sends PUT with weight=3, `weight set 5 0` triggers validation error, `weight set 5 6` triggers validation error, `weight list` displays table.
+- [X] T030 [P] [US6] Create `src/SunnySunday.Tests/Cli/WeightCommandTests.cs` covering: `weight set 5 3` sends PUT with weight=3, `weight set 5 0` triggers validation error, `weight set 5 6` triggers validation error, `weight list` displays table.
 
 ### Implementation for User Story 6
 
-- [ ] T031 [P] [US6] Create `src/SunnySunday.Cli/Commands/Weight/WeightSetCommand.cs` as `AsyncCommand<Settings>`: validate weight range (1–5), call `PutWeightAsync`, display confirmation.
-- [ ] T032 [P] [US6] Create `src/SunnySunday.Cli/Commands/Weight/WeightListCommand.cs` as `AsyncCommand`: call `GetWeightsAsync`, display table with ID, Text (truncated), Book, Weight; show "No custom weights" if empty.
-- [ ] T033 [US6] Register weight commands in the command tree: `weight` branch with `set` and `list` subcommands in `src/SunnySunday.Cli/Program.cs`.
+- [X] T031 [P] [US6] Create `src/SunnySunday.Cli/Commands/Weight/WeightSetCommand.cs` as `AsyncCommand<Settings>`: validate weight range (1–5), call `PutWeightAsync`, display confirmation.
+- [X] T032 [P] [US6] Create `src/SunnySunday.Cli/Commands/Weight/WeightListCommand.cs` as `AsyncCommand`: call `GetWeightsAsync`, display table with ID, Text (truncated), Book, Weight; show "No custom weights" if empty.
+- [X] T033 [US6] Register weight commands in the command tree: `weight` branch with `set` and `list` subcommands in `src/SunnySunday.Cli/Program.cs`.
 
 **Checkpoint**: Weight commands work. Tests pass.
 

--- a/src/SunnySunday.Cli/Commands/Weight/WeightListCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Weight/WeightListCommand.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Cli.Commands.Weight;
+
+/// <summary>
+/// Lists all highlights that have a non-default recap weight.
+/// Usage: sunny weight list
+/// </summary>
+public sealed class WeightListCommand(SunnyHttpClient client, ILogger<WeightListCommand> logger)
+    : ServerCommand<WeightListCommand.Settings>
+{
+    protected override ILogger Logger => logger;
+
+    public sealed class Settings : LogCommandSettings;
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        logger.LogDebug("Fetching weighted highlights from server");
+
+        List<Core.Contracts.WeightedHighlightDto> weights;
+        try
+        {
+            weights = await client.GetWeightsAsync(cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        if (weights.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]No custom weights set.[/]");
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("ID");
+        table.AddColumn("Text");
+        table.AddColumn("Book");
+        table.AddColumn("Weight");
+
+        foreach (var h in weights)
+            table.AddRow(h.Id.ToString(), Markup.Escape(h.Text), Markup.Escape(h.BookTitle), h.Weight.ToString());
+
+        AnsiConsole.Write(table);
+        return 0;
+    }
+}

--- a/src/SunnySunday.Cli/Commands/Weight/WeightSetCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Weight/WeightSetCommand.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Cli.Commands.Weight;
+
+/// <summary>
+/// Sets the recap weight for a specific highlight.
+/// Usage: sunny weight set &lt;id&gt; &lt;weight&gt;   (weight 1–5)
+/// </summary>
+public sealed class WeightSetCommand(SunnyHttpClient client, ILogger<WeightSetCommand> logger)
+    : ServerCommand<WeightSetCommand.Settings>
+{
+    protected override ILogger Logger => logger;
+
+    public sealed class Settings : LogCommandSettings
+    {
+        [CommandArgument(0, "<id>")]
+        [Description("ID of the highlight to update.")]
+        public int Id { get; set; }
+
+        [CommandArgument(1, "<weight>")]
+        [Description("New recap weight (1–5). Higher values increase selection frequency.")]
+        public int Weight { get; set; }
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        if (settings.Weight < 1 || settings.Weight > 5)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Weight must be between [green]1[/] and [green]5[/] (got [yellow]{settings.Weight}[/]).");
+            return 1;
+        }
+
+        logger.LogDebug("Setting weight {Weight} on highlight {Id}", settings.Weight, settings.Id);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.PutWeightAsync(settings.Id, new SetWeightRequest { Weight = settings.Weight }, cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Highlight with ID [yellow]{settings.Id}[/] not found.");
+            return 1;
+        }
+
+        response.EnsureSuccessStatusCode();
+        AnsiConsole.MarkupLine($"[green]✓[/] Weight for highlight [bold]{settings.Id}[/] set to [bold]{settings.Weight}[/].");
+        return 0;
+    }
+}

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -7,6 +7,7 @@ using Spectre.Console.Cli;
 using SunnySunday.Cli.Commands;
 using SunnySunday.Cli.Commands.Config;
 using SunnySunday.Cli.Commands.Exclude;
+using SunnySunday.Cli.Commands.Weight;
 using SunnySunday.Cli.Infrastructure;
 
 var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER");
@@ -82,6 +83,15 @@ app.Configure(config =>
             .WithDescription("Remove an exclusion.");
         exc.AddCommand<ExcludeListCommand>("list")
             .WithDescription("List all current exclusions.");
+    });
+
+    config.AddBranch("weight", wgt =>
+    {
+        wgt.SetDescription("Manage highlight recap weights.");
+        wgt.AddCommand<WeightSetCommand>("set")
+            .WithDescription("Set the recap weight for a highlight (1–5).");
+        wgt.AddCommand<WeightListCommand>("list")
+            .WithDescription("List all highlights with custom weights.");
     });
 });
 

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.6.1</Version>
+    <Version>0.7.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/WeightCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/WeightCommandTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using RichardSzalay.MockHttp;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Commands.Weight;
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Tests.Cli;
+
+public sealed class WeightCommandTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _mockHttp = new();
+
+    public void Dispose() => _mockHttp.Dispose();
+
+    [Fact]
+    public async Task WeightSet_ValidWeight_SendsPut()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/highlights/5/weight")
+            .Respond(HttpStatusCode.OK);
+
+        var exitCode = await RunWeightCommand("set", "5", "3");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task WeightSet_WeightZero_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "*")
+            .Respond(HttpStatusCode.OK);
+
+        var exitCode = await RunWeightCommand("set", "5", "0");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task WeightSet_WeightSix_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "*")
+            .Respond(HttpStatusCode.OK);
+
+        var exitCode = await RunWeightCommand("set", "5", "6");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task WeightSet_NotFound_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Put, "http://localhost:5000/highlights/999/weight")
+            .Respond(HttpStatusCode.NotFound);
+
+        var exitCode = await RunWeightCommand("set", "999", "3");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task WeightSet_ServerUnreachable_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Put, "http://localhost:5000/highlights/5/weight")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var exitCode = await RunWeightCommand("set", "5", "3");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task WeightList_DisplaysTable()
+    {
+        var handler = _mockHttp.When(HttpMethod.Get, "http://localhost:5000/highlights/weights")
+            .Respond("application/json", """
+                [
+                    {"id":1,"text":"Some highlight","bookTitle":"Clean Code","weight":3},
+                    {"id":2,"text":"Another one","bookTitle":"The Pragmatic Programmer","weight":5}
+                ]
+                """);
+
+        var exitCode = await RunWeightCommand("list");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task WeightList_Empty_DisplaysNoWeightsMessage()
+    {
+        _mockHttp.When(HttpMethod.Get, "http://localhost:5000/highlights/weights")
+            .Respond("application/json", "[]");
+
+        var exitCode = await RunWeightCommand("list");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task WeightList_ServerUnreachable_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Get, "http://localhost:5000/highlights/weights")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var exitCode = await RunWeightCommand("list");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    private async Task<int> RunWeightCommand(params string[] args)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddTransient(_ =>
+        {
+            var httpClient = _mockHttp.ToHttpClient();
+            httpClient.BaseAddress = new Uri("http://localhost:5000");
+            return new SunnyHttpClient(httpClient);
+        });
+
+        var registrar = new TypeRegistrar(services);
+        var app = new CommandApp(registrar);
+
+        app.Configure(config =>
+        {
+            config.SetApplicationName("sunny");
+            config.AddBranch("weight", wgt =>
+            {
+                wgt.AddCommand<WeightSetCommand>("set");
+                wgt.AddCommand<WeightListCommand>("list");
+            });
+        });
+
+        var fullArgs = new[] { "weight" }.Concat(args).ToArray();
+        return await app.RunAsync(fullArgs);
+    }
+}


### PR DESCRIPTION
## Summary

Implements US6 (Manage Weights) from the Client CLI feature.

### Commands
- `sunny weight set <id> <weight>` — validates weight 1–5, PUT /highlights/{id}/weight, handles 404
- `sunny weight list` — GET /highlights/weights, displays Spectre table (ID, Text, Book, Weight); "No custom weights set." when empty

Both commands inherit `ServerCommand<TSettings>` for uniform error handling and structured logging.

### Tests (8 new)
- Set valid weight sends PUT
- Weight 0 triggers validation error (no HTTP call)
- Weight 6 triggers validation error (no HTTP call)
- Set 404 returns exit 1
- Set server unreachable returns exit 1
- List with data displays table
- List empty displays message
- List server unreachable returns exit 1

**134 tests pass** (126 existing + 8 new).

Closes #132