### PR TITLE
[Feature 006] Server URL validation with tests (US8)

### DIFF
--- a/specs/006-client-cli/tasks.md
+++ b/specs/006-client-cli/tasks.md
@@ -69,11 +69,11 @@
 
 ### Tests for User Story 8
 
-- [ ] T011 [P] [US8] Create `src/SunnySunday.Tests/Cli/ServerUrlValidationTests.cs` covering: missing env var exits with actionable error, malformed URL exits with validation error, valid URL allows command execution.
+- [X] T011 [P] [US8] Create `src/SunnySunday.Tests/Cli/ServerUrlValidationTests.cs` covering: missing env var exits with actionable error, malformed URL exits with validation error, valid URL allows command execution.
 
 ### Implementation for User Story 8
 
-- [ ] T012 [US8] Verify `src/SunnySunday.Cli/Program.cs` validation logic: missing `SUNNY_SERVER` → Spectre error markup + exit 1; malformed URI (not absolute, not HTTP/HTTPS) → validation error + exit 1. (Logic implemented in T005; this task adds edge-case handling and test coverage.)
+- [X] T012 [US8] Verify `src/SunnySunday.Cli/Program.cs` validation logic: missing `SUNNY_SERVER` → Spectre error markup + exit 1; malformed URI (not absolute, not HTTP/HTTPS) → validation error + exit 1. (Logic implemented in T005; this task adds edge-case handling and test coverage.)
 
 **Checkpoint**: Server URL validation is robust and tested. No command executes without a valid `SUNNY_SERVER`.
 

--- a/src/SunnySunday.Cli/Infrastructure/ServerUrlValidator.cs
+++ b/src/SunnySunday.Cli/Infrastructure/ServerUrlValidator.cs
@@ -1,0 +1,34 @@
+namespace SunnySunday.Cli.Infrastructure;
+
+/// <summary>
+/// Validates the SUNNY_SERVER environment variable value.
+/// </summary>
+public static class ServerUrlValidator
+{
+    public enum ValidationResult
+    {
+        Valid,
+        Missing,
+        Malformed,
+    }
+
+    /// <summary>
+    /// Validates <paramref name="value"/> and, on success, outputs the parsed <see cref="Uri"/>.
+    /// </summary>
+    public static ValidationResult Validate(string? value, out Uri? uri)
+    {
+        uri = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return ValidationResult.Missing;
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out uri)
+            || (uri.Scheme != "http" && uri.Scheme != "https"))
+        {
+            uri = null;
+            return ValidationResult.Malformed;
+        }
+
+        return ValidationResult.Valid;
+    }
+}

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -12,7 +12,9 @@ using SunnySunday.Cli.Infrastructure;
 
 var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER");
 
-if (string.IsNullOrWhiteSpace(serverUrl))
+var validationResult = ServerUrlValidator.Validate(serverUrl, out var serverUri);
+
+if (validationResult == ServerUrlValidator.ValidationResult.Missing)
 {
     AnsiConsole.MarkupLine("[red]Error:[/] SUNNY_SERVER environment variable is not set.");
     AnsiConsole.MarkupLine("[grey]Set it to the server URL, e.g.:[/]");
@@ -20,8 +22,7 @@ if (string.IsNullOrWhiteSpace(serverUrl))
     return 1;
 }
 
-if (!Uri.TryCreate(serverUrl, UriKind.Absolute, out var serverUri)
-    || (serverUri.Scheme != "http" && serverUri.Scheme != "https"))
+if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
 {
     AnsiConsole.MarkupLine($"[red]Error:[/] SUNNY_SERVER value is not a valid HTTP URL: [yellow]{serverUrl}[/]");
     return 1;

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/ServerUrlValidationTests.cs
+++ b/src/SunnySunday.Tests/Cli/ServerUrlValidationTests.cs
@@ -1,0 +1,60 @@
+using SunnySunday.Cli.Infrastructure;
+
+namespace SunnySunday.Tests.Cli;
+
+public sealed class ServerUrlValidationTests
+{
+    [Fact]
+    public void Validate_NullValue_ReturnsMissing()
+    {
+        var result = ServerUrlValidator.Validate(null, out var uri);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Missing, result);
+        Assert.Null(uri);
+    }
+
+    [Fact]
+    public void Validate_EmptyString_ReturnsMissing()
+    {
+        var result = ServerUrlValidator.Validate(string.Empty, out var uri);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Missing, result);
+        Assert.Null(uri);
+    }
+
+    [Fact]
+    public void Validate_WhitespaceOnly_ReturnsMissing()
+    {
+        var result = ServerUrlValidator.Validate("   ", out var uri);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Missing, result);
+        Assert.Null(uri);
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com")]
+    [InlineData("//missing-scheme")]
+    [InlineData("file:///local/path")]
+    public void Validate_MalformedOrNonHttpUrl_ReturnsMalformed(string value)
+    {
+        var result = ServerUrlValidator.Validate(value, out var uri);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Malformed, result);
+        Assert.Null(uri);
+    }
+
+    [Theory]
+    [InlineData("http://192.168.1.10:8080")]
+    [InlineData("http://localhost:5000")]
+    [InlineData("https://sunny.example.com")]
+    [InlineData("http://sunny.example.com/prefix")]
+    public void Validate_ValidHttpUrl_ReturnsValidWithUri(string value)
+    {
+        var result = ServerUrlValidator.Validate(value, out var uri);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Valid, result);
+        Assert.NotNull(uri);
+        Assert.Equal(value, uri.ToString().TrimEnd('/'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements US8 (Server URL Configuration) — test coverage for `SUNNY_SERVER` validation.

### Changes
- New `src/SunnySunday.Cli/Infrastructure/ServerUrlValidator.cs`: static class with `Validate(string?, out Uri?)` returning a `ValidationResult` enum (Missing / Malformed / Valid)
- Refactored `Program.cs` to delegate to `ServerUrlValidator` instead of inline logic — behaviour unchanged
- New `src/SunnySunday.Tests/Cli/ServerUrlValidationTests.cs`: 11 tests covering every case

### Test cases
- `null`, empty string, whitespace → `Missing`
- `not-a-url`, `ftp://…`, `file://…`, relative URL → `Malformed`
- `http://…`, `https://…` → `Valid` with non-null `Uri`

**150 tests pass** (139 existing + 11 new).

Closes #134