### PR TITLE
Add `sunny config kindle-email` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ That's it. Your first recap will arrive on the next scheduled delivery (default:
 | `sunny status` | Show server status and next recap |
 | `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule |
 | `sunny config count <1-15>` | Set highlights per recap (default: 3) |
+| `sunny config kindle-email <address>` | Set the Kindle delivery email address |
 | `sunny exclude highlight <id>` | Exclude a highlight from all recaps |
 | `sunny exclude book <title>` | Exclude all highlights from a book |
 | `sunny exclude author <name>` | Exclude all highlights from an author |

--- a/src/SunnySunday.Cli/Commands/Config/ConfigKindleEmailCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigKindleEmailCommand.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Cli.Commands.Config;
+
+/// <summary>
+/// Sets the Kindle delivery email address on the server.
+/// Usage: sunny config kindle-email &lt;address&gt;
+/// </summary>
+public sealed partial class ConfigKindleEmailCommand(SunnyHttpClient client, ILogger<ConfigKindleEmailCommand> logger)
+    : ServerCommand<ConfigKindleEmailCommand.Settings>
+{
+    protected override ILogger Logger => logger;
+
+    public sealed class Settings : LogCommandSettings
+    {
+        [CommandArgument(0, "<address>")]
+        [Description("Send-to-Kindle email address (e.g. yourname_XXXX@kindle.com).")]
+        public string Address { get; set; } = string.Empty;
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var address = settings.Address.Trim();
+
+        if (!EmailRegex().IsMatch(address))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] [yellow]{Markup.Escape(address)}[/] is not a valid email address.");
+            return 1;
+        }
+
+        logger.LogDebug("Setting Kindle email to {Address}", address);
+
+        var request = new UpdateSettingsRequest { KindleEmail = address };
+
+        SettingsResponse response;
+        try
+        {
+            response = await client.PutSettingsAsync(request, cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        AnsiConsole.MarkupLine($"[green]✓[/] Kindle email set to [bold]{Markup.Escape(response.KindleEmail ?? address)}[/].");
+        return 0;
+    }
+
+    [GeneratedRegex(
+        @"^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex EmailRegex();
+}

--- a/src/SunnySunday.Cli/Commands/Config/ConfigKindleEmailCommand.cs
+++ b/src/SunnySunday.Cli/Commands/Config/ConfigKindleEmailCommand.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -74,6 +74,8 @@ app.Configure(config =>
             .WithDescription("Configure recap schedule (cadence and time).");
         cfg.AddCommand<ConfigCountCommand>("count")
             .WithDescription("Configure number of highlights per recap.");
+        cfg.AddCommand<ConfigKindleEmailCommand>("kindle-email")
+            .WithDescription("Set the Kindle delivery email address.");
         cfg.AddCommand<ConfigShowCommand>("show")
             .WithDescription("Display all current settings.");
     });

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.8.1</Version>
+    <Version>0.9.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/ConfigCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/ConfigCommandTests.cs
@@ -260,3 +260,87 @@ public sealed class ConfigCommandTests : IDisposable
         return await app.RunAsync(["config", "show"]);
     }
 }
+
+public sealed class ConfigKindleEmailCommandTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _mockHttp = new();
+
+    public void Dispose() => _mockHttp.Dispose();
+
+    [Fact]
+    public async Task KindleEmail_ValidAddress_SendsPutAndPrintsConfirmation()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Respond("application/json", """
+                {"schedule":"daily","deliveryDay":null,"deliveryTime":"18:00","count":5,"kindleEmail":"user_abc123@kindle.com","timezone":"UTC"}
+                """);
+
+        var exitCode = await RunKindleEmailCommand("user_abc123@kindle.com");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task KindleEmail_InvalidAddress_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Respond("application/json", "{}");
+
+        var exitCode = await RunKindleEmailCommand("not-an-email");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task KindleEmail_EmptyString_ReturnsOneWithoutHttpCall()
+    {
+        var handler = _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Respond("application/json", "{}");
+
+        var exitCode = await RunKindleEmailCommand("   ");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, _mockHttp.GetMatchCount(handler));
+    }
+
+    [Fact]
+    public async Task KindleEmail_ServerUnreachable_ReturnsOne()
+    {
+        _mockHttp.When(HttpMethod.Put, "http://localhost:5000/settings")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var exitCode = await RunKindleEmailCommand("user@kindle.com");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    private async Task<int> RunKindleEmailCommand(params string[] args)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddTransient(_ =>
+        {
+            var httpClient = _mockHttp.ToHttpClient();
+            httpClient.BaseAddress = new Uri("http://localhost:5000");
+            return new SunnyHttpClient(httpClient);
+        });
+
+        var registrar = new TypeRegistrar(services);
+        var app = new CommandApp(registrar);
+
+        app.Configure(config =>
+        {
+            config.SetApplicationName("sunny");
+            config.AddBranch("config", cfg =>
+            {
+                cfg.AddCommand<ConfigKindleEmailCommand>("kindle-email");
+            });
+        });
+
+        var fullArgs = new[] { "config", "kindle-email" }.Concat(args).ToArray();
+        return await app.RunAsync(fullArgs);
+    }
+}


### PR DESCRIPTION
Introduce a new command to set the Kindle email address via the CLI. This command validates the email format before making a PUT request to update the settings on the server. It also includes tests to ensure proper functionality and error handling. Update the CLI reference in the README and relevant documentation.

Close #155