### PR TITLE
Default SUNNY_SERVER to http://localhost:8080 when not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,16 @@ docker run --rm -e SUNNY_SERVER=http://192.168.1.10:8080 ghcr.io/krusty93/sunnys
 ### 3. Sync your highlights
 
 ```sh
-export SUNNY_SERVER=http://192.168.1.10:8080
-sunny sync   # auto-detects Kindle mount path
+sunny sync   # SUNNY_SERVER defaults to http://localhost:8080
 ```
 
 That's it. Your first recap will arrive on the next scheduled delivery (default: every Sunday at 18:00).
+
+> **Server on a different machine?** Set `SUNNY_SERVER` before running CLI commands:
+> ```sh
+> export SUNNY_SERVER=http://192.168.1.10:8080
+> sunny sync
+> ```
 
 ---
 

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -10,19 +10,19 @@ using SunnySunday.Cli.Commands.Exclude;
 using SunnySunday.Cli.Commands.Weight;
 using SunnySunday.Cli.Infrastructure;
 
+const string DefaultServerUrl = "http://localhost:8080";
+
 var serverUrl = Environment.GetEnvironmentVariable("SUNNY_SERVER");
 
 var validationResult = ServerUrlValidator.Validate(serverUrl, out var serverUri);
 
 if (validationResult == ServerUrlValidator.ValidationResult.Missing)
 {
-    AnsiConsole.MarkupLine("[red]Error:[/] SUNNY_SERVER environment variable is not set.");
-    AnsiConsole.MarkupLine("[grey]Set it to the server URL, e.g.:[/]");
-    AnsiConsole.MarkupLine("[grey]  export SUNNY_SERVER=http://192.168.1.10:8080[/]");
-    return 1;
+    serverUrl = DefaultServerUrl;
+    serverUri = new Uri(DefaultServerUrl);
+    AnsiConsole.MarkupLine($"[grey]SUNNY_SERVER not set — using default: {DefaultServerUrl}[/]");
 }
-
-if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
+else if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
 {
     AnsiConsole.MarkupLine($"[red]Error:[/] SUNNY_SERVER value is not a valid HTTP URL: [yellow]{serverUrl}[/]");
     return 1;

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
When `SUNNY_SERVER` is not set the CLI now falls back to `http://localhost:8080` instead of exiting with an error. A grey informational note is printed so the user knows which URL is being used.

## Changes

- **`Program.cs`** — replace the `Missing` error path with a silent default; the `Malformed` error path is unchanged.
- **`README.md`** — update "Sync your highlights" step to show the default; add a callout for multi-machine setups.

## Behaviour

| Before | After |
|---|---|
| `Error: SUNNY_SERVER environment variable is not set.` → exit 1 | `SUNNY_SERVER not set — using default: http://localhost:8080` → continues |
| Malformed URL → exit 1 | Malformed URL → exit 1 (unchanged) |

Closes #159