### PR TITLE
Fix EPUB title, heading, and attribution format

### DIFF
--- a/src/SunnySunday.Server/Services/EpubComposer.cs
+++ b/src/SunnySunday.Server/Services/EpubComposer.cs
@@ -5,7 +5,7 @@ namespace SunnySunday.Server.Services;
 
 public static class EpubComposer
 {
-    public static byte[] Compose(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate)
+    public static byte[] Compose(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string cadence)
     {
         using var stream = new MemoryStream();
         using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
@@ -20,7 +20,7 @@ public static class EpubComposer
             AddEntry(archive, "META-INF/container.xml", BuildContainerXml());
             AddEntry(archive, "OEBPS/content.opf", BuildContentOpf(recapDate));
             AddEntry(archive, "OEBPS/toc.ncx", BuildTocNcx());
-            AddEntry(archive, "OEBPS/highlights.xhtml", BuildHighlightsXhtml(highlights, recapDate));
+            AddEntry(archive, "OEBPS/highlights.xhtml", BuildHighlightsXhtml(highlights, recapDate, cadence));
         }
 
         return stream.ToArray();
@@ -46,8 +46,9 @@ public static class EpubComposer
         <?xml version="1.0" encoding="UTF-8"?>
         <package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId" version="2.0">
           <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-            <dc:title>Sunny Sunday Recap – {recapDate:yyyy-MM-dd}</dc:title>
+            <dc:title>Notes Recap ({recapDate:yyyy-MM-dd HH:mm})</dc:title>
             <dc:creator>Sunny Sunday</dc:creator>
+            <dc:subject>sunny-sunday</dc:subject>
             <dc:identifier id="BookId">sunny-recap-{recapDate:yyyyMMdd-HHmmss}</dc:identifier>
             <dc:language>en</dc:language>
           </metadata>
@@ -75,8 +76,9 @@ public static class EpubComposer
         </ncx>
         """;
 
-    private static string BuildHighlightsXhtml(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate)
+    private static string BuildHighlightsXhtml(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string cadence)
     {
+        var cadenceLabel = cadence.Equals("weekly", StringComparison.OrdinalIgnoreCase) ? "Weekly" : "Daily";
         var sb = new StringBuilder();
         sb.AppendLine("""
             <?xml version="1.0" encoding="UTF-8"?>
@@ -85,12 +87,12 @@ public static class EpubComposer
             <head><title>Highlights</title></head>
             <body>
             """);
-        sb.AppendLine($"<h1>Sunny Sunday Recap — {recapDate:yyyy-MM-dd}</h1>");
+        sb.AppendLine($"<h1>Sunny Sunday {cadenceLabel} Recap ({recapDate:yyyy-MM-dd HH:mm})</h1>");
         sb.AppendLine("<ul>");
 
         foreach (var h in highlights)
         {
-            sb.AppendLine($"<li><blockquote>{EscapeXml(h.Text)}</blockquote><p>— <em>{EscapeXml(h.BookTitle)}</em> by {EscapeXml(h.AuthorName)}</p></li>");
+            sb.AppendLine($"<li><blockquote>{EscapeXml(h.Text)}</blockquote><p><em>{EscapeXml(h.BookTitle)}</em> by {EscapeXml(h.AuthorName)}</p></li>");
         }
 
         sb.AppendLine("</ul>");

--- a/src/SunnySunday.Server/Services/RecapService.cs
+++ b/src/SunnySunday.Server/Services/RecapService.cs
@@ -53,7 +53,7 @@ public sealed class RecapService : IRecapService
             return;
         }
 
-        var epubContent = EpubComposer.Compose(candidates, scheduledFor);
+        var epubContent = EpubComposer.Compose(candidates, scheduledFor, settings.Schedule);
         var fileName = $"recap-{scheduledFor:yyyyMMdd-HHmmss}.epub";
 
         var attemptCount = 0;

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Recap/EpubComposerTests.cs
+++ b/src/SunnySunday.Tests/Recap/EpubComposerTests.cs
@@ -18,7 +18,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_ReturnsValidZipArchive()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -29,7 +29,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_MimetypeIsFirstEntry()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -41,7 +41,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_MimetypeIsUncompressed()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -54,7 +54,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_MimetypeContentIsCorrect()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -66,7 +66,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_ContainsRequiredEpubFiles()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -80,7 +80,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_ContainerXmlPointsToContentOpf()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -91,22 +91,59 @@ public sealed class EpubComposerTests
     }
 
     [Fact]
-    public void Compose_ContentOpfContainsRecapDateInTitle()
+    public void Compose_ContentOpf_TitleIsNotesRecapWithDateTimeAndTag()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
 
         var opf = ReadEntry(archive, "OEBPS/content.opf");
-        Assert.Contains("2026-04-20", opf);
-        Assert.Contains("Sunny Sunday Recap", opf);
+        Assert.Contains("Notes Recap (2026-04-20 18:00)", opf);
+        Assert.Contains("<dc:subject>sunny-sunday</dc:subject>", opf);
+    }
+
+    [Fact]
+    public void Compose_HighlightsXhtml_DailyHeadingIncludesCadenceAndDateTime()
+    {
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
+
+        using var stream = new MemoryStream(epub);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+        var xhtml = ReadEntry(archive, "OEBPS/highlights.xhtml");
+        Assert.Contains("<h1>Sunny Sunday Daily Recap (2026-04-20 18:00)</h1>", xhtml);
+    }
+
+    [Fact]
+    public void Compose_HighlightsXhtml_WeeklyHeadingIncludesCadenceAndDateTime()
+    {
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "weekly");
+
+        using var stream = new MemoryStream(epub);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+        var xhtml = ReadEntry(archive, "OEBPS/highlights.xhtml");
+        Assert.Contains("<h1>Sunny Sunday Weekly Recap (2026-04-20 18:00)</h1>", xhtml);
+    }
+
+    [Fact]
+    public void Compose_HighlightsXhtml_NoEmDashBeforeBookTitle()
+    {
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
+
+        using var stream = new MemoryStream(epub);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+        var xhtml = ReadEntry(archive, "OEBPS/highlights.xhtml");
+        Assert.DoesNotContain("— <em>", xhtml);
+        Assert.Contains("<em>Steve Jobs Biography</em>", xhtml);
     }
 
     [Fact]
     public void Compose_HighlightsXhtml_RendersFlatList()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -120,7 +157,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_HighlightsXhtml_PreservesInputOrder()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -138,7 +175,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_HighlightsXhtml_IncludesSourceMetadata()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -155,7 +192,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_HighlightsXhtml_EscapesSpecialCharacters()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate);
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -173,7 +210,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_EmptyHighlights_ProducesValidEpubWithEmptyList()
     {
-        var epub = EpubComposer.Compose([], RecapDate);
+        var epub = EpubComposer.Compose([], RecapDate, "daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);


### PR DESCRIPTION
Fixes three formatting issues in the generated recap EPUB.

## Changes

### `EpubComposer`
- **File title** (`dc:title` in `content.opf`): changed from `Sunny Sunday Recap – YYYY-MM-DD` to `Notes Recap (YYYY-MM-DD HH:mm)`
- **`dc:subject` tag** added: `sunny-sunday`
- **Internal heading** (`<h1>`): changed from `Sunny Sunday Recap — YYYY-MM-DD` to `Sunny Sunday Daily/Weekly Recap (YYYY-MM-DD HH:mm)` — cadence label resolved from the schedule settings
- **Attribution**: removed em dash (`—`) before the italic book title; now renders as `<em>Book Title</em> by Author`
- `Compose` signature gains a `cadence` parameter (`"daily"` / `"weekly"`)

### `RecapService`
- Passes `settings.Schedule` as the cadence argument to `EpubComposer.Compose`

### `EpubComposerTests`
- All 13 existing tests updated to use the new `Compose` signature
- 3 new tests: `ContentOpf_TitleIsNotesRecapWithDateTimeAndTag`, `HighlightsXhtml_DailyHeadingIncludesCadenceAndDateTime`, `HighlightsXhtml_WeeklyHeadingIncludesCadenceAndDateTime`, `HighlightsXhtml_NoEmDashBeforeBookTitle`

### Version bump
- `SunnySunday.Server`: `0.9.0` → `0.9.1` (patch)

Closes #168