### PR TITLE
Add devcontainer-lock.json to pin feature versions

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "digest": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.9.1",
+      "digest": "sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850"
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {
+      "version": "1.1.2",
+      "digest": "sha256:757c6c2899dc902c44a9f6164c1f7392832ced13c6bb632d8d60a880f2e92456"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "digest": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/devcontainers-extra/features/uv:1": {
+      "version": "1.0.2",
+      "digest": "sha256:1ac5b9f17a9e9e745933d0ac2ecf758e06ed3da4423cd22c94cce4d482fd2dd8"
+    }
+  }
+}


### PR DESCRIPTION
Adds `.devcontainer/devcontainer-lock.json` to pin all five devcontainer features to their current resolved digests, making the dev environment reproducible.

## Pinned versions

| Feature | Version | Digest |
|---|---|---|
| `github-cli:1` | 1.1.0 | `sha256:d22f50b...` |
| `docker-outside-of-docker:1` | 1.9.1 | `sha256:dc89605...` |
| `copilot-cli:1` | 1.1.2 | `sha256:757c6c2...` |
| `python:1` | 1.8.0 | `sha256:fbcad69...` |
| `uv:1` (devcontainers-extra) | 1.0.2 | `sha256:1ac5b9f...` |

`devcontainer.json` continues to use major-version tags for readability; the lock file provides reproducibility by pinning the exact OCI manifest digest.

Closes #169