### PR TITLE
Status: show yellow warning when Kindle email is not configured

### DIFF
--- a/src/SunnySunday.Cli/Commands/StatusCommand.cs
+++ b/src/SunnySunday.Cli/Commands/StatusCommand.cs
@@ -40,6 +40,7 @@ public sealed class StatusCommand(SunnyHttpClient client, ILogger<StatusCommand>
         table.AddRow("Excluded Highlights", response.ExcludedHighlights.ToString());
         table.AddRow("Excluded Books", response.ExcludedBooks.ToString());
         table.AddRow("Excluded Authors", response.ExcludedAuthors.ToString());
+        table.AddRow("Kindle Email", FormatKindleEmail(response.KindleEmailConfigured));
         table.AddRow("Next Recap", FormatTimestamp(response.NextRecap) ?? "[grey]Not scheduled[/]");
         table.AddRow("Last Recap Status", FormatLastStatus(response.LastRecapStatus));
 
@@ -60,6 +61,11 @@ public sealed class StatusCommand(SunnyHttpClient client, ILogger<StatusCommand>
 
         return dt.ToLocalTime().ToString("yyyy-MM-dd HH:mm zzz");
     }
+
+    private static string FormatKindleEmail(bool configured) =>
+        configured
+            ? "[green]\u2713 Configured[/]"
+            : "[yellow]\u26a0 Not configured \u2014 run: sunny config kindle-email <address>[/]";
 
     private static string FormatLastStatus(string? status) => status switch
     {

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Core/Contracts/StatusResponse.cs
+++ b/src/SunnySunday.Core/Contracts/StatusResponse.cs
@@ -34,4 +34,7 @@ public sealed record StatusResponse
 
     /// <summary>Error detail when LastRecapStatus is "failed"; null otherwise.</summary>
     public string? LastRecapError { get; set; }
+
+    /// <summary>Indicates whether a Kindle delivery email is configured for the user.</summary>
+    public bool KindleEmailConfigured { get; set; }
 }

--- a/src/SunnySunday.Core/SunnySunday.Core.csproj
+++ b/src/SunnySunday.Core/SunnySunday.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/SunnySunday.Server/Endpoints/StatusEndpoints.cs
+++ b/src/SunnySunday.Server/Endpoints/StatusEndpoints.cs
@@ -12,10 +12,12 @@ public static class StatusEndpoints
         app.MapGet("/status", async ([FromServices] UserRepository userRepo, [FromServices] StatusRepository statusRepo, [FromServices] ISchedulerService schedulerService) =>
         {
             var userId = await userRepo.EnsureUserAsync();
+            var user = await userRepo.GetByIdAsync(userId);
             var status = await statusRepo.GetStatusAsync(userId);
 
             var nextFire = schedulerService.GetNextFireTimeUtc();
             status.NextRecap = nextFire?.ToString("O");
+            status.KindleEmailConfigured = !string.IsNullOrWhiteSpace(user.KindleEmail);
 
             return Results.Ok(status);
         })

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Cli/StatusCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/StatusCommandTests.cs
@@ -26,7 +26,8 @@ public sealed class StatusCommandTests : IDisposable
                     "excludedAuthors": 0,
                     "nextRecap": "2026-05-04T08:00:00Z",
                     "lastRecapStatus": "delivered",
-                    "lastRecapError": null
+                    "lastRecapError": null,
+                    "kindleEmailConfigured": true
                 }
                 """);
 
@@ -73,6 +74,30 @@ public sealed class StatusCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Status_KindleEmailNotConfigured_ReturnsZero()
+    {
+        _mockHttp.When(HttpMethod.Get, "http://localhost:5000/status")
+            .Respond("application/json", """
+                {
+                    "totalHighlights": 5,
+                    "totalBooks": 1,
+                    "totalAuthors": 1,
+                    "excludedHighlights": 0,
+                    "excludedBooks": 0,
+                    "excludedAuthors": 0,
+                    "nextRecap": null,
+                    "lastRecapStatus": null,
+                    "lastRecapError": null,
+                    "kindleEmailConfigured": false
+                }
+                """);
+
+        var exitCode = await RunStatusCommand();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
     public async Task Status_FailedLastRecap_ReturnsZero()
     {
         _mockHttp.When(HttpMethod.Get, "http://localhost:5000/status")
@@ -86,7 +111,8 @@ public sealed class StatusCommandTests : IDisposable
                     "excludedAuthors": 0,
                     "nextRecap": null,
                     "lastRecapStatus": "failed",
-                    "lastRecapError": "SMTP connection timeout"
+                    "lastRecapError": "SMTP connection timeout",
+                    "kindleEmailConfigured": true
                 }
                 """);
 


### PR DESCRIPTION
When `sunny status` is run and no Kindle email has been set, the Kindle Email row now displays a yellow warning with instructions. When an email is configured it shows a green confirmation.

## Changes

### `StatusResponse` (Core)
- New `bool KindleEmailConfigured` property

### `StatusEndpoints` (Server)
- Fetches the user record and populates `KindleEmailConfigured = !string.IsNullOrWhiteSpace(user.KindleEmail)`

### `StatusCommand` (CLI)
- New `Kindle Email` row in the status table
  - `false` → `⚠ Not configured — run: sunny config kindle-email <address>` (yellow)
  - `true`  → `✓ Configured` (green)
- New `FormatKindleEmail(bool)` helper

### Tests
- Existing mock responses updated with `kindleEmailConfigured` field
- New test `Status_KindleEmailNotConfigured_ReturnsZero`

### Version bumps
- `SunnySunday.Core`: `0.6.0` → `0.6.1`
- `SunnySunday.Server`: `0.9.1` → `0.9.2`
- `SunnySunday.Cli`: `0.9.1` → `0.9.2`

Closes #167