### PR TITLE
Server: change default highlight count per recap from 3 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ That's it. Your first recap will arrive on the next scheduled delivery (default:
 | `sunny sync [path]` | Import highlights from `My Clippings.txt` |
 | `sunny status` | Show server status and next recap |
 | `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule |
-| `sunny config count <1-15>` | Set highlights per recap (default: 3) |
+| `sunny config count <1-15>` | Set highlights per recap (default: 5) |
 | `sunny config kindle-email <address>` | Set the Kindle delivery email address |
 | `sunny exclude highlight <id>` | Exclude a highlight from all recaps |
 | `sunny exclude book <title>` | Exclude all highlights from a book |

--- a/src/SunnySunday.Server/Models/Settings.cs
+++ b/src/SunnySunday.Server/Models/Settings.cs
@@ -10,7 +10,7 @@ public class Settings
 
     public string DeliveryTime { get; set; } = "18:00";
 
-    public int Count { get; set; } = 3;
+    public int Count { get; set; } = 5;
 
     public string Timezone { get; set; } = "UTC";
 }

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Api/SettingsEndpointTests.cs
+++ b/src/SunnySunday.Tests/Api/SettingsEndpointTests.cs
@@ -32,7 +32,7 @@ public sealed class SettingsEndpointTests : IDisposable
         Assert.Equal("daily", result.Schedule);
         Assert.Null(result.DeliveryDay);
         Assert.Equal("18:00", result.DeliveryTime);
-        Assert.Equal(3, result.Count);
+        Assert.Equal(5, result.Count);
         Assert.Equal(string.Empty, result.KindleEmail);
     }
 
@@ -50,7 +50,7 @@ public sealed class SettingsEndpointTests : IDisposable
         Assert.Equal("weekly", result.Schedule);
         Assert.Null(result.DeliveryDay);
         Assert.Equal("18:00", result.DeliveryTime);
-        Assert.Equal(3, result.Count);
+        Assert.Equal(5, result.Count);
         Assert.Equal(string.Empty, result.KindleEmail);
     }
 


### PR DESCRIPTION
New installations now default to 5 highlights per recap instead of 3.

## Changes

- `Settings.Count` default: `3` → `5`
- `README.md`: updated documentation table to reflect `(default: 5)`
- `SettingsEndpointTests`: updated default-value assertions from `3` to `5`
- `SunnySunday.Server`: `0.9.1` → `0.9.3`

Closes #164