### PR TITLE
Server: default delivery timezone to host machine's local timezone on first run

### DIFF
--- a/src/SunnySunday.Server/Program.cs
+++ b/src/SunnySunday.Server/Program.cs
@@ -129,6 +129,11 @@ await QuartzSchemaInitializer.ApplyAsync(connectionString);
 
         var userId = await userRepo.EnsureUserAsync();
         var settings = await settingsRepo.GetByUserIdAsync(userId);
+
+        // Default the timezone to the host machine's local timezone on first run
+        settings.Timezone = TimeZoneInfo.Local.Id;
+        await settingsRepo.UpsertAsync(settings);
+
         await schedulerService.ScheduleAsync(settings);
     }
 }

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
On first run, instead of defaulting to `UTC`, the server now detects the host machine's local timezone via `TimeZoneInfo.Local.Id` and persists it as the initial schedule timezone.

## Changes

### `Program.cs` (Server)
- On first-run block: detects `TimeZoneInfo.Local.Id`, sets `settings.Timezone`, persists via `settingsRepo.UpsertAsync` before scheduling

### Version bump
- `SunnySunday.Server`: `0.9.3` → `0.9.4`

Closes #162