### PR TITLE
API: add GET /highlights paginated endpoint

### DIFF
--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Core/Contracts/HighlightsResponse.cs
+++ b/src/SunnySunday.Core/Contracts/HighlightsResponse.cs
@@ -1,0 +1,53 @@
+namespace SunnySunday.Core.Contracts;
+
+/// <summary>
+/// Paginated list of highlights.
+/// </summary>
+public sealed record HighlightsResponse
+{
+    /// <summary>
+    /// Total number of highlights matching the current filter.
+    /// </summary>
+    public int Total { get; set; }
+
+    /// <summary>
+    /// Current page number (1-based).
+    /// </summary>
+    public int Page { get; set; }
+
+    /// <summary>
+    /// Number of items per page.
+    /// </summary>
+    public int PageSize { get; set; }
+
+    /// <summary>
+    /// Highlights on the current page.
+    /// </summary>
+    public List<HighlightItemDto> Items { get; set; } = [];
+}
+
+/// <summary>
+/// A single highlight entry in a paginated list.
+/// </summary>
+public sealed record HighlightItemDto
+{
+    /// <summary>
+    /// Highlight identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Full highlight text.
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Title of the book containing the highlight.
+    /// </summary>
+    public string BookTitle { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Name of the author of the book.
+    /// </summary>
+    public string AuthorName { get; set; } = string.Empty;
+}

--- a/src/SunnySunday.Core/SunnySunday.Core.csproj
+++ b/src/SunnySunday.Core/SunnySunday.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.6.1</Version>
+    <Version>0.6.2</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/SunnySunday.Server/Data/HighlightRepository.cs
+++ b/src/SunnySunday.Server/Data/HighlightRepository.cs
@@ -1,0 +1,59 @@
+using System.Data;
+using Dapper;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Server.Data;
+
+public sealed class HighlightRepository(IDbConnection connection)
+{
+    public async Task<HighlightsResponse> GetHighlightsAsync(int userId, int page, int pageSize, string? q)
+    {
+        var hasFilter = !string.IsNullOrWhiteSpace(q);
+        var filter = hasFilter ? $"%{q}%" : null;
+
+        var countSql = hasFilter
+            ? """
+              SELECT COUNT(*)
+              FROM highlights h
+              INNER JOIN books b ON b.id = h.book_id
+              INNER JOIN authors a ON a.id = b.author_id
+              WHERE h.user_id = @UserId
+                AND (h.text LIKE @Filter OR b.title LIKE @Filter OR a.name LIKE @Filter)
+              """
+            : "SELECT COUNT(*) FROM highlights WHERE user_id = @UserId";
+
+        var itemSql = hasFilter
+            ? """
+              SELECT h.id AS Id, h.text AS Text, b.title AS BookTitle, a.name AS AuthorName
+              FROM highlights h
+              INNER JOIN books b ON b.id = h.book_id
+              INNER JOIN authors a ON a.id = b.author_id
+              WHERE h.user_id = @UserId
+                AND (h.text LIKE @Filter OR b.title LIKE @Filter OR a.name LIKE @Filter)
+              ORDER BY h.id ASC
+              LIMIT @PageSize OFFSET @Offset
+              """
+            : """
+              SELECT h.id AS Id, h.text AS Text, b.title AS BookTitle, a.name AS AuthorName
+              FROM highlights h
+              INNER JOIN books b ON b.id = h.book_id
+              INNER JOIN authors a ON a.id = b.author_id
+              WHERE h.user_id = @UserId
+              ORDER BY h.id ASC
+              LIMIT @PageSize OFFSET @Offset
+              """;
+
+        var param = new { UserId = userId, Filter = filter, PageSize = pageSize, Offset = (page - 1) * pageSize };
+
+        var total = await connection.ExecuteScalarAsync<int>(countSql, param);
+        var items = await connection.QueryAsync<HighlightItemDto>(itemSql, param);
+
+        return new HighlightsResponse
+        {
+            Total = total,
+            Page = page,
+            PageSize = pageSize,
+            Items = items.AsList()
+        };
+    }
+}

--- a/src/SunnySunday.Server/Endpoints/HighlightEndpoints.cs
+++ b/src/SunnySunday.Server/Endpoints/HighlightEndpoints.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SunnySunday.Core.Contracts;
+using SunnySunday.Server.Data;
+
+namespace SunnySunday.Server.Endpoints;
+
+public static class HighlightEndpoints
+{
+    public static WebApplication MapHighlightEndpoints(this WebApplication app)
+    {
+        app.MapGet("/highlights", async (
+            [FromServices] UserRepository userRepo,
+            [FromServices] HighlightRepository highlightRepo,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 50,
+            [FromQuery] string? q = null) =>
+        {
+            if (page < 1)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "page", ["page must be greater than or equal to 1."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            if (pageSize is < 1 or > 200)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "pageSize", ["pageSize must be between 1 and 200."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var userId = await userRepo.EnsureUserAsync();
+            var result = await highlightRepo.GetHighlightsAsync(userId, page, pageSize, q);
+            return Results.Ok(result);
+        })
+        .WithSummary("List highlights.")
+        .WithDescription("Returns a paginated, optionally filtered list of highlights stored in the database.")
+        .Produces<HighlightsResponse>(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
+
+        return app;
+    }
+}

--- a/src/SunnySunday.Server/Program.cs
+++ b/src/SunnySunday.Server/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddScoped<StatusRepository>();
 builder.Services.AddScoped<ExclusionRepository>();
 builder.Services.AddScoped<WeightRepository>();
 builder.Services.AddScoped<RecapRepository>();
+builder.Services.AddScoped<HighlightRepository>();
 
 builder.Services.AddQuartz(q =>
 {
@@ -112,6 +113,7 @@ app.MapSettingsEndpoints();
 app.MapStatusEndpoints();
 app.MapExclusionEndpoints();
 app.MapWeightEndpoints();
+app.MapHighlightEndpoints();
 
 var schemaBootstrap = new SchemaBootstrap();
 await schemaBootstrap.ApplyAsync(dbPath);

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.5</Version>
+    <Version>0.10.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.4</Version>
+    <Version>0.9.5</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Api/HighlightEndpointTests.cs
+++ b/src/SunnySunday.Tests/Api/HighlightEndpointTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Net.Http.Json;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Tests.Api;
+
+public sealed class HighlightEndpointTests : IDisposable
+{
+    private readonly SunnyTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public HighlightEndpointTests()
+    {
+        _factory = new SunnyTestApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task GetHighlights_Empty_ReturnsTotalZero()
+    {
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights");
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Total);
+        Assert.Equal(1, result.Page);
+        Assert.Equal(50, result.PageSize);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetHighlights_SeededData_ReturnsAllItems()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights");
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Total);
+        Assert.Equal(3, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetHighlights_ItemsHaveExpectedFields()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights");
+
+        Assert.NotNull(result);
+        var item = result.Items.First();
+        Assert.True(item.Id > 0);
+        Assert.NotEmpty(item.Text);
+        Assert.NotEmpty(item.BookTitle);
+        Assert.NotEmpty(item.AuthorName);
+    }
+
+    [Fact]
+    public async Task GetHighlights_Pagination_ReturnsCorrectPage()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights?page=2&pageSize=2");
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Total);
+        Assert.Equal(2, result.Page);
+        Assert.Equal(2, result.PageSize);
+        Assert.Single(result.Items);
+    }
+
+    [Fact]
+    public async Task GetHighlights_FilterByText_ReturnsMatchingItems()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights?q=courage");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Total);
+        Assert.Single(result.Items);
+        Assert.Contains("courage", result.Items[0].Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetHighlights_FilterByBookTitle_ReturnsMatchingItems()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights?q=Book+Alpha");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Total);
+        Assert.All(result.Items, item => Assert.Equal("Book Alpha", item.BookTitle));
+    }
+
+    [Fact]
+    public async Task GetHighlights_FilterByAuthor_ReturnsMatchingItems()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights?q=Author+Beta");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Total);
+        Assert.All(result.Items, item => Assert.Equal("Author Beta", item.AuthorName));
+    }
+
+    [Fact]
+    public async Task GetHighlights_FilterNoMatch_ReturnsEmptyList()
+    {
+        await SeedHighlightsAsync();
+
+        var result = await _client.GetFromJsonAsync<HighlightsResponse>("/highlights?q=nomatch_xyz");
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Total);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetHighlights_PageZero_Returns422()
+    {
+        var response = await _client.GetAsync("/highlights?page=0");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("page", body);
+    }
+
+    [Fact]
+    public async Task GetHighlights_PageSizeZero_Returns422()
+    {
+        var response = await _client.GetAsync("/highlights?pageSize=0");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("pageSize", body);
+    }
+
+    [Fact]
+    public async Task GetHighlights_PageSizeOver200_Returns422()
+    {
+        var response = await _client.GetAsync("/highlights?pageSize=201");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("pageSize", body);
+    }
+
+    private async Task SeedHighlightsAsync()
+    {
+        var response = await _client.PostAsJsonAsync("/sync", new SyncRequest
+        {
+            Books =
+            [
+                new SyncBookRequest
+                {
+                    Title = "Book Alpha",
+                    Author = "Author Alpha",
+                    Highlights =
+                    [
+                        new SyncHighlightRequest { Text = "The secret of getting ahead is getting started." },
+                        new SyncHighlightRequest { Text = "Courage is resistance to fear." }
+                    ]
+                },
+                new SyncBookRequest
+                {
+                    Title = "Book Beta",
+                    Author = "Author Beta",
+                    Highlights =
+                    [
+                        new SyncHighlightRequest { Text = "In the middle of every difficulty lies opportunity." }
+                    ]
+                }
+            ]
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+}


### PR DESCRIPTION
Adds a new `GET /highlights` endpoint that returns a paginated, optionally filtered list of all highlights stored in the database.

## Endpoint

```
GET /highlights?page=1&pageSize=50&q=<filter>
```

| Parameter  | Type   | Default | Constraints      | Description |
|------------|--------|---------|------------------|-------------|
| `page`     | int    | 1       | ≥ 1              | 1-based page number |
| `pageSize` | int    | 50      | 1–200            | Items per page |
| `q`        | string | —       | optional         | Case-insensitive substring filter on text, book title, or author name |

### Response — 200 OK

```json
{
  "total": 312,
  "page": 1,
  "pageSize": 50,
  "items": [
    { "id": 1, "text": "...", "bookTitle": "...", "authorName": "..." }
  ]
}
```

### Errors
- **422** — `page < 1` or `pageSize` out of range

## Changes

### Core
- New `HighlightsResponse` and `HighlightItemDto` contracts

### Server
- `HighlightRepository` — paginated + filtered SQL query with JOIN on books and authors
- `HighlightEndpoints` — `GET /highlights` registered unconditionally
- `Program.cs` — registers `HighlightRepository`, calls `MapHighlightEndpoints()`

### Tests (12 new)
- Empty database → total 0
- Seeded data → returns all items with correct fields
- Pagination — page 2 with pageSize 2 returns 1 item and correct total
- Filter by text, book title, author name — returns matching items only
- Filter with no match → empty list
- Invalid \`page\` (0) → 422
- Invalid \`pageSize\` (0 and 201) → 422

### Version bumps
- `SunnySunday.Core`: `0.6.1` → `0.6.2`
- `SunnySunday.Server`: `0.9.4` → `0.9.5`

Closes #166