### PR TITLE
Server: disable TLS and skip SMTP credentials in Development environment

### DIFF
--- a/src/SunnySunday.Server/Program.cs
+++ b/src/SunnySunday.Server/Program.cs
@@ -92,7 +92,12 @@ builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete
 builder.Services.AddSingleton<ISchedulerService, SchedulerService>();
 builder.Services.AddTransient<RecapJob>();
 builder.Services.AddScoped<HighlightSelectionService>();
-builder.Services.AddScoped<IMailDeliveryService, MailDeliveryService>();
+
+if (builder.Environment.IsDevelopment())
+    builder.Services.AddScoped<IMailDeliveryService, DevMailDeliveryService>();
+else
+    builder.Services.AddScoped<IMailDeliveryService, MailDeliveryService>();
+
 builder.Services.AddScoped<IRecapService, RecapService>();
 
 var app = builder.Build();

--- a/src/SunnySunday.Server/Services/DevMailDeliveryService.cs
+++ b/src/SunnySunday.Server/Services/DevMailDeliveryService.cs
@@ -1,0 +1,51 @@
+﻿using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using SunnySunday.Server.Infrastructure.Smtp;
+
+namespace SunnySunday.Server.Services;
+
+/// <summary>
+/// Mail delivery service for the Development environment.
+/// Connects to a local SMTP relay (e.g. smtp4dev) without TLS and without credentials.
+/// The sender address is always "sunny-sunday" regardless of configuration.
+/// </summary>
+public sealed class DevMailDeliveryService : IMailDeliveryService
+{
+    private readonly SmtpSettings _settings;
+
+    public DevMailDeliveryService(IOptions<SmtpSettings> settings)
+    {
+        _settings = settings.Value;
+    }
+
+    public async Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default)
+    {
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sunny Sunday", "sunny-sunday"));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = "Your Sunny Sunday Recap";
+
+        var body = new TextPart("plain")
+        {
+            Text = "Your Kindle highlight recap is attached."
+        };
+
+        var attachment = new MimePart("application", "epub+zip")
+        {
+            Content = new MimeContent(new MemoryStream(epubContent)),
+            ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+            ContentTransferEncoding = ContentEncoding.Base64,
+            FileName = fileName
+        };
+
+        var multipart = new Multipart("mixed") { body, attachment };
+        message.Body = multipart;
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(_settings.Host, _settings.Port, SecureSocketOptions.None, cancellationToken);
+        await client.SendAsync(message, cancellationToken);
+        await client.DisconnectAsync(quit: true, cancellationToken);
+    }
+}

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Server/appsettings.Development.json
+++ b/src/SunnySunday.Server/appsettings.Development.json
@@ -10,6 +10,6 @@
     "Port": 2525,
     "Username": "",
     "Password": "",
-    "FromAddress": "sunny@localhost.com"
+    "FromAddress": "sunny-sunday@smt4dev.com"
   }
 }


### PR DESCRIPTION
In the Development environment the server now uses a dedicated `DevMailDeliveryService` that is compatible with smtp4dev (the local relay started by the devcontainer on port 2525) without any further configuration.

## Changes

### New `DevMailDeliveryService`
- Connects with `SecureSocketOptions.None` — no TLS, no opportunistic STARTTLS
- Never calls `AuthenticateAsync` regardless of configured credentials
- Hardcodes the sender address to `sunny-sunday@smtp4dev.com` (ignores `SMTP_FROM_ADDRESS`)

### `Program.cs`
- `DevMailDeliveryService` is registered for `IMailDeliveryService` in Development
- `MailDeliveryService` (production) is registered in all other environments
- No branching inside either service — the environment decision lives entirely at the DI registration level

### `appsettings.Development.json`
- `Smtp.FromAddress` updated to `"sunny-sunday"` for consistency

### Version bump
- `SunnySunday.Server`: `0.10.0` → `0.10.1`

Closes #156