### PR TITLE
README: add SMTP configuration quick reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ docker run -d \
   ghcr.io/krusty93/sunnysunday.server:latest
 ```
 
+Replace the `SMTP_*` values with those for your provider. The following table contains the common ones:
+
+|         | SMTP_HOST             | SMTP_PORT | SMTP_USER       | SMTP_PASSWORD              | Notes                                                                                       |
+|---------|-----------------------|-----------|-----------------|----------------------------|---------------------------------------------------------------------------------------------|
+| GMail   | smtp.gmail.com        | 587       | you@gmail.com   | your-app-password          | requires an [App Password](https://myaccount.google.com/apppasswords) (2FA must be enabled) |
+| Outlook | smtp-mail.outlook.com | 587       | you@outlook.com | yourpassword               | use your full Microsoft account email as `SMTP_USER`                                        |
+| iCloud  | smtp.mail.me.com      | 587       | you@icloud.com  | your-app-specific-password | requires an [app-specific password](https://support.apple.com/en-us/102654)                 |
+
 ### 3. Sync the Kindle highlights
 
 Upload highlights to the server using the CLI. It automatically detects the path to your Kindle:

--- a/README.md
+++ b/README.md
@@ -38,13 +38,11 @@ docker run -d \
   ghcr.io/krusty93/sunnysunday.server:latest
 ```
 
-Replace the `SMTP_*` values with those for your provider. The following table contains the common ones:
+Replace the `SMTP_*` values with those for your provider.
 
-|         | SMTP_HOST             | SMTP_PORT | SMTP_USER       | SMTP_PASSWORD              | Notes                                                                                       |
-|---------|-----------------------|-----------|-----------------|----------------------------|---------------------------------------------------------------------------------------------|
-| GMail   | smtp.gmail.com        | 587       | you@gmail.com   | your-app-password          | requires an [App Password](https://myaccount.google.com/apppasswords) (2FA must be enabled) |
-| Outlook | smtp-mail.outlook.com | 587       | you@outlook.com | yourpassword               | use your full Microsoft account email as `SMTP_USER`                                        |
-| iCloud  | smtp.mail.me.com      | 587       | you@icloud.com  | your-app-specific-password | requires an [app-specific password](https://support.apple.com/en-us/102654)                 |
+> Gmail and Outlook personal accounts do not support SMTP with password authentication.
+>
+> Use a free SMTP relay like [Resend](https://resend.com/docs/send-with-smtp), [MailerSend](https://www.mailersend.com/help/smtp-relay) or [Mailgun](https://www.mailgun.com/features/smtp-server/) instead. They offer a free tier with a generous limit of free emails. Otherwise, you can use your own SMPT relay server.
 
 ### 3. Sync the Kindle highlights
 

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -40,34 +40,6 @@ docker run -d \
 
 That's it. The server is running and will start sending recaps on the default schedule (daily at 18:00 client's local time).
 
-#### SMTP provider quick reference
-
-Replace the `SMTP_*` values with those for your provider:
-
-**Gmail** — requires an [App Password](https://myaccount.google.com/apppasswords) (2FA must be enabled):
-```sh
--e SMTP_HOST=smtp.gmail.com \
--e SMTP_PORT=587 \
--e SMTP_USER=you@gmail.com \
--e SMTP_PASSWORD=your-app-password
-```
-
-**Outlook / Hotmail** — use your full Microsoft account email as `SMTP_USER`:
-```sh
--e SMTP_HOST=smtp-mail.outlook.com \
--e SMTP_PORT=587 \
--e SMTP_USER=you@outlook.com \
--e SMTP_PASSWORD=yourpassword
-```
-
-**iCloud Mail** — requires an [app-specific password](https://support.apple.com/en-us/102654):
-```sh
--e SMTP_HOST=smtp.mail.me.com \
--e SMTP_PORT=587 \
--e SMTP_USER=you@icloud.com \
--e SMTP_PASSWORD=your-app-specific-password
-```
-
 ### Client CLI
 
 **Option A — Docker (no install required):**

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -40,6 +40,34 @@ docker run -d \
 
 That's it. The server is running and will start sending recaps on the default schedule (daily at 18:00 client's local time).
 
+#### SMTP provider quick reference
+
+Replace the `SMTP_*` values with those for your provider:
+
+**Gmail** — requires an [App Password](https://myaccount.google.com/apppasswords) (2FA must be enabled):
+```sh
+-e SMTP_HOST=smtp.gmail.com \
+-e SMTP_PORT=587 \
+-e SMTP_USER=you@gmail.com \
+-e SMTP_PASSWORD=your-app-password
+```
+
+**Outlook / Hotmail** — use your full Microsoft account email as `SMTP_USER`:
+```sh
+-e SMTP_HOST=smtp-mail.outlook.com \
+-e SMTP_PORT=587 \
+-e SMTP_USER=you@outlook.com \
+-e SMTP_PASSWORD=yourpassword
+```
+
+**iCloud Mail** — requires an [app-specific password](https://support.apple.com/en-us/102654):
+```sh
+-e SMTP_HOST=smtp.mail.me.com \
+-e SMTP_PORT=587 \
+-e SMTP_USER=you@icloud.com \
+-e SMTP_PASSWORD=your-app-specific-password
+```
+
 ### Client CLI
 
 **Option A — Docker (no install required):**


### PR DESCRIPTION
Include a quick reference in the README for configuring SMTP with Gmail, Outlook, and iCloud. Remove outdated advice and revert previous changes for clarity.

Close #158