### PR TITLE
Server: expose POST /dev/recap/trigger endpoint in Development environment

### DIFF
--- a/docs/DX.md
+++ b/docs/DX.md
@@ -278,6 +278,27 @@ Errors are actionable — they tell the user exactly what to do.
 
 ---
 
+## Development endpoints
+
+These endpoints are registered **only when `ASPNETCORE_ENVIRONMENT=Development`** and appear in the local Swagger UI (`http://localhost:8080/swagger`).
+
+### `POST /dev/recap/trigger`
+
+Executes the full recap pipeline immediately (highlight selection → EPUB composition → email delivery via smtp4dev) without waiting for the scheduled time.
+
+```sh
+curl -X POST http://localhost:8080/dev/recap/trigger
+```
+
+Response:
+```json
+{ "status": "triggered", "scheduledFor": "2026-05-06T14:32:00Z" }
+```
+
+Returns `500` with an error message if the pipeline throws.
+
+---
+
 ## Decisions
 
 - `sunny sync` auto-detects the Kindle mount path on macOS, Linux, and Windows. If not found, it prompts the user to enter the path interactively.

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -278,27 +278,6 @@ Errors are actionable — they tell the user exactly what to do.
 
 ---
 
-## Development endpoints
-
-These endpoints are registered **only when `ASPNETCORE_ENVIRONMENT=Development`** and appear in the local Swagger UI (`http://localhost:8080/swagger`).
-
-### `POST /dev/recap/trigger`
-
-Executes the full recap pipeline immediately (highlight selection → EPUB composition → email delivery via smtp4dev) without waiting for the scheduled time.
-
-```sh
-curl -X POST http://localhost:8080/dev/recap/trigger
-```
-
-Response:
-```json
-{ "status": "triggered", "scheduledFor": "2026-05-06T14:32:00Z" }
-```
-
-Returns `500` with an error message if the pipeline throws.
-
----
-
 ## Decisions
 
 - `sunny sync` auto-detects the Kindle mount path on macOS, Linux, and Windows. If not found, it prompts the user to enter the path interactively.

--- a/src/SunnySunday.Server/Endpoints/DevEndpoints.cs
+++ b/src/SunnySunday.Server/Endpoints/DevEndpoints.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using SunnySunday.Server.Data;
+using SunnySunday.Server.Services;
+
+namespace SunnySunday.Server.Endpoints;
+
+/// <summary>
+/// Development-only endpoints. Registered exclusively when the host environment is Development.
+/// </summary>
+public static class DevEndpoints
+{
+    public static WebApplication MapDevEndpoints(this WebApplication app)
+    {
+        app.MapPost("/dev/recap/trigger", async (
+            [FromServices] UserRepository userRepo,
+            [FromServices] IRecapService recapService,
+            CancellationToken ct) =>
+        {
+            var userId = await userRepo.EnsureUserAsync();
+            var scheduledFor = DateTimeOffset.UtcNow;
+
+            try
+            {
+                await recapService.ExecuteAsync(userId, scheduledFor, ct);
+                return Results.Ok(new { status = "triggered", scheduledFor });
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        })
+        .WithSummary("Trigger a recap immediately (Development only).")
+        .WithDescription("Executes the full recap pipeline synchronously for the implicit user. Only available in the Development environment.")
+        .Produces(StatusCodes.Status200OK)
+        .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+        return app;
+    }
+}

--- a/src/SunnySunday.Server/Program.cs
+++ b/src/SunnySunday.Server/Program.cs
@@ -108,6 +108,7 @@ if (app.Environment.IsDevelopment())
     {
         options.DisplayRequestDuration();
     });
+    app.MapDevEndpoints();
 }
 
 app.MapGet("/", () => "Sunny Sunday server is running.");

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.10.2</Version>
+    <Version>0.10.3</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Adds a dev-only endpoint to trigger the full recap pipeline immediately without waiting for the Quartz schedule.

## Changes

### New `DevEndpoints.cs`
- `POST /dev/recap/trigger` — resolves user ID 1, calls `IRecapService.ExecuteAsync(userId, DateTimeOffset.UtcNow)`, returns `{ "status": "triggered", "scheduledFor": "<utc-iso>" }` on success or `500` on error
- OpenAPI summary/description included (visible in dev Swagger UI only)

### `Program.cs`
- `app.MapDevEndpoints()` called inside the existing `if (app.Environment.IsDevelopment())` block — never registered in production

### `docs/DX.md`
- New **Development endpoints** section documenting `POST /dev/recap/trigger` with curl example and response shape

### Version bump
- `SunnySunday.Server`: `0.10.2` → `0.10.3`

Closes #160