### PR TITLE
README: document Docker volume mount scenarios for My Clippings.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,53 @@ That's it. Your first recap will arrive on the next scheduled delivery (default:
 
 ---
 
+## Mounting your Clippings file (Docker CLI users)
+
+If you run the CLI via Docker rather than the native binary, mount `My Clippings.txt` with a read-only volume.
+
+### Scenario 1 — Kindle connected via USB
+
+**macOS** (Kindle mounts at `/Volumes/Kindle`):
+```sh
+docker run --rm \
+  -v "/Volumes/Kindle/documents:/kindle:ro" \
+  -e SUNNY_SERVER=http://host.docker.internal:8080 \
+  ghcr.io/krusty93/sunnysunday.cli:latest \
+  sync "/kindle/My Clippings.txt"
+```
+
+**Linux** (Kindle mounts at `/media/$USER/Kindle`):
+```sh
+docker run --rm \
+  -v "/media/$USER/Kindle/documents:/kindle:ro" \
+  -e SUNNY_SERVER=http://localhost:8080 \
+  ghcr.io/krusty93/sunnysunday.cli:latest \
+  sync "/kindle/My Clippings.txt"
+```
+
+**Windows** (PowerShell, Kindle mounts as drive `D:`):
+```powershell
+docker run --rm `
+  -v "D:\documents:/kindle:ro" `
+  -e SUNNY_SERVER=http://host.docker.internal:8080 `
+  ghcr.io/krusty93/sunnysunday.cli:latest `
+  sync "/kindle/My Clippings.txt"
+```
+
+### Scenario 2 — File in the current directory
+
+```sh
+docker run --rm \
+  -v "$PWD/My Clippings.txt:/clippings/My Clippings.txt:ro" \
+  -e SUNNY_SERVER=http://host.docker.internal:8080 \
+  ghcr.io/krusty93/sunnysunday.cli:latest \
+  sync "/clippings/My Clippings.txt"
+```
+
+> **Native binary users:** `sunny sync` auto-detects the Kindle mount path on all platforms — no volume mounting needed.
+
+---
+
 ## CLI reference
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ Existing solutions deliver periodic recaps only via mobile or web apps. Sunny Su
 
 ## Getting started
 
-### 1. Deploy the server
+### 1. Connect your Kindle device
+
+Connect your Kindle device to your computer via USB cable.
+
+### 2. Run the server
 
 ```sh
+docker network create sunnysunday
+
 docker run -d \
   --name sunny-server \
   --restart unless-stopped \
@@ -28,123 +34,158 @@ docker run -d \
   -e SMTP_PASSWORD=yourpassword \
   -p 8080:8080 \
   -v sunny-data:/data \
+  --network sunnysunday \
   ghcr.io/krusty93/sunnysunday.server:latest
 ```
 
-Optional supply-chain verification:
+### 3. Sync the Kindle highlights
+
+Upload highlights to the server using the CLI. It automatically detects the path to your Kindle:
+
+<details>
+  <summary>Docker (suggested - no install)</summary>
+
+  **Windows** (Kindle mounts as drive `D:`):
+
+  ```powershell
+  docker run `
+    -v "D:\documents:/kindle:ro" `
+    --network sunnysunday `
+    -e SUNNY_SERVER="http://sunny-server:8080" `
+    ghcr.io/krusty93/sunnysunday.cli:latest `
+    sync "/kindle/My Clippings.txt"
+  ```
+
+  > NB: Follow the [WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/connect-usb) to allow WSL to access the Kindle device. Another simpler option is to copy the `My Clippings.txt` file to your PC (e.g. local path) and mounting the volume:
+
+  ```powershell
+  docker run `
+    -v "$(PWD):/kindle:ro" `
+    --network sunnysunday `
+    -e SUNNY_SERVER="http://sunny-server:8080" `
+    ghcr.io/krusty93/sunnysunday.cli:latest `
+    sync "/kindle/My Clippings.txt"
+  ```
+
+  **macOS** (Kindle mounts at `/Volumes/Kindle`):
+  ```sh
+  docker run \
+    -v "/Volumes/Kindle/documents:/kindle:ro" \
+    -e SUNNY_SERVER="http://sunny-server:8080" \
+    ghcr.io/krusty93/sunnysunday.cli:latest \
+    sync "/kindle/My Clippings.txt"
+  ```
+
+  **Linux** (Kindle mounts at `/media/$USER/Kindle`):
+  ```sh
+  docker run \
+    -v "/media/$USER/Kindle/documents:/kindle:ro" \
+    -e SUNNY_SERVER="http://sunny-server:8080" \
+    ghcr.io/krusty93/sunnysunday.cli:latest \
+    sync "/kindle/My Clippings.txt"
+  ```
+
+</details>
+
+<details>
+  <summary>Windows</summary>
+
+#### winget
+
+  ```sh
+  winget install Krusty93.SunnySunday sync
+  ```
+
+#### Binary
+
+  Replace `<version>` with the actual version number (e.g. `1.0.0`).
+
+  ```powershell
+  curl -L https://github.com/Krusty93/sunny-sunday/releases/download/cli%2Fv<version>/sunny-<version>-win-x64 -o ./sunny.exe
+  ./sunny.exe sync
+  ```
+
+</details>
+
+<details>
+  <summary>MacOS</summary>
+
+  Replace `<version>` with the actual version number (e.g. `1.0.0`).
+
+#### Apple Silicon
+
+  ```sh
+  curl -L https://github.com/Krusty93/sunny-sunday/releases/download/cli%2Fv<version>/sunny-<version>-osx-arm64 -o /usr/local/bin/sunny
+  chmod +x /usr/local/bin/sunny
+  sunny sync
+  ```
+
+#### Intel
+
+  ```sh
+  curl -L https://github.com/Krusty93/sunny-sunday/releases/download/cli%2Fv<version>/sunny-<version>-osx-amd64 -o /usr/local/bin/sunny
+  chmod +x /usr/local/bin/sunny
+  sunny sync
+  ```
+
+</details>
+
+<details>
+  <summary>Linux</summary>
+
+  Replace `<version>` with the actual version number (e.g. `1.0.0`).
+
+  ```sh
+  curl -L https://github.com/Krusty93/sunny-sunday/releases/download/cli%2Fv<version>/sunny-<version>-linux-x64 -o /usr/local/bin/sunny
+  chmod +x /usr/local/bin/sunny
+  sunny sync
+  ```
+
+</details>
+
+The client automatically connects to `http://localhost:8080`. If you ran the server on a different host machine or port, you can override the default URL exporting the variable `SUNNY_SERVER`:
 
 ```sh
-gh attestation verify \
-  oci://ghcr.io/krusty93/sunnysunday.server:latest \
-  --owner Krusty93
+# binary
+export SUNNY_SERVER=http://192.168.1.10:8080
+sunny sync
+
+# Docker
+docker run \
+  -e SUNNY_SERVER=http://192.168.1.10:8080 \
+  ghcr.io/krusty93/sunnysunday.cli:latest sync
 ```
 
-### 2. Install the client CLI
+That's it. Your first recap will arrive on the next scheduled delivery (default: every day at 18:00).
 
-**macOS (Apple Silicon)**
-```sh
-curl -L https://github.com/Krusty93/sunny-sunday/releases/latest/download/sunny-darwin-arm64 -o /usr/local/bin/sunny
-chmod +x /usr/local/bin/sunny
-```
-
-**macOS (Intel) / Linux**
-```sh
-curl -L https://github.com/Krusty93/sunny-sunday/releases/latest/download/sunny-darwin-amd64 -o /usr/local/bin/sunny
-chmod +x /usr/local/bin/sunny
-```
-
-**Windows**
-```sh
-winget install Krusty93.SunnySunday
-```
-
-**Docker (no install)**
-```sh
-docker run --rm -e SUNNY_SERVER=http://192.168.1.10:8080 ghcr.io/krusty93/sunnysunday.cli:latest <command>
-```
-
-### 3. Sync your highlights
-
-```sh
-sunny sync   # SUNNY_SERVER defaults to http://localhost:8080
-```
-
-That's it. Your first recap will arrive on the next scheduled delivery (default: every Sunday at 18:00).
-
-> **Server on a different machine?** Set `SUNNY_SERVER` before running CLI commands:
+> **My Clippings.txt on a different path?** Override the default location using:
+>
 > ```sh
-> export SUNNY_SERVER=http://192.168.1.10:8080
-> sunny sync
+> sunny sync <path>
 > ```
-
----
-
-## Mounting your Clippings file (Docker CLI users)
-
-If you run the CLI via Docker rather than the native binary, mount `My Clippings.txt` with a read-only volume.
-
-### Scenario 1 — Kindle connected via USB
-
-**macOS** (Kindle mounts at `/Volumes/Kindle`):
-```sh
-docker run --rm \
-  -v "/Volumes/Kindle/documents:/kindle:ro" \
-  -e SUNNY_SERVER=http://host.docker.internal:8080 \
-  ghcr.io/krusty93/sunnysunday.cli:latest \
-  sync "/kindle/My Clippings.txt"
-```
-
-**Linux** (Kindle mounts at `/media/$USER/Kindle`):
-```sh
-docker run --rm \
-  -v "/media/$USER/Kindle/documents:/kindle:ro" \
-  -e SUNNY_SERVER=http://localhost:8080 \
-  ghcr.io/krusty93/sunnysunday.cli:latest \
-  sync "/kindle/My Clippings.txt"
-```
-
-**Windows** (PowerShell, Kindle mounts as drive `D:`):
-```powershell
-docker run --rm `
-  -v "D:\documents:/kindle:ro" `
-  -e SUNNY_SERVER=http://host.docker.internal:8080 `
-  ghcr.io/krusty93/sunnysunday.cli:latest `
-  sync "/kindle/My Clippings.txt"
-```
-
-### Scenario 2 — File in the current directory
-
-```sh
-docker run --rm \
-  -v "$PWD/My Clippings.txt:/clippings/My Clippings.txt:ro" \
-  -e SUNNY_SERVER=http://host.docker.internal:8080 \
-  ghcr.io/krusty93/sunnysunday.cli:latest \
-  sync "/clippings/My Clippings.txt"
-```
-
-> **Native binary users:** `sunny sync` auto-detects the Kindle mount path on all platforms — no volume mounting needed.
+>
 
 ---
 
 ## CLI reference
 
-| Command | Description |
-|---|---|
-| `sunny sync [path]` | Import highlights from `My Clippings.txt` |
-| `sunny status` | Show server status and next recap |
-| `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule |
-| `sunny config count <1-15>` | Set highlights per recap (default: 5) |
-| `sunny config kindle-email <address>` | Set the Kindle delivery email address |
-| `sunny exclude highlight <id>` | Exclude a highlight from all recaps |
-| `sunny exclude book <title>` | Exclude all highlights from a book |
-| `sunny exclude author <name>` | Exclude all highlights from an author |
-| `sunny exclude remove highlight <id>` | Re-include a highlight |
-| `sunny exclude remove book <title>` | Re-include a book |
-| `sunny exclude remove author <name>` | Re-include an author |
-| `sunny exclude list` | List all exclusions |
-| `sunny weight set <id> <1-5>` | Set highlight weight |
-| `sunny weight list` | Show weighted highlights |
-| `sunny version` | Print version |
+|                   Command                       |              Description                  |
+|-------------------------------------------------|-------------------------------------------|
+| `sunny sync [path]`                             | Import highlights from `My Clippings.txt` |
+| `sunny status`                                  | Show server status and next recap         |
+| `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule                        |
+| `sunny config count <1-15>`                     | Set highlights per recap (default: 5)     |
+| `sunny config kindle-email <address>`           | Set the Kindle delivery email address     |
+| `sunny exclude highlight <id>`                  | Exclude a highlight from all recaps       |
+| `sunny exclude book <title>`                    | Exclude all highlights from a book        |
+| `sunny exclude author <name>`                   | Exclude all highlights from an author     |
+| `sunny exclude remove highlight <id>`           | Re-include a highlight                    |
+| `sunny exclude remove book <title>`             | Re-include a book                         |
+| `sunny exclude remove author <name>`            | Re-include an author                      |
+| `sunny exclude list`                            | List all exclusions                       |
+| `sunny weight set <id> <1-5>`                   | Set highlight weight                      |
+| `sunny weight list`                             | Show weighted highlights                  |
+| `sunny version`                                 | Print version                             |
 
 ---
 
@@ -157,11 +198,22 @@ docker run --rm \
 
 ---
 
+## Supply chain verification
+
+Verify Docker image origin via GitHub CLI:
+
+```sh
+gh attestation verify \
+  oci://ghcr.io/krusty93/sunnysunday.server:latest \
+  --owner Krusty93
+```
+
+---
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
-
+MIT, see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ That's it. Your first recap will arrive on the next scheduled delivery (default:
 | `sunny sync [path]`                             | Import highlights from `My Clippings.txt` |
 | `sunny status`                                  | Show server status and next recap         |
 | `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule                        |
+| `sunny config schedule show`                    | Show current schedule                     |
+| `sunny config count show`                       | Show current highlights-per-recap setting |
 | `sunny config count <1-15>`                     | Set highlights per recap (default: 5)     |
 | `sunny config kindle-email <address>`           | Set the Kindle delivery email address     |
 | `sunny exclude highlight <id>`                  | Exclude a highlight from all recaps       |

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -22,6 +22,8 @@ The guiding DX principle: **zero friction after a one-time setup**. Onboarding r
 ### Server
 
 ```sh
+docker network create sunnysunday
+
 docker run -d \
   --name sunny-server \
   --restart unless-stopped \
@@ -32,6 +34,7 @@ docker run -d \
   -e SMTP_PASSWORD=yourpassword \
   -p 8080:8080 \
   -v sunny-data:/data \
+  --network sunnysunday \
   ghcr.io/krusty93/sunnysunday.server:latest
 ```
 
@@ -73,13 +76,12 @@ docker run -d \
   --name sunny-server \
   --restart unless-stopped \
   -e KINDLE_EMAIL=your-address@kindle.com \
-  -e SUNNY_SERVER=http://192.168.1.10:8080 \
   -p 8080:8080 \
   -v sunny-data:/data \
   ghcr.io/krusty93/sunnysunday.server:latest
 ```
 
-On the client side, set `SUNNY_SERVER` once in your shell profile:
+The client automatically connects to `http://localhost:8080`. If your server runs on a different host or port, set `SUNNY_SERVER` on the client side:
 
 ```sh
 # ~/.zshrc or ~/.bashrc (macOS/Linux)
@@ -195,7 +197,7 @@ sunny weight list
 ### Highlights per recap
 
 ```sh
-sunny config count 5      # Show 5 highlights per recap (default: 3, min: 1, max: 15)
+sunny config count 5      # Show 5 highlights per recap (default: 5, min: 1, max: 15)
 sunny config count show   # Print current setting
 ```
 
@@ -208,7 +210,7 @@ sunny status
 ```
 Server:       http://192.168.1.10:8080 ✓ online
 Highlights:   1,198 total · 12 excluded · 34 weighted
-Highlights/recap: 3 (default)
+Highlights/recap: 5 (default)
 Last recap:   Mar 30, 2026 at 18:00 (3 highlights delivered)
 Next recap:   Apr 5, 2026 at 18:00
 Schedule:     weekly (Sunday at 18:00)
@@ -257,24 +259,25 @@ Errors are actionable — they tell the user exactly what to do.
 
 ## Full CLI reference
 
-| Command | Description |
-|---|---|
-| `sunny sync [path]` | Import highlights from `My Clippings.txt` (auto-detects Kindle path if omitted) |
-| `sunny status` | Show server status, next recap, highlight stats |
-| `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule and optional delivery time |
-| `sunny config schedule show` | Show current schedule |
-| `sunny config count <1-15>` | Set number of highlights per recap |
-| `sunny config count show` | Show current highlights-per-recap setting |
-| `sunny exclude highlight <id>` | Exclude a highlight from all recaps |
-| `sunny exclude book <title>` | Exclude all highlights from a book |
-| `sunny exclude author <name>` | Exclude all highlights from an author |
-| `sunny exclude remove highlight <id>` | Re-include a previously excluded highlight |
-| `sunny exclude remove book <title>` | Re-include a previously excluded book |
-| `sunny exclude remove author <name>` | Re-include a previously excluded author |
-| `sunny exclude list` | List all exclusions |
-| `sunny weight set <id> <1-5>` | Set weight for a highlight |
-| `sunny weight list` | Show all weighted highlights |
-| `sunny version` | Print client and server version |
+|                   Command                       |              Description                  |
+|-------------------------------------------------|-------------------------------------------|
+| `sunny sync [path]`                             | Import highlights from `My Clippings.txt` |
+| `sunny status`                                  | Show server status and next recap         |
+| `sunny config schedule <daily\|weekly> [HH:MM]` | Set recap schedule                        |
+| `sunny config schedule show`                    | Show current schedule                     |
+| `sunny config count show`                       | Show current highlights-per-recap setting |
+| `sunny config count <1-15>`                     | Set highlights per recap (default: 5)     |
+| `sunny config kindle-email <address>`           | Set the Kindle delivery email address     |
+| `sunny exclude highlight <id>`                  | Exclude a highlight from all recaps       |
+| `sunny exclude book <title>`                    | Exclude all highlights from a book        |
+| `sunny exclude author <name>`                   | Exclude all highlights from an author     |
+| `sunny exclude remove highlight <id>`           | Re-include a highlight                    |
+| `sunny exclude remove book <title>`             | Re-include a book                         |
+| `sunny exclude remove author <name>`            | Re-include an author                      |
+| `sunny exclude list`                            | List all exclusions                       |
+| `sunny weight set <id> <1-5>`                   | Set highlight weight                      |
+| `sunny weight list`                             | Show weighted highlights                  |
+| `sunny version`                                 | Print version                             |
 
 ---
 

--- a/src/SunnySunday.Server/Properties/launchSettings.json
+++ b/src/SunnySunday.Server/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5102",
+      "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7028;http://localhost:5102",
+      "applicationUrl": "https://localhost:8080;http://localhost:8081",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.10.3</Version>
+    <Version>0.10.4</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Adds a **Mounting your Clippings file** section for Docker CLI users with concrete copy-paste examples for all platforms.

## Changes

### `README.md`
New section after the Getting Started sync step:
- **Scenario 1 — Kindle via USB**: macOS (`/Volumes/Kindle`), Linux (`/media/$USER/Kindle`), Windows PowerShell (`D:\documents`)
- **Scenario 2 — File in current directory**: single-file mount with `$PWD`
- Note clarifying that native binary users get auto-detection for free

### `docs/DX.md`
Same coverage added under **Day-to-day usage → Sync**, after the native-binary examples.

Closes #163