### PR TITLE
Remove unnecessary suppress message and update Serilog.Settings.Configuration package version

### DIFF
--- a/src/SunnySunday.Cli/Infrastructure/TypeRegistrar.cs
+++ b/src/SunnySunday.Cli/Infrastructure/TypeRegistrar.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 
 namespace SunnySunday.Cli.Infrastructure;
@@ -16,8 +15,6 @@ public sealed class TypeRegistrar(IServiceProvider services) : ITypeRegistrar
 
     public ITypeResolver Build() => new TypeResolver(services, _registrations, _instances, _factories);
 
-    [UnconditionalSuppressMessage("Trimming", "IL2067",
-        Justification = "Types registered by Spectre.Console.Cli are preserved via TrimMode=partial.")]
     public void Register(Type service, Type implementation)
         => _registrations[service] = implementation;
 

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.7</Version>
+    <Version>0.9.8</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Spectre.Console" Version="0.55.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
@@ -34,7 +34,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TrimMode>partial</TrimMode>
     <NoWarn>$(NoWarn);CA1724;</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Eliminate an unnecessary suppress message related to trimming and update the Serilog.Settings.Configuration package to version 10.0.0 for improved compatibility.

Close #205