### PR TITLE
Fix workflow for release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,6 @@ jobs:
             --runtime ${{ matrix.rid }} \
             --self-contained true \
             -p:PublishSingleFile=true \
-            -p:PublishTrimmed=true \
             --output publish/${{ matrix.rid }}
 
       - name: Rename Binary


### PR DESCRIPTION
Remove the `PublishTrimmed` option from the release workflow to address issues with the build process.

Fix #205