### PR TITLE
Evolve CLI to TUI: Replace Spectre.Console with Terminal.Gui

### DIFF
--- a/specs/007-evolve-cli-to-tui/plan.md
+++ b/specs/007-evolve-cli-to-tui/plan.md
@@ -5,18 +5,18 @@
 
 ## Summary
 
-Evolve the existing `sunny` CLI into a dual-mode application: when invoked without arguments, it launches a persistent interactive TUI built exclusively with Spectre.Console's `Layout`, `LiveDisplay`, `Panel`, `Table`, and `FigletText` APIs. When invoked with arguments, the existing `CommandApp` processes commands identically to today. The TUI provides a branded splash screen, always-visible status chrome, a navigable book list, highlight detail management, settings editing, and client-side search. One targeted server-side addition supports the TUI: a dedicated `POST /settings/test-email` endpoint for plain-text SMTP verification.
+Evolve the existing `sunny` CLI into a dual-mode application: when invoked without arguments, it launches a persistent interactive TUI built with Terminal.Gui v2. When invoked with arguments, the existing Spectre.Console.Cli `CommandApp` processes commands identically to today. The TUI provides a branded splash screen, always-visible status chrome, a navigable book list, highlight detail management, settings editing, and client-side search. One targeted server-side addition supports the TUI: a dedicated `POST /settings/test-email` endpoint for plain-text SMTP verification.
 
 ## Technical Context
 
 **Language/Version**: C# / .NET 10 (`net10.0` TFM)
-**Primary Dependencies**: Spectre.Console 0.55.0 (already in project) — `Layout`, `LiveDisplay`, `Panel`, `Table`, `FigletText`, `Markup`. No new UI framework.
+**Primary Dependencies**: Terminal.Gui 2.1.0 (new dependency) — `Application`, `Window`, `FrameView`, `View`, `Label`, `TableView`. Spectre.Console.Cli (already in project) continues to be used for CLI command routing.
 **Storage**: N/A — TUI is stateless; all data fetched from server REST API and cached in memory for the session.
 **Testing**: xUnit (existing `SunnySunday.Tests` project) — test data/logic layer, not rendering.
 **Target Platform**: Cross-platform CLI (Windows, macOS, Linux) — interactive terminals with ≥80×24.
 **Project Type**: CLI application with one supporting server endpoint addition
 **Performance Goals**: TUI startup < 3s (SC-007-01), search filtering < 200ms (SC-007-07), book list scrolling smooth with 100+ books (SC-007-05).
-**Constraints**: No new NuGet UI dependencies (FR-007-14). No changes to existing API endpoints (FR-007-18). One new server endpoint required: `POST /settings/test-email` (documented on #188). Single-user MVP. Custom render loop — Spectre.Console is NOT a TUI framework.
+**Constraints**: Terminal.Gui 2.1.0 added as a new NuGet dependency for TUI rendering (supersedes FR-007-14). No changes to existing API endpoints (FR-007-18). One new server endpoint required: `POST /settings/test-email` (documented on #188). Single-user MVP. Terminal.Gui provides a native event loop — no custom render loop needed.
 **Scale/Scope**: Single user, 3 screens, ~12 new source files in `Tui/` folder, 1 server endpoint addition, ~7 new test files.
 
 ## Constitution Check
@@ -32,13 +32,13 @@ Evolve the existing `sunny` CLI into a dual-mode application: when invoked witho
 | V. Tests Ship with Code | **PASS** | Unit tests for data/logic layer included per phase |
 | VI. Simplicity / YAGNI | **PASS** | No new frameworks, no new projects, no local caching beyond session |
 | Tech: C# / .NET 10 only | **PASS** | All new code is C# |
-| Tech: Spectre.Console | **PASS** | All TUI rendering via Spectre.Console APIs |
+| Tech: Terminal.Gui (TUI) | **PASS** | All TUI rendering via Terminal.Gui v2 APIs; Spectre.Console.Cli retained for CLI routing |
 | Tech: REST HTTP + JSON | **PASS** | TUI uses existing `SunnyHttpClient` methods |
 | Tech: Docker distribution | **PASS** | TUI runs in Docker with `-it` flag |
 | Exclusion: No web UI | **PASS** | TUI is terminal-based, not web |
 | Exclusion: No auth for MVP | **PASS** | No authentication added |
 
-**Post-design re-check**: All gates pass. No new NuGet packages introduced. Three new methods added to `SunnyHttpClient` (using existing HTTP infrastructure). `SunnyJsonContext` extended with two types for trimming compatibility. One new server-side endpoint (`POST /settings/test-email`) identified and documented on #188.
+**Post-design re-check**: All gates pass. Terminal.Gui 2.1.0 added as a new NuGet dependency to provide the event loop, widget system, and layout engine for TUI rendering. Spectre.Console.Cli is retained for CLI command routing. Three new methods added to `SunnyHttpClient` (using existing HTTP infrastructure). `SunnyJsonContext` extended with two types for trimming compatibility. One new server-side endpoint (`POST /settings/test-email`) identified and documented on #188.
 
 ## Project Structure
 
@@ -114,10 +114,10 @@ No constitution violations. No complexity justification needed.
 - [ ] T001 Create `src/SunnySunday.Cli/Tui/ViewModels/BookViewModel.cs`: record with `Title`, `Author`, `HighlightCount`, `IReadOnlyList<HighlightViewModel> Highlights`. Add static factory method `FromHighlights(IEnumerable<HighlightItemDto> items) → List<BookViewModel>` that groups by `(BookTitle, AuthorName)`. Namespace `SunnySunday.Cli.Tui.ViewModels`.
 - [ ] T002 Create `src/SunnySunday.Cli/Tui/ViewModels/HighlightViewModel.cs`: record with `Id`, `Text`, `BookTitle`, `AuthorName`, `IsExcluded`, `Weight`. Namespace `SunnySunday.Cli.Tui.ViewModels`.
 - [ ] T003 Create `src/SunnySunday.Cli/Tui/TuiApp.cs`: the main orchestrator class. Constructor takes `SunnyHttpClient`, `string serverUrl`, `string version`. Key responsibilities:
-  1. Build a Spectre `Layout` with three rows: Chrome, Content, KeyHints.
+  1. Initialize Terminal.Gui `Application` and create the root `Window`.
   2. Manage a `Stack<IScreen>` — push initial screen on startup.
-  3. Run the render loop: `AnsiConsole.Live(layout).StartAsync(async ctx => { while (!ct.IsCancellationRequested) { render current screen → layout["Content"]; ctx.Refresh(); key = Console.ReadKey(true); result = await currentScreen.HandleKeyAsync(key, ct); handle Push/Pop/Quit; } })`.
-  4. Set `Console.TreatControlCAsInput = true` on start, restore on exit.
+  3. Use Terminal.Gui's event loop (`Application.Run`) with `IScreen.CreateView()` producing `View` instances that are swapped into the content `FrameView` on navigation.
+  4. Handle `Q` and `Ctrl+C` via Terminal.Gui key bindings to stop `Application.Run` cleanly.
   5. Handle terminal size check: if < 80×24, display resize message instead of content.
   Public method: `Task RunAsync(CancellationToken ct)`.
 - [ ] T004 Modify `src/SunnySunday.Cli/Program.cs`: add TUI mode detection **before** `CommandApp` creation. Logic: if `args.Length == 0 && !Console.IsInputRedirected`, create `TuiApp` and call `RunAsync`. If `args.Length == 0 && Console.IsInputRedirected`, fall through to `CommandApp` (shows help). If `args.Length > 0`, fall through to `CommandApp` (existing behavior). Import `SunnySunday.Cli.Tui` namespace.
@@ -134,16 +134,16 @@ No constitution violations. No complexity justification needed.
 
 **Purpose**: Build the persistent header region (`StatusChrome`) that appears on every TUI screen: Figlet banner, version, server connection status, and Kindle email warning.
 
-- [ ] T009 Create `src/SunnySunday.Cli/Tui/StatusChrome.cs`: class that produces the chrome `IRenderable`. Constructor takes `string serverUrl`, `string version`. Methods:
+- [ ] T009 Create `src/SunnySunday.Cli/Tui/StatusChrome.cs`: class that produces the chrome `View`. Constructor takes `string serverUrl`, `string version`. Methods:
   1. `async Task RefreshAsync(SunnyHttpClient client, CancellationToken ct)` — calls `PingAsync` (`GET /`) to check connection (HTTP 200 = connected). If connected, calls `GetSettingsAsync` to check `KindleEmailConfigured`. Catches `HttpRequestException` → sets disconnected state.
-  2. `IRenderable Render()` — builds a `Rows` renderable containing:
-     - `FigletText("SunnySunday")` with accent color. If terminal width < 60, fall back to `Markup("[bold]SunnySunday[/]")`.
-     - Version line: `Markup($"v{version}")`.
+  2. `View Render()` — builds a Terminal.Gui `View` containing:
+     - ASCII art "SUNNY" banner with colored `Label` rows.
+     - Version line.
      - Connection status: green `● Connected to {url}` or red `● Disconnected — cannot reach {url}`.
      - Conditional warning: yellow `⚠ Kindle email not configured — recaps cannot be delivered` (only if `KindleEmailConfigured == false`).
   Properties: `bool IsConnected`, `bool KindleEmailConfigured`.
-- [ ] T010 Wire `StatusChrome` into `TuiApp.cs`: create `StatusChrome` in constructor, call `RefreshAsync` on startup and after each failed API call. Assign `StatusChrome.Render()` to `layout["Chrome"]` on each refresh cycle.
-- [ ] T011 Add key hint bar rendering to `TuiApp.cs`: assign `new Markup(currentScreen.KeyHints)` to `layout["KeyHints"]` on each refresh. Style with dim/grey markup.
+- [ ] T010 Wire `StatusChrome` into `TuiApp.cs`: create `StatusChrome` in constructor, call `RefreshAsync` on startup and after each failed API call. Add the chrome `View` to the root window layout.
+- [ ] T011 Add key hint bar rendering to `TuiApp.cs`: render a footer `View` with key hint labels sourced from `currentScreen.KeyHints`. Style with dim/grey color.
 
 **Checkpoint**: TUI displays Figlet banner, version, connection status, and (if applicable) Kindle email warning. These persist when navigating between screens.
 
@@ -155,7 +155,7 @@ No constitution violations. No complexity justification needed.
 
 - [ ] T012 Create `src/SunnySunday.Cli/Tui/BookListScreen.cs`: implements `IScreen`. State: `List<BookViewModel> books`, `List<BookViewModel> filteredBooks`, `int selectedIndex`, `bool isSearchActive`, `string searchQuery`.
   1. `InitializeAsync`: fetch all highlights from server (paginate through `GetHighlightsAsync` until all loaded), group into `BookViewModel` list via `BookViewModel.FromHighlights()`. Also fetch exclusions and weights to enrich `HighlightViewModel.IsExcluded` and `Weight` fields.
-  2. `Render()`: build a Spectre `Table` with columns Title, Author, Highlights. Highlight the selected row with a distinct style (e.g., `[bold on blue]`). If search is active, show search input line above table. If no books, show empty state message: "No highlights found. Run `sunny sync` to import."
+  2. `Render()`: build a Terminal.Gui `TableView` with columns Title, Author, Highlights. Highlight the selected row with a distinct style. If search is active, show search input above table. If no books, show empty state message: "No highlights found. Run `sunny sync` to import."
   3. `HandleKeyAsync`: `↑` = decrement selectedIndex (clamp), `↓` = increment (clamp), `Enter` = return `Push(new HighlightDetailScreen(selectedBook))`, `S` = return `Push(new SettingsScreen())`, `/` = activate search mode, `R` = refresh (re-fetch data from server and re-render), `Q` = return `Quit`, `Ctrl+C` = return `Quit`.
   4. `KeyHints`: `"[↑↓] Navigate · [Enter] View · [S] Settings · [/] Search · [R] Refresh · [Q] Quit"`.
   Constructor takes `SunnyHttpClient`.

--- a/specs/007-evolve-cli-to-tui/quickstart.md
+++ b/specs/007-evolve-cli-to-tui/quickstart.md
@@ -14,9 +14,9 @@
 
 ---
 
-## No New Dependencies
+## New Dependency: Terminal.Gui
 
-All TUI functionality uses Spectre.Console 0.55.0 (already referenced in `SunnySunday.Cli.csproj`). No new NuGet packages are required.
+The TUI uses **Terminal.Gui 2.1.0** (added to `SunnySunday.Cli.csproj`) as the TUI rendering framework. Spectre.Console.Cli is retained for CLI command routing. `dotnet restore` fetches the package automatically on first build.
 
 ---
 

--- a/specs/007-evolve-cli-to-tui/research.md
+++ b/specs/007-evolve-cli-to-tui/research.md
@@ -8,29 +8,27 @@
 
 ## Research Tasks & Findings
 
-### 1. Spectre.Console TUI Rendering Strategy (Custom Render Loop)
+### 1. TUI Rendering Strategy (Terminal.Gui v2)
 
-**Decision**: Build a custom render loop using `AnsiConsole.Live` + `Console.ReadKey(true)` to create a persistent interactive TUI within Spectre.Console
+**Decision**: Use Terminal.Gui v2 (`Terminal.Gui` NuGet package, version 2.1.0) as the TUI framework
 
 **Rationale**:
-- Spectre.Console 0.55.0 provides `Layout`, `Panel`, `Table`, `FigletText`, and `LiveDisplay` — all the building blocks needed for a persistent TUI.
-- Spectre.Console does **not** provide a built-in event loop, persistent keyboard input handling, or screen management. These must be implemented manually.
-- The pattern: `AnsiConsole.Live(rootLayout).StartAsync(async ctx => { while (!quit) { key = Console.ReadKey(true); handle(key); ctx.Refresh(); } })`.
-- `LiveDisplay` manages cursor positioning and differential updates, minimizing flicker. The `ctx.Refresh()` call triggers a re-render of the entire layout tree.
-- `Layout` provides split regions (e.g., top = chrome, center = content, bottom = key hints). Each region can be independently updated by swapping its `IRenderable` content.
-- Terminal raw mode is entered implicitly when using `Console.ReadKey(true)` (intercept mode — keys are not echoed).
+- Terminal.Gui v2 provides a native event loop (`Application.Run`), widget system (`View`, `Window`, `FrameView`, `Label`, `TableView`), and layout engine — removing the need for a custom render loop entirely.
+- `IScreen.CreateView()` returns a Terminal.Gui `View` that is mounted into a `FrameView` on screen push/pop. The framework handles all re-rendering, cursor management, and keyboard dispatch.
+- Screen transitions (push/pop) are implemented by replacing the content `FrameView`'s subview and calling `Application.Refresh()`.
+- Terminal.Gui v2 provides correct handling of `Ctrl+C`, terminal resize, and raw/cooked mode across all target platforms (Windows, macOS, Linux).
+- The `Application.Create()` → `_app.Init()` → `Application.Run(topLevel)` → `Application.Shutdown()` lifecycle integrates cleanly with `async/await` by running the event loop on the main thread.
 
 **Key implementation details**:
-- `Console.ReadKey(true)` is blocking — the render loop runs on the main thread, alternating between waiting for input and refreshing.
-- `Ctrl+C` must be handled explicitly: set `Console.TreatControlCAsInput = true` at TUI start, restore on exit.
-- `CancellationTokenSource` for coordinating shutdown — signal cancellation on `Q` or `Ctrl+C`, then exit the loop.
-- Screen transitions: each "screen" produces an `IRenderable` for the content area. Switching screens = swapping the content panel in the layout.
+- `Application.Create()` + `_app.Init()` set up the terminal driver before any view is created.
+- Each `IScreen` produces a `View` via `CreateView(Action<ScreenResult> navigate)` and optionally a toolbar `View` via `CreateToolbarView(...)`.
+- Navigation callbacks (`navigate(ScreenResult.Push(...))`, `navigate(ScreenResult.Pop())`) are invoked from within view key handlers.
+- `Application.Shutdown()` is called in a `finally` block to guarantee terminal restoration on exit.
 
 **Alternatives considered**:
-- **Terminal.Gui**: Full TUI framework with event loop, widgets, and layout engine. However, adding it violates FR-007-14 (Spectre.Console only) and constitution principle VI (YAGNI). It would also conflict with Spectre's ANSI output.
-- **gui.cs**: Same as Terminal.Gui (renamed). Same concerns apply.
-- **Spectre.Console `Prompt`-based flow**: Using sequential prompts (SelectionPrompt, TextPrompt) for each screen. Simpler but does not provide a persistent layout with always-visible chrome — each prompt clears the screen. Rejected for not meeting US-2 (persistent banner).
-- **Raw ANSI escape codes**: Full control but enormous effort and fragile cross-platform behavior. Spectre.Console already abstracts this.
+- **Spectre.Console custom render loop**: `AnsiConsole.Live` + `Console.ReadKey(true)`. Spectre.Console does not provide a built-in event loop, keyboard dispatch, or widget system. A fully custom render loop would be required, adding significant complexity for scrolling, focus management, and modal overlays. Rejected in favour of Terminal.Gui.
+- **Spectre.Console `Prompt`-based flow**: Sequential `SelectionPrompt` / `TextPrompt` screens. Does not support a persistent layout with always-visible chrome (each prompt clears the screen). Rejected for not meeting US-2.
+- **Raw ANSI escape codes**: Full control but enormous effort and fragile cross-platform behaviour. Terminal.Gui already abstracts this.
 
 ---
 
@@ -55,21 +53,24 @@
 
 ### 3. Screen Architecture Pattern
 
-**Decision**: Define an `IScreen` interface with `Render()` returning `IRenderable` and `HandleKeyAsync()` returning a screen transition result. The `TuiApp` orchestrator manages a screen stack.
+**Decision**: Define an `IScreen` interface with `CreateView(Action<ScreenResult>)` returning a Terminal.Gui `View` and a `navigate` callback for screen transitions. The `TuiApp` orchestrator manages a screen stack.
 
 **Rationale**:
 - Each TUI page (book list, highlight detail, settings) has distinct layout, data, and key bindings. An interface-based approach provides clean separation.
-- The screen stack pattern supports `Esc` = pop (go back) naturally. Pushing a new screen overlays the previous; popping restores it.
+- The screen stack pattern supports `Esc` = pop (go back) naturally. Pushing a new screen replaces the content frame; popping restores the previous view.
 - Screens own their data fetching and state. The orchestrator only manages transitions and the chrome.
-- This pattern is testable: screens can be unit-tested by calling `HandleKeyAsync` with synthetic `ConsoleKeyInfo` values and asserting the returned transition or state change.
+- This pattern is testable: screens can be unit-tested by verifying state mutations triggered by key bindings registered on the view.
 
-**Interface shape**:
+**Interface shape** (as implemented):
 ```csharp
 interface IScreen
 {
-    IRenderable Render();
-    Task<ScreenResult> HandleKeyAsync(ConsoleKeyInfo key, CancellationToken ct);
-    Task InitializeAsync(CancellationToken ct); // data loading on screen entry
+    View CreateView(Action<ScreenResult> navigate);
+    View? CreateToolbarView(Action<ScreenResult> navigate) => null;
+    int ToolbarHeight => 0;
+    Task InitializeAsync(CancellationToken cancellationToken);
+    string Title { get; }
+    IReadOnlyList<(string Key, string Label)> KeyHints { get; }
 }
 
 enum ScreenAction { None, Push, Pop, Quit }

--- a/specs/007-evolve-cli-to-tui/spec.md
+++ b/specs/007-evolve-cli-to-tui/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `007-evolve-cli-to-tui`  
 **Created**: 2026-05-09  
 **Status**: Draft  
-**Input**: User request: "Evolve the current sunny CLI (Spectre.Console) into a complete Terminal User Interface (TUI) to provide a richer, more guided, end-to-end user experience. The existing CLI command interface must be preserved — the TUI is an additional mode that activates when no command is given."
+**Input**: User request: "Evolve the current sunny CLI (Spectre.Console.Cli) into a complete Terminal User Interface (TUI) to provide a richer, more guided, end-to-end user experience. The existing CLI command interface must be preserved — the TUI is an additional mode that activates when no command is given."
 
 ## User Scenarios & Testing
 
@@ -140,18 +140,18 @@ A search bar allows the user to filter the book list table by typing a query. Th
 
 ---
 
-### User Story 8 — TUI Rendering Approach with Spectre.Console (Priority: P1)
+### User Story 8 — TUI Rendering Approach with Terminal.Gui (Priority: P1)
 
-The TUI is built using Spectre.Console's Live rendering, Layout, Panel, and Table APIs — not a full TUI framework. The application manages a custom render loop that listens for keyboard input and re-renders the screen layout on each interaction. This approach works within Spectre.Console's capabilities without introducing a new dependency.
+The TUI is built using Terminal.Gui v2 — a dedicated TUI framework with a native event loop, composable views, keyboard input dispatch, and layout engine. The application uses Terminal.Gui's `Application`, `Window`, `FrameView`, and `View` types to compose screens. Spectre.Console.Cli is still used exclusively for CLI command routing; Terminal.Gui handles only TUI rendering.
 
-**Why this priority**: The rendering approach is foundational — every TUI user story depends on a viable rendering strategy. Using Spectre.Console avoids adding a new framework but requires a custom render loop pattern.
+**Why this priority**: The rendering approach is foundational — every TUI user story depends on a viable rendering strategy. Terminal.Gui provides a built-in event loop, proper screen management, and widget composition that avoids the complexity and limitations of a custom render loop.
 
 **Independent Test**: Launch the TUI and verify that the screen renders correctly with panels and layout. Press keys and verify the screen updates without flickering or corruption.
 
 **Acceptance Scenarios**:
 
-1. **Given** Spectre.Console is the only UI library used, **When** the TUI starts, **Then** the screen is composed using Spectre.Console's Layout API with distinct regions (banner, status bar, content area).
-2. **Given** the TUI is running, **When** the user presses a key, **Then** the content area updates without full-screen flicker (using Spectre.Console's Live rendering for controlled updates).
+1. **Given** Terminal.Gui is the TUI framework, **When** the TUI starts, **Then** the screen is composed using Terminal.Gui's `Window` and `FrameView` types with distinct regions (banner, status bar, content area).
+2. **Given** the TUI is running, **When** the user presses a key, **Then** the content area updates without full-screen flicker (using Terminal.Gui's native event loop for controlled updates).
 3. **Given** the TUI is running, **When** the terminal is resized, **Then** the layout adjusts gracefully to the new terminal dimensions.
 4. **Given** the TUI is running, **When** the user presses `Q` or `Ctrl+C`, **Then** the TUI exits cleanly, restoring the terminal to its original state.
 
@@ -187,8 +187,8 @@ The TUI is built using Spectre.Console's Live rendering, Layout, Panel, and Tabl
 - **FR-007-12a**: Settings page MUST support sending a simple plain-text test email via `POST /settings/test-email` to verify SMTP configuration.
 - **FR-007-12b**: Settings page MUST support triggering a recap via `POST /dev/recap/trigger`, but ONLY when the .NET environment is `Development`. This option MUST be hidden in non-Development environments.
 - **FR-007-13**: TUI MUST provide a client-side search bar (activated by `/`) that filters the book list by title, author, and highlight text (case-insensitive).
-- **FR-007-14**: TUI MUST be built exclusively with Spectre.Console — no new UI framework dependencies.
-- **FR-007-15**: TUI MUST use Spectre.Console's Layout and Live rendering APIs for screen composition and flicker-free updates.
+- **FR-007-14**: TUI MUST use Terminal.Gui v2 as the TUI rendering framework. Spectre.Console.Cli continues to be used for CLI command routing when arguments are provided.
+- **FR-007-15**: TUI MUST use Terminal.Gui's `Application`, `Window`, `FrameView`, and `View` APIs for screen composition and event-driven rendering.
 - **FR-007-16**: TUI MUST provide visible key hints on each screen showing available actions and navigation shortcuts.
 - **FR-007-16a**: TUI MUST support a refresh action (`R` key) on every screen that re-fetches data from the server and re-renders the current screen without navigating away.
 - **FR-007-17**: TUI MUST exit cleanly on `Q` or `Ctrl+C`, restoring the terminal state.
@@ -219,8 +219,8 @@ The TUI is built using Spectre.Console's Live rendering, Layout, Panel, and Tabl
 
 ## Assumptions
 
-- Spectre.Console 0.55.0 (already in the project) supports the Layout, Live, Panel, Table, and FigletText APIs needed for TUI composition.
-- Spectre.Console does NOT provide a built-in event loop or persistent input handling; the TUI will implement a custom render loop using `Console.ReadKey` and `AnsiConsole.Live` for controlled re-rendering.
+- Terminal.Gui v2 (added as a new NuGet dependency) provides the event loop, input dispatch, widget composition, and layout engine needed for TUI rendering.
+- Spectre.Console.Cli continues to handle CLI command routing unchanged; Terminal.Gui is used exclusively for the TUI mode.
 - The REST API surface from features 004 and 005 is mostly sufficient for TUI functionality. One new endpoint is required: `POST /settings/test-email` to send a simple plain-text test email for SMTP verification. This missing API is documented as a comment on issue #188.
 - All data displayed in the TUI (books, highlights, settings) is fetched via existing REST endpoints and cached client-side for the duration of the TUI session.
 - Single-user architecture — no concurrent TUI sessions modifying the same server.

--- a/specs/007-evolve-cli-to-tui/tasks.md
+++ b/specs/007-evolve-cli-to-tui/tasks.md
@@ -3,7 +3,7 @@
 **Input**: Design documents from `/specs/007-evolve-cli-to-tui/`
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
 
-**Tests**: Included — xUnit tests for data/logic layer (mode detection, book grouping, search filter, screen key handling). Rendering output is NOT tested per research decision (Spectre.Console `LiveDisplay` bypasses `TestConsole`).
+**Tests**: Included — xUnit tests for data/logic layer (mode detection, book grouping, search filter, screen key handling). Rendering output is NOT tested directly per research decision (Terminal.Gui's `Application.Run` requires a real terminal driver; unit tests target logic and state only).
 
 **Organization**: Tasks are grouped by user story so each slice stays independently testable after the shared foundation is in place. The plan defines 7 phases matching 8 user stories: Phase 1 covers US1 (Dual-Mode) + US8 (Render Loop) as foundational infrastructure, Phase 2 covers US2 (Chrome), Phase 3 covers US3 (Book List) + US7 (Search), Phase 4 covers US4 (Highlight Detail), Phase 5 covers US5 (Test Email API), Phase 6 covers US6 (Settings), and Phase 7 handles polish and edge cases.
 
@@ -22,7 +22,7 @@
 - [X] T001 [P] [US8] Create `src/SunnySunday.Cli/Tui/IScreen.cs`: define `IScreen` interface with `Render() → IRenderable`, `HandleKeyAsync(ConsoleKeyInfo, CancellationToken) → Task<ScreenResult>`, `InitializeAsync(CancellationToken) → Task`, `KeyHints → string`. Define `ScreenAction` enum (`None`, `Push`, `Pop`, `Quit`) and `ScreenResult` record. Namespace `SunnySunday.Cli.Tui`.
 - [X] T002 [P] [US8] Create `src/SunnySunday.Cli/Tui/ViewModels/BookViewModel.cs`: record with `Title`, `Author`, `HighlightCount`, `IReadOnlyList<HighlightViewModel> Highlights`. Add static factory method `FromHighlights(IEnumerable<HighlightItemDto> items) → List<BookViewModel>` that groups by `(BookTitle, AuthorName)`.
 - [X] T003 [P] [US8] Create `src/SunnySunday.Cli/Tui/ViewModels/HighlightViewModel.cs`: record with `Id`, `Text`, `BookTitle`, `AuthorName`, `IsExcluded`, `Weight`.
-- [X] T004 [US8] Create `src/SunnySunday.Cli/Tui/TuiApp.cs`: main orchestrator class. Constructor takes `SunnyHttpClient`, `string serverUrl`, `string version`. Builds a Spectre `Layout` with three rows: Chrome, Content, KeyHints. Manages a `Stack<IScreen>`. Runs the render loop via `AnsiConsole.Live(layout).StartAsync` with `Console.ReadKey(true)` input loop. Sets `Console.TreatControlCAsInput = true` on start, restores on exit. Public method: `Task RunAsync(CancellationToken ct)`.
+- [X] T004 [US8] Create `src/SunnySunday.Cli/Tui/TuiApp.cs`: main orchestrator class. Constructor takes `SunnyHttpClient`, `string serverUrl`, `string version`. Initializes Terminal.Gui `Application`, creates a root `Window` with chrome, content `FrameView`, and footer bar. Manages a `Stack<IScreen>`. Runs the event loop via `Application.Run`. Handles `Q` and `Ctrl+C` to stop cleanly. Public method: `Task RunAsync(CancellationToken ct)`.
 - [X] T005 [US1] Modify `src/SunnySunday.Cli/Program.cs`: add TUI mode detection **before** `CommandApp` creation. Logic: if `args.Length == 0 && !Console.IsInputRedirected`, create `TuiApp` and call `RunAsync`; if `args.Length == 0 && Console.IsInputRedirected`, fall through to `CommandApp` (shows help); if `args.Length > 0`, fall through to `CommandApp` (existing behavior).
 - [X] T006 [P] Add `GetHighlightsAsync(int page, int pageSize, string? query, CancellationToken ct)` method to `src/SunnySunday.Cli/Infrastructure/SunnyHttpClient.cs`: calls `GET /highlights?page={page}&pageSize={pageSize}&q={query}`, returns `HighlightsResponse`. Add `PostTestEmailAsync(CancellationToken ct)` method: calls `POST /settings/test-email`, returns `HttpResponseMessage` (sends a simple plain-text test email, not a recap). Add `DeleteHighlightAsync(int id, CancellationToken ct)` method: calls `DELETE /highlights/{id}`, returns `HttpResponseMessage`. Add `PingAsync(CancellationToken ct)` method: calls `GET /`, returns `bool` (true if HTTP 200, false otherwise). Keep existing `PostTestRecapAsync` (calls `POST /dev/recap/trigger`) for dev-only use.
 - [X] T007 [P] Update `src/SunnySunday.Cli/Infrastructure/SunnyJsonContext.cs`: add `[JsonSerializable(typeof(HighlightsResponse))]` and `[JsonSerializable(typeof(HighlightItemDto))]` for trimming compatibility.
@@ -37,9 +37,9 @@
 
 **Purpose**: Build the persistent header region (`StatusChrome`) that appears on every TUI screen: Figlet banner, version, server connection status, and Kindle email warning. Covers US2 (Startup Splash and Always-Visible Chrome).
 
-- [X] T010 [US2] Create `src/SunnySunday.Cli/Tui/StatusChrome.cs`: class that produces the chrome `IRenderable`. Constructor takes `string serverUrl`, `string version`. `RefreshAsync(SunnyHttpClient, CancellationToken)` calls `PingAsync` (`GET /`) to check connection (HTTP 200 = connected); if connected, calls `GetSettingsAsync` to check `KindleEmailConfigured`; catches `HttpRequestException` → disconnected state. `Render()` builds a `Rows` renderable with: `FigletText("SunnySunday")` (fall back to `Markup("[bold]SunnySunday[/]")` if terminal width < 60), version line, connection status (green/red), conditional Kindle email warning (yellow). Exposes `IsConnected` and `KindleEmailConfigured` properties.
-- [X] T011 [US2] Wire `StatusChrome` into `TuiApp.cs`: create `StatusChrome` in constructor, call `RefreshAsync` on startup and after each failed API call. Assign `StatusChrome.Render()` to `layout["Chrome"]` on each refresh cycle.
-- [X] T012 [US2] Add key hint bar rendering to `TuiApp.cs`: assign `new Markup(currentScreen.KeyHints)` to `layout["KeyHints"]` on each refresh. Style with dim/grey markup.
+- [X] T010 [US2] Create `src/SunnySunday.Cli/Tui/StatusChrome.cs`: class that produces a chrome `View`. Constructor takes `string serverUrl`, `string version`. `RefreshAsync(SunnyHttpClient, CancellationToken)` calls `PingAsync` (`GET /`) to check connection; if connected, calls `GetSettingsAsync` to check `KindleEmailConfigured`; catches `HttpRequestException` → disconnected state. `Render()` builds a Terminal.Gui `View` with: ASCII art "SUNNY" banner with colored `Label` rows, version line, connection status (green/red), conditional Kindle email warning (yellow). Exposes `IsConnected` and `KindleEmailConfigured` properties.
+- [X] T011 [US2] Wire `StatusChrome` into `TuiApp.cs`: create `StatusChrome` in constructor, call `RefreshAsync` on startup and after each failed API call. Add the chrome `View` to the root window.
+- [X] T012 [US2] Add key hint bar rendering to `TuiApp.cs`: render a footer `View` with key hint `Label` pairs sourced from `currentScreen.KeyHints`. Style with dim/grey color.
 
 **Checkpoint**: TUI displays Figlet banner, version, connection status, and (if applicable) Kindle email warning. These persist when navigating between screens.
 
@@ -49,7 +49,7 @@
 
 **Purpose**: Implement the main landing screen showing all imported books in a navigable table, plus the client-side search filter. Covers US3 (Book List Main Screen) and US7 (Client-Side Search).
 
-- [X] T013 [US3] Create `src/SunnySunday.Cli/Tui/BookListScreen.cs`: implements `IScreen`. State: `List<BookViewModel> books`, `List<BookViewModel> filteredBooks`, `int selectedIndex`, `bool isSearchActive`, `string searchQuery`. `InitializeAsync`: fetch all highlights from server (paginate through `GetHighlightsAsync`), group into `BookViewModel` list via `BookViewModel.FromHighlights()`, enrich with exclusions and weights. `Render()`: build Spectre `Table` with Title, Author, Highlights columns; highlight selected row; show empty state if no books. `HandleKeyAsync`: `↑/↓` = navigate, `Enter` = `Push(HighlightDetailScreen)`, `S` = `Push(SettingsScreen)`, `/` = activate search, `R` = refresh (re-fetch data from server and re-render), `Q`/`Ctrl+C` = `Quit`. `KeyHints`: `"[↑↓] Navigate · [Enter] View · [S] Settings · [/] Search · [R] Refresh · [Q] Quit"`. Constructor takes `SunnyHttpClient`.
+- [X] T013 [US3] Create `src/SunnySunday.Cli/Tui/BookListScreen.cs`: implements `IScreen`. State: `List<BookViewModel> books`, `List<BookViewModel> filteredBooks`, `int selectedIndex`, `bool isSearchActive`, `string searchQuery`. `InitializeAsync`: fetch all highlights from server (paginate through `GetHighlightsAsync`), group into `BookViewModel` list via `BookViewModel.FromHighlights()`, enrich with exclusions and weights. `CreateView`: build Terminal.Gui `TableView` with Title, Author, Highlights columns; highlight selected row; show empty state if no books. Key bindings: `↑/↓` = navigate, `Enter` = `Push(HighlightDetailScreen)`, `S` = `Push(SettingsScreen)`, `/` = activate search, `R` = refresh, `Q`/`Ctrl+C` = `Quit`. `KeyHints`: `[("\u2191\u2193", "Navigate"), ("Enter", "View"), ("S", "Settings"), ("/", "Search"), ("R", "Refresh"), ("Q", "Quit")]`. Constructor takes `SunnyHttpClient`.
 - [X] T014 [P] [US7] Create `src/SunnySunday.Cli/Tui/SearchFilter.cs`: static class with method `List<BookViewModel> Apply(IEnumerable<BookViewModel> books, string query)`. Filters books where title, author, or any highlight text contains the query (case-insensitive, `OrdinalIgnoreCase`). Returns matching books with all their highlights.
 - [X] T015 [US7] Integrate search into `BookListScreen`: when search is active, keystrokes append to `searchQuery`, `Esc` clears search, `Backspace` removes last character. After each keystroke, apply `SearchFilter.Apply()` to `filteredBooks` and reset `selectedIndex` to 0. `Render()` uses `filteredBooks` when search is active. Show search input line above table. Show "No results matching '[query]'" for empty results.
 - [X] T016 [US3] Wire `BookListScreen` as the initial screen in `TuiApp.RunAsync()`: push `BookListScreen` onto the screen stack on startup.
@@ -96,13 +96,13 @@
 
 ## Phase 7: Polish, Edge Cases & Documentation
 
-**Purpose**: Handle edge cases (terminal size, disconnected server, non-interactive terminal, Figlet fallback), update architecture docs, and run full test suite.
+**Purpose**: Handle edge cases (terminal size, disconnected server, non-interactive terminal), update architecture docs, and run full test suite.
 
-- [ ] T026 [P] Implement terminal size check in `src/SunnySunday.Cli/Tui/TuiApp.cs`: on each render cycle, check `Console.WindowWidth` and `Console.WindowHeight`. If below 80×24, render a centered message: "Terminal too small. Please resize to at least 80×24." instead of the normal layout.
+- [ ] T026 [P] Implement terminal size check in `src/SunnySunday.Cli/Tui/TuiApp.cs`: on startup, check `Application.Screen.Bounds`. If below 80×24, render a centered message: "Terminal too small. Please resize to at least 80×24." instead of the normal layout.
 - [ ] T027 [P] Update `docs/ARCHITECTURE.md` and `README.md`: add the TUI architecture section and refresh the repository-level project presentation so the README reflects CLI mode, TUI mode, and SMTP verification capabilities.
 - [ ] T028 [P] Implement graceful server disconnection handling in TUI screens: when any `SunnyHttpClient` call throws `HttpRequestException` during a TUI action, catch it, update `StatusChrome.IsConnected = false`, and display an inline error message in the content area (e.g., "Cannot reach server. Check connection."). Do not crash the TUI.
-- [ ] T029 [P] Implement Figlet fallback in `src/SunnySunday.Cli/Tui/StatusChrome.cs`: if `Console.WindowWidth < 60`, render plain `Markup("[bold]SunnySunday[/]")` instead of `FigletText`.
-- [ ] T030 Implement clean exit in `src/SunnySunday.Cli/Tui/TuiApp.cs`: on quit (`Q` or `Ctrl+C`), restore `Console.TreatControlCAsInput = false`, clear the live display, and return control to the terminal cleanly.
+- [ ] T029 [P] Verify ASCII art banner in `src/SunnySunday.Cli/Tui/StatusChrome.cs` renders correctly at narrow terminal widths; confirm that the banner truncates gracefully without errors when the terminal is narrower than the banner width.
+- [ ] T030 Implement clean exit in `src/SunnySunday.Cli/Tui/TuiApp.cs`: on quit (`Q` or `Ctrl+C`), call `Application.RequestStop()` and ensure `Application.Shutdown()` is called in the `finally` block to restore terminal state cleanly.
 - [ ] T031 Run full test suite: `dotnet test src/SunnySunday.slnx`. Confirm no regressions across all existing parser, API, CLI, infrastructure, recap, and settings test-email API tests. All new TUI tests pass.
 
 **Checkpoint**: All edge cases handled. Architecture docs updated. Full test suite green. TUI is feature-complete per spec.
@@ -181,8 +181,8 @@ The smallest demonstrable increment is **Phase 1 + Phase 2 + Phase 3** — a use
 
 ## Notes
 
-- No new NuGet packages — all TUI rendering uses Spectre.Console 0.55.0 (already in project).
+- Terminal.Gui 2.1.0 added as a new NuGet dependency for TUI rendering. Spectre.Console.Cli is retained for CLI command routing.
 - One targeted server-side change is included: `POST /settings/test-email` plus the supporting mail-delivery contract.
-- Testing strategy focuses on data/logic layer (mode detection, grouping, search, key handling). Spectre.Console `LiveDisplay` rendering is NOT unit-tested per research decision.
+- Testing strategy focuses on data/logic layer (mode detection, grouping, search, key handling). Terminal.Gui rendering is NOT unit-tested directly per research decision.
 - All new source files live in `src/SunnySunday.Cli/Tui/` and `src/SunnySunday.Tests/Tui/`.
 - View models are stateless projections of API responses — no local persistence beyond session memory.


### PR DESCRIPTION
Transition the CLI to a Terminal User Interface (TUI) by integrating Terminal.Gui for rendering, enhancing user experience while maintaining the existing CLI command interface. Update documentation to reflect the new dependency and TUI architecture.