### PR TITLE
Add POST /settings/test-email endpoint with plain-text verification email

### DIFF
--- a/specs/007-evolve-cli-to-tui/tasks.md
+++ b/specs/007-evolve-cli-to-tui/tasks.md
@@ -75,9 +75,9 @@
 
 **Purpose**: Add the missing server endpoint required by the TUI settings page to verify SMTP configuration with a plain-text test email. Covers US5 (Test Email Verification Endpoint).
 
-- [ ] T021 [US5] Update `src/SunnySunday.Server/Services/IMailDeliveryService.cs` to add a plain-text test email contract, and implement it in `src/SunnySunday.Server/Services/MailDeliveryService.cs` and `src/SunnySunday.Server/Services/DevMailDeliveryService.cs` without recap attachments.
-- [ ] T022 [P] [US5] Update `src/SunnySunday.Server/Endpoints/SettingsEndpoints.cs` to add `POST /settings/test-email` with success, validation, and SMTP failure handling.
-- [ ] T023 [P] [US5] Create `src/SunnySunday.Tests/Api/SettingsTestEmailEndpointTests.cs` covering successful send, missing Kindle email, and SMTP failure.
+- [X] T021 [US5] Update `src/SunnySunday.Server/Services/IMailDeliveryService.cs` to add a plain-text test email contract, and implement it in `src/SunnySunday.Server/Services/MailDeliveryService.cs` and `src/SunnySunday.Server/Services/DevMailDeliveryService.cs` without recap attachments.
+- [X] T022 [P] [US5] Update `src/SunnySunday.Server/Endpoints/SettingsEndpoints.cs` to add `POST /settings/test-email` with success, validation, and SMTP failure handling.
+- [X] T023 [P] [US5] Create `src/SunnySunday.Tests/Api/SettingsTestEmailEndpointTests.cs` covering successful send, missing Kindle email, and SMTP failure.
 
 **Checkpoint**: `POST /settings/test-email` is implemented and tested before the TUI settings screen consumes it.
 

--- a/src/SunnySunday.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/SunnySunday.Server/Endpoints/SettingsEndpoints.cs
@@ -74,6 +74,37 @@ public static partial class SettingsEndpoints
         .Produces<SettingsResponse>(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
+        app.MapPost("/settings/test-email", async ([FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
+        {
+            var userId = await userRepo.EnsureUserAsync();
+            var user = await userRepo.GetByIdAsync(userId);
+
+            if (string.IsNullOrWhiteSpace(user.KindleEmail))
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "kindleEmail", ["Kindle email must be configured before sending a test email."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            try
+            {
+                await mailService.SendTestEmailAsync(user.KindleEmail);
+                return Results.Ok(new { message = "Test email sent successfully." });
+            }
+            catch (Exception ex) when (ex is MailKit.Net.Smtp.SmtpCommandException or MailKit.Net.Smtp.SmtpProtocolException or System.Net.Sockets.SocketException or IOException)
+            {
+                return Results.Problem(
+                    detail: ex.Message,
+                    title: "SMTP delivery failed.",
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        })
+        .WithSummary("Send a plain-text test email.")
+        .WithDescription("Sends a simple verification email to the configured Kindle email address without generating a recap.")
+        .Produces(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
+        .ProducesProblem(StatusCodes.Status502BadGateway);
+
         return app;
     }
 

--- a/src/SunnySunday.Server/Services/DevMailDeliveryService.cs
+++ b/src/SunnySunday.Server/Services/DevMailDeliveryService.cs
@@ -48,4 +48,21 @@ public sealed class DevMailDeliveryService : IMailDeliveryService
         await client.SendAsync(message, cancellationToken);
         await client.DisconnectAsync(quit: true, cancellationToken);
     }
+
+    public async Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+    {
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sunny Sunday", "sunny-sunday"));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = "Sunny Sunday - Test Email";
+        message.Body = new TextPart("plain")
+        {
+            Text = "This is a test email from Sunny Sunday. If you received this, your SMTP configuration is working correctly."
+        };
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(_settings.Host, _settings.Port, SecureSocketOptions.None, cancellationToken);
+        await client.SendAsync(message, cancellationToken);
+        await client.DisconnectAsync(quit: true, cancellationToken);
+    }
 }

--- a/src/SunnySunday.Server/Services/IMailDeliveryService.cs
+++ b/src/SunnySunday.Server/Services/IMailDeliveryService.cs
@@ -3,4 +3,6 @@
 public interface IMailDeliveryService
 {
     Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default);
+
+    Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default);
 }

--- a/src/SunnySunday.Server/Services/MailDeliveryService.cs
+++ b/src/SunnySunday.Server/Services/MailDeliveryService.cs
@@ -48,4 +48,27 @@ public sealed class MailDeliveryService : IMailDeliveryService
         await client.SendAsync(message, cancellationToken);
         await client.DisconnectAsync(quit: true, cancellationToken);
     }
+
+    public async Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+    {
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sunny Sunday", _settings.Username));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = "Sunny Sunday - Test Email";
+        message.Body = new TextPart("plain")
+        {
+            Text = "This is a test email from Sunny Sunday. If you received this, your SMTP configuration is working correctly."
+        };
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(_settings.Host, _settings.Port, useSsl: false, cancellationToken);
+
+        if (!string.IsNullOrEmpty(_settings.Username))
+        {
+            await client.AuthenticateAsync(_settings.Username, _settings.Password, cancellationToken);
+        }
+
+        await client.SendAsync(message, cancellationToken);
+        await client.DisconnectAsync(quit: true, cancellationToken);
+    }
 }

--- a/src/SunnySunday.Server/SunnySunday.Server.csproj
+++ b/src/SunnySunday.Server/SunnySunday.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/SunnySunday.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using SunnySunday.Core.Contracts;
+using SunnySunday.Server.Services;
+
+namespace SunnySunday.Tests.Api;
+
+public sealed class SettingsTestEmailEndpointTests : IDisposable
+{
+    private readonly FakeMailDeliveryService _fakeMail = new();
+    private readonly SunnyTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public SettingsTestEmailEndpointTests()
+    {
+        _factory = new SunnyTestApplicationFactory(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMailDeliveryService));
+                if (descriptor is not null)
+                    services.Remove(descriptor);
+
+                services.AddSingleton<IMailDeliveryService>(_fakeMail);
+            });
+        });
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task PostTestEmail_WithKindleEmail_SendsSuccessfully()
+    {
+        await _client.PutAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+
+        var response = await _client.PostAsync("/settings/test-email", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_WithoutKindleEmail_Returns422()
+    {
+        var response = await _client.PostAsync("/settings/test-email", null);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("kindleEmail", body);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_WhenSmtpFails_Returns502()
+    {
+        await _client.PutAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+        _fakeMail.ShouldThrow = true;
+
+        var response = await _client.PostAsync("/settings/test-email", null);
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("SMTP delivery failed", body);
+    }
+
+    private sealed class FakeMailDeliveryService : IMailDeliveryService
+    {
+        public string? LastTestEmailAddress { get; private set; }
+        public bool ShouldThrow { get; set; }
+
+        public Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+        {
+            if (ShouldThrow)
+                throw new System.Net.Sockets.SocketException(10061);
+
+            LastTestEmailAddress = toAddress;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SunnySunday.Tests/Api/SunnyTestApplicationFactory.cs
+++ b/src/SunnySunday.Tests/Api/SunnyTestApplicationFactory.cs
@@ -11,9 +11,11 @@ namespace SunnySunday.Tests.Api;
 public sealed class SunnyTestApplicationFactory : WebApplicationFactory<Program>
 {
     private readonly SqliteConnection _connection;
+    private readonly Action<IWebHostBuilder>? _configureWebHost;
 
-    public SunnyTestApplicationFactory()
+    public SunnyTestApplicationFactory(Action<IWebHostBuilder>? configureWebHost = null)
     {
+        _configureWebHost = configureWebHost;
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
         using var pragma = _connection.CreateCommand();
@@ -53,6 +55,8 @@ public sealed class SunnyTestApplicationFactory : WebApplicationFactory<Program>
         });
 
         builder.UseEnvironment("Testing");
+
+        _configureWebHost?.Invoke(builder);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/SunnySunday.Tests/Recap/RecapServiceTests.cs
+++ b/src/SunnySunday.Tests/Recap/RecapServiceTests.cs
@@ -217,4 +217,7 @@ internal sealed class FakeMailDeliveryService : IMailDeliveryService
 
         return Task.CompletedTask;
     }
+
+    public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }


### PR DESCRIPTION
## Phase 5: Test Email API Endpoint

Adds the missing server endpoint required by the TUI settings page to verify SMTP configuration with a plain-text test email, without triggering a recap.

### Changes

**T021 — Mail delivery contract & implementations**
- Added `SendTestEmailAsync(string toAddress, CancellationToken)` to `IMailDeliveryService`
- Implemented in `MailDeliveryService` (production SMTP with auth) and `DevMailDeliveryService` (local relay, no TLS/auth)
- Plain-text email with subject "Sunny Sunday — Test Email"

**T022 — `POST /settings/test-email` endpoint**
- Returns `200 OK` with success message on successful send
- Returns `422 Unprocessable Entity` when Kindle email is not configured
- Returns `502 Bad Gateway` on SMTP delivery failure (catches `SmtpCommandException`, `SmtpProtocolException`, `SocketException`, `IOException`)

**T023 — API tests**
- `PostTestEmail_WithKindleEmail_SendsSuccessfully` — verifies 200 and correct recipient
- `PostTestEmail_WithoutKindleEmail_Returns422` — verifies validation error
- `PostTestEmail_WhenSmtpFails_Returns502` — verifies SMTP failure handling
- Extended `SunnyTestApplicationFactory` with optional `Action<IWebHostBuilder>` for DI overrides

### Test results
All 206 tests pass (3 new + 203 existing), no regressions.

Closes #198