### PR TITLE
Add In-TUI Sync Workflow for Highlight Imports

### DIFF
--- a/specs/007-evolve-cli-to-tui/spec.md
+++ b/specs/007-evolve-cli-to-tui/spec.md
@@ -57,8 +57,29 @@ On startup, the TUI displays a table of all imported books retrieved from the se
 
 1. **Given** the server has imported highlights for multiple books, **When** the TUI main screen renders, **Then** a table is displayed with columns: Title, Author, Highlight Count.
 2. **Given** the book list table is displayed, **When** the user presses the up/down arrow keys, **Then** the selected row changes visually.
-3. **Given** the server has no imported highlights, **When** the TUI main screen renders, **Then** an empty state message is displayed (e.g., "No highlights found. Run `sunny sync` to import.").
+3. **Given** the server has no imported highlights, **When** the TUI main screen renders, **Then** an empty state message is displayed with a visible in-TUI sync action (e.g., "No highlights found. Press `I` to sync from My Clippings.txt.").
 4. **Given** the server returns many books, **When** the table exceeds the terminal height, **Then** the list scrolls to keep the selected row visible.
+
+---
+
+### User Story 9 — In-TUI Sync / Import Workflow (Priority: P1)
+
+When the user is on the TUI main screen, they can run the equivalent of `sunny sync` without leaving TUI mode. The TUI reuses the same sync behavior as the CLI: detect `My Clippings.txt` when possible, allow manual path entry when needed, parse highlights, upload them to the server, show the sync summary, and refresh the book list in place.
+
+**Why this priority**: The TUI is intended to provide a guided, end-to-end experience. Without an in-TUI sync flow, first-time and empty-state users still have to drop back to the CLI, which breaks the main promise of feature 007.
+
+**Independent Test**: Launch `sunny` in TUI mode against an empty server. Trigger the sync action from the main screen, provide a valid clippings path, and verify the TUI shows the sync outcome and refreshes the book list without exiting.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the book list screen, **When** the user triggers the sync action, **Then** the TUI starts the sync/import flow without exiting to the CLI.
+2. **Given** a default `My Clippings.txt` path is detected, **When** the sync flow starts, **Then** the TUI offers that path for use or confirmation.
+3. **Given** no default clippings path is detected, **When** the sync flow starts, **Then** the TUI prompts for a custom file path and allows the user to cancel safely.
+4. **Given** the user provides a missing or invalid file path, **When** the sync flow validates the path, **Then** the TUI shows an actionable validation error and remains usable.
+5. **Given** the clippings file parses successfully but contains no highlights, **When** the sync flow completes, **Then** the TUI shows the empty-result outcome and keeps the user on the current screen.
+6. **Given** parsing fails, **When** the sync flow processes the file, **Then** the TUI shows the parser error without crashing or dropping to raw CLI output.
+7. **Given** the sync upload succeeds, **When** the server returns the import summary, **Then** the TUI shows the same outcome data as the CLI sync flow (new highlights, duplicates, new books, new authors) and refreshes the visible book list.
+8. **Given** the server is unreachable during sync, **When** the upload fails, **Then** the TUI shows an inline or dialog error, updates connection state, and remains interactive.
 
 ---
 
@@ -164,6 +185,8 @@ The TUI is built using Terminal.Gui v2 — a dedicated TUI framework with a nati
 - **Very large number of books (100+)**: The book list must remain navigable through scrolling; rendering performance must not degrade noticeably.
 - **Terminal too small**: If the terminal dimensions are below a minimum usable size (e.g., less than 80×24), the TUI displays a message asking the user to resize.
 - **Non-interactive terminal (piped input)**: If stdin is not a TTY, the TUI does not start; the help text is displayed instead (same as `sunny --help`).
+- **Sync path prompt cancelled**: If the user cancels clippings path confirmation or manual entry, the TUI returns to the current screen without side effects.
+- **Invalid clippings path in TUI sync**: If the user enters a missing or unreadable path, the TUI shows a validation error and allows retry without leaving TUI mode.
 - **Concurrent modification**: If another CLI instance modifies data while the TUI is open, the TUI shows stale data until the user presses `R` to refresh the current screen.
 - **Interrupted API call**: If the user navigates away during an in-flight API call, the TUI cancels the request and returns to the previous screen without error.
 - **Figlet rendering in narrow terminals**: If the terminal is too narrow for the full Figlet text, fall back to a plain-text "SunnySunday" heading.
@@ -181,6 +204,11 @@ The TUI is built using Terminal.Gui v2 — a dedicated TUI framework with a nati
 - **FR-007-07**: TUI MUST support keyboard navigation (up/down arrow keys) for selecting rows in the book list.
 - **FR-007-08**: TUI MUST support pressing Enter on a selected book to open the highlight detail view for that book.
 - **FR-007-09**: TUI MUST provide actions in the highlight detail view: modify weight, exclude/include by highlight, exclude/include by book, exclude/include by author, delete highlight.
+- **FR-007-09a**: TUI main screen MUST provide a sync/import action that is accessible from both populated and empty states.
+- **FR-007-09b**: TUI MUST allow the user to run the highlight sync workflow entirely inside TUI mode without exiting to the CLI.
+- **FR-007-09c**: TUI sync MUST auto-detect `My Clippings.txt` using the same detection logic as the CLI and MUST allow manual path entry or cancellation when auto-detection is unavailable or unsuitable.
+- **FR-007-09d**: TUI sync MUST reuse the same parsing, request mapping, and `POST /sync` upload behavior as CLI `sunny sync`.
+- **FR-007-09e**: After a successful sync, TUI MUST show the sync outcome summary and refresh the current book list data.
 - **FR-007-10**: TUI MUST provide a settings page accessible from the main screen via the `S` key.
 - **FR-007-11**: Settings page MUST allow editing: Kindle email, recap schedule (cadence + time), highlight count per recap.
 - **FR-007-12**: Server MUST expose `POST /settings/test-email` to send a simple plain-text test email for SMTP verification without generating a recap.
@@ -193,7 +221,7 @@ The TUI is built using Terminal.Gui v2 — a dedicated TUI framework with a nati
 - **FR-007-16a**: TUI MUST support a refresh action (`R` key) on every screen that re-fetches data from the server and re-renders the current screen without navigating away.
 - **FR-007-17**: TUI MUST exit cleanly on `Q` or `Ctrl+C`, restoring the terminal state.
 - **FR-007-18**: TUI MUST NOT modify any existing REST API endpoints; all interactions use the current API surface.
-- **FR-007-19**: TUI MUST show an appropriate empty state when no highlights have been imported.
+- **FR-007-19**: TUI MUST show an appropriate empty state when no highlights have been imported, including a visible sync/import action.
 - **FR-007-20**: TUI MUST detect non-interactive terminals (stdin is not a TTY) and fall back to displaying help text instead of starting TUI mode.
 - **FR-007-21**: All existing CLI commands MUST continue to function identically when invoked with arguments — zero behavioral regression.
 
@@ -203,6 +231,7 @@ The TUI is built using Terminal.Gui v2 — a dedicated TUI framework with a nati
 - **Screen**: An abstraction representing a distinct TUI page (BookListScreen, HighlightDetailScreen, SettingsScreen) with its own layout, data, and input handling.
 - **StatusChrome**: The persistent header region containing the Figlet banner, version, connection status, and Kindle email warning — shared across all screens.
 - **SearchFilter**: Client-side filter component that narrows the book list based on a text query matched against title, author, and highlight text.
+- **SyncWorkflow**: Shared application workflow used by both CLI and TUI to resolve the clippings path, parse highlights, upload the sync request, and return a structured outcome summary.
 
 ## Success Criteria
 
@@ -210,18 +239,20 @@ The TUI is built using Terminal.Gui v2 — a dedicated TUI framework with a nati
 
 - **SC-007-01**: Users can launch the TUI by running `sunny` with no arguments and see the book list within 3 seconds (under normal network conditions).
 - **SC-007-02**: All existing CLI commands (`sunny sync`, `sunny status`, `sunny config *`, `sunny exclude *`, `sunny weight *`) continue to work identically — zero regressions.
-- **SC-007-03**: Users can navigate the book list, view highlight details, and modify settings without leaving the TUI — completing a full management workflow in a single session.
+- **SC-007-03**: Users can import highlights, navigate the book list, view highlight details, and modify settings without leaving the TUI — completing a full management workflow in a single session.
 - **SC-007-04**: Users without Kindle email configured are informed by a persistent warning visible on every screen, reducing failed recap deliveries.
 - **SC-007-05**: Users with 100+ books can scroll and search the book list without perceptible rendering lag.
 - **SC-007-06**: The TUI renders correctly in terminals with at least 80 columns and 24 rows.
 - **SC-007-07**: Search filters the book list as the user types, showing results within 200ms of each keystroke.
 - **SC-007-08**: Users can verify SMTP delivery with a plain-text test email without sending a real recap.
+- **SC-007-09**: A first-time user with no imported books can complete a sync from within the TUI and see the refreshed book list in the same session.
 
 ## Assumptions
 
 - Terminal.Gui v2 (added as a new NuGet dependency) provides the event loop, input dispatch, widget composition, and layout engine needed for TUI rendering.
 - Spectre.Console.Cli continues to handle CLI command routing unchanged; Terminal.Gui is used exclusively for the TUI mode.
 - The REST API surface from features 004 and 005 is mostly sufficient for TUI functionality. One new endpoint is required: `POST /settings/test-email` to send a simple plain-text test email for SMTP verification. This missing API is documented as a comment on issue #188.
+- The existing `sunny sync` flow can be extracted into a shared workflow consumed by both the CLI command and the TUI without changing the current CLI contract.
 - All data displayed in the TUI (books, highlights, settings) is fetched via existing REST endpoints and cached client-side for the duration of the TUI session.
 - Single-user architecture — no concurrent TUI sessions modifying the same server.
 - The TUI is a convenience layer; all operations remain available via CLI commands for scripting and automation.

--- a/specs/007-evolve-cli-to-tui/tasks.md
+++ b/specs/007-evolve-cli-to-tui/tasks.md
@@ -5,7 +5,7 @@
 
 **Tests**: Included — xUnit tests for data/logic layer (mode detection, book grouping, search filter, screen key handling). Rendering output is NOT tested directly per research decision (Terminal.Gui's `Application.Run` requires a real terminal driver; unit tests target logic and state only).
 
-**Organization**: Tasks are grouped by user story so each slice stays independently testable after the shared foundation is in place. The plan defines 7 phases matching 8 user stories: Phase 1 covers US1 (Dual-Mode) + US8 (Render Loop) as foundational infrastructure, Phase 2 covers US2 (Chrome), Phase 3 covers US3 (Book List) + US7 (Search), Phase 4 covers US4 (Highlight Detail), Phase 5 covers US5 (Test Email API), Phase 6 covers US6 (Settings), and Phase 7 handles polish and edge cases.
+**Organization**: Tasks are grouped by user story so each slice stays independently testable after the shared foundation is in place. The plan defines 8 phases matching 9 user stories: Phase 1 covers US1 (Dual-Mode) + US8 (Render Loop) as foundational infrastructure, Phase 2 covers US2 (Chrome), Phase 3 covers US3 (Book List) + US7 (Search), Phase 3b covers US9 (In-TUI Sync), Phase 4 covers US4 (Highlight Detail), Phase 5 covers US5 (Test Email API), Phase 6 covers US6 (Settings), and Phase 7 handles polish and edge cases.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -57,6 +57,20 @@
 - [X] T018 [P] [US3] Write `src/SunnySunday.Tests/Tui/BookListScreenTests.cs`: test key handling: `↑/↓` changes `selectedIndex` within bounds, `Enter` returns `Push` with correct book, `Q` returns `Quit`, `/` activates search mode. Test empty state when no books loaded.
 
 **Checkpoint**: TUI launches with book list populated from server. Arrow keys navigate rows. Search filters the list. `Enter` attempts to push highlight detail screen (implemented next phase). Tests pass.
+
+---
+
+## Phase 3b: In-TUI Sync Workflow
+
+**Purpose**: Replicate the `sunny sync` workflow inside the TUI so a user can import highlights without leaving the session. Covers US9 (In-TUI Sync / Import Workflow).
+
+- [ ] T032 [US9] Create `src/SunnySunday.Cli/Sync/ClippingsSyncWorkflow.cs`: extract the orchestration currently embedded in `src/SunnySunday.Cli/Commands/SyncCommand.cs` into a shared workflow that resolves the clippings path, parses the file, maps `SyncRequest`, posts to `POST /sync`, and returns a structured outcome for success, empty input, validation errors, parse failures, and connectivity failures.
+- [ ] T033 [US9] Update `src/SunnySunday.Cli/Commands/SyncCommand.cs` to delegate to `ClippingsSyncWorkflow` while preserving the current CLI prompts, exit codes, and summary output.
+- [ ] T034 [US9] Update `src/SunnySunday.Cli/Tui/BookListScreen.cs` and supporting TUI views to add an in-TUI sync/import action (recommended shortcut: `I`) for both populated and empty states, including default-path confirmation, manual path entry, inline/dialog outcome rendering, and book list refresh after success.
+- [ ] T035 [P] [US9] Create `src/SunnySunday.Tests/Cli/ClippingsSyncWorkflowTests.cs`: cover successful sync, empty clippings file, missing file, parse failure, server unreachable, and request mapping parity with the existing CLI sync contract.
+- [ ] T036 [P] [US9] Extend `src/SunnySunday.Tests/Tui/BookListScreenTests.cs` to cover sync action availability, safe cancellation, manual-path validation, successful refresh after sync, and non-crashing error handling.
+
+**Checkpoint**: From the TUI main screen, a user can import highlights without exiting, see the sync outcome, and browse the refreshed book list in the same session.
 
 ---
 
@@ -115,11 +129,12 @@
 
 - **Phase 1 (Infra)**: No dependencies — start immediately. **BLOCKS all subsequent phases.**
 - **Phase 2 (Chrome)**: Depends on Phase 1 (`TuiApp` + `Layout` structure). **BLOCKS Phase 3** (chrome must exist before content screens).
-- **Phase 3 (Book List + Search)**: Depends on Phase 2 (chrome provides the layout context). **BLOCKS Phases 4, 5, and 6.**
+- **Phase 3 (Book List + Search)**: Depends on Phase 2 (chrome provides the layout context). **BLOCKS Phases 3b, 4, 5, and 6.**
+- **Phase 3b (In-TUI Sync)**: Depends on Phase 3 and the existing CLI sync/parser pipeline. **BLOCKS the end-to-end first-run TUI experience.**
 - **Phase 4 (Highlight Detail)**: Depends on Phase 3. **Parallel with Phase 5.**
 - **Phase 5 (Test Email API)**: Depends on Phase 3. **Parallel with Phase 4.**
 - **Phase 6 (Settings)**: Depends on Phase 3 and Phase 5.
-- **Phase 7 (Polish)**: Depends on all preceding phases.
+- **Phase 7 (Polish)**: Depends on all preceding phases, including Phase 3b.
 
 ### User Story Dependencies
 
@@ -128,6 +143,7 @@
 - **US2 (Chrome)**: Phase 2 — depends on render loop from Phase 1.
 - **US3 (Book List)**: Phase 3 — depends on chrome from Phase 2.
 - **US7 (Search)**: Phase 3 — co-located with book list, depends on chrome from Phase 2.
+- **US9 (In-TUI Sync)**: Phase 3b — depends on the book list from Phase 3 and the existing CLI sync/parser pipeline.
 - **US4 (Highlight Detail)**: Phase 4 — depends on book list from Phase 3. Independent of US5.
 - **US5 (Test Email API)**: Phase 5 — depends on book list from Phase 3 for feature sequencing. Independent of US4.
 - **US6 (Settings)**: Phase 6 — depends on book list from Phase 3 and the API endpoint from Phase 5.
@@ -136,6 +152,7 @@
 
 - Within Phase 1: `T001`, `T002`, `T003` (interface + view models) can run in parallel. `T006`, `T007` (HTTP client) can run in parallel. `T008`, `T009` (tests) can run in parallel.
 - Within Phase 3: `T014` (SearchFilter) and `T017`, `T018` (tests) can run in parallel with each other.
+- Within Phase 3b: `T032` must land before `T033` and `T034`; `T035` and `T036` can be developed in parallel once the shared workflow and TUI entry point stabilize.
 - Phases 4 and 5 are fully independent once Phase 3 is complete.
 - Within Phase 7: `T026`, `T027`, `T028`, `T029` can run in parallel (different files/concerns).
 
@@ -169,13 +186,14 @@ Phase 3 ──┬──► Phase 4 (T019) ──┐
 1. Complete Phase 1 (Infra) — mode detection, render loop, view models, HTTP extensions.
 2. Complete Phase 2 (Chrome) — branded header with connection status.
 3. Complete Phase 3 (Book List + Search) — main screen with navigation and filtering.
-4. Land Phase 4 (Highlight Detail) and Phase 5 (Test Email API) in parallel or either order.
-5. Complete Phase 6 (Settings) once the API endpoint exists.
-6. Finish with Phase 7 (Polish) — edge cases, docs, full regression suite.
+4. Complete Phase 3b (In-TUI Sync) so first-time users can import highlights without leaving the TUI.
+5. Land Phase 4 (Highlight Detail) and Phase 5 (Test Email API) in parallel or either order.
+6. Complete Phase 6 (Settings) once the API endpoint exists.
+7. Finish with Phase 7 (Polish) — edge cases, docs, full regression suite.
 
 ### Suggested MVP Scope
 
-The smallest demonstrable increment is **Phase 1 + Phase 2 + Phase 3** — a user can launch `sunny` with no arguments, see a branded TUI with the book list, navigate rows, and search. All existing CLI commands remain unchanged.
+The smallest end-to-end TUI increment is **Phase 1 + Phase 2 + Phase 3 + Phase 3b** — a user can launch `sunny` with no arguments, import highlights from within the TUI, and immediately browse the refreshed book list without leaving the session. All existing CLI commands remain unchanged.
 
 ---
 


### PR DESCRIPTION
Implement an in-TUI sync workflow that allows users to import highlights without exiting TUI mode. This enhancement improves user experience by enabling seamless highlight management within the session. The changes include the extraction of sync orchestration into a shared workflow and updates to the TUI interface for importing highlights.

Fixes #189