### PR TITLE
Implement shared sync workflow and TUI import flow

### DIFF
--- a/specs/007-evolve-cli-to-tui/tasks.md
+++ b/specs/007-evolve-cli-to-tui/tasks.md
@@ -64,11 +64,11 @@
 
 **Purpose**: Replicate the `sunny sync` workflow inside the TUI so a user can import highlights without leaving the session. Covers US9 (In-TUI Sync / Import Workflow).
 
-- [ ] T032 [US9] Create `src/SunnySunday.Cli/Sync/ClippingsSyncWorkflow.cs`: extract the orchestration currently embedded in `src/SunnySunday.Cli/Commands/SyncCommand.cs` into a shared workflow that resolves the clippings path, parses the file, maps `SyncRequest`, posts to `POST /sync`, and returns a structured outcome for success, empty input, validation errors, parse failures, and connectivity failures.
-- [ ] T033 [US9] Update `src/SunnySunday.Cli/Commands/SyncCommand.cs` to delegate to `ClippingsSyncWorkflow` while preserving the current CLI prompts, exit codes, and summary output.
-- [ ] T034 [US9] Update `src/SunnySunday.Cli/Tui/BookListScreen.cs` and supporting TUI views to add an in-TUI sync/import action (recommended shortcut: `I`) for both populated and empty states, including default-path confirmation, manual path entry, inline/dialog outcome rendering, and book list refresh after success.
-- [ ] T035 [P] [US9] Create `src/SunnySunday.Tests/Cli/ClippingsSyncWorkflowTests.cs`: cover successful sync, empty clippings file, missing file, parse failure, server unreachable, and request mapping parity with the existing CLI sync contract.
-- [ ] T036 [P] [US9] Extend `src/SunnySunday.Tests/Tui/BookListScreenTests.cs` to cover sync action availability, safe cancellation, manual-path validation, successful refresh after sync, and non-crashing error handling.
+- [X] T032 [US9] Create `src/SunnySunday.Cli/Sync/ClippingsSyncWorkflow.cs`: extract the orchestration currently embedded in `src/SunnySunday.Cli/Commands/SyncCommand.cs` into a shared workflow that resolves the clippings path, parses the file, maps `SyncRequest`, posts to `POST /sync`, and returns a structured outcome for success, empty input, validation errors, parse failures, and connectivity failures.
+- [X] T033 [US9] Update `src/SunnySunday.Cli/Commands/SyncCommand.cs` to delegate to `ClippingsSyncWorkflow` while preserving the current CLI prompts, exit codes, and summary output.
+- [X] T034 [US9] Update `src/SunnySunday.Cli/Tui/BookListScreen.cs` and supporting TUI views to add an in-TUI sync/import action (recommended shortcut: `I`) for both populated and empty states, including default-path confirmation, manual path entry, inline/dialog outcome rendering, and book list refresh after success.
+- [X] T035 [P] [US9] Create `src/SunnySunday.Tests/Cli/ClippingsSyncWorkflowTests.cs`: cover successful sync, empty clippings file, missing file, parse failure, server unreachable, and request mapping parity with the existing CLI sync contract.
+- [X] T036 [P] [US9] Extend `src/SunnySunday.Tests/Tui/BookListScreenTests.cs` to cover sync action availability, safe cancellation, manual-path validation, successful refresh after sync, and non-crashing error handling.
 
 **Checkpoint**: From the TUI main screen, a user can import highlights without exiting, see the sync outcome, and browse the refreshed book list in the same session.
 

--- a/src/SunnySunday.Cli/Commands/SyncCommand.cs
+++ b/src/SunnySunday.Cli/Commands/SyncCommand.cs
@@ -2,8 +2,8 @@
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
-using SunnySunday.Cli.Infrastructure;
 using SunnySunday.Cli.Parsing;
+using SunnySunday.Cli.Sync;
 using SunnySunday.Core.Contracts;
 
 namespace SunnySunday.Cli.Commands;
@@ -11,7 +11,7 @@ namespace SunnySunday.Cli.Commands;
 /// <summary>
 /// Parses a Kindle clippings file and syncs highlights to the server.
 /// </summary>
-public sealed class SyncCommand(SunnyHttpClient client, ILogger<SyncCommand> logger) : ServerCommand<SyncCommand.Settings>
+public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncCommand> logger) : ServerCommand<SyncCommand.Settings>
 {
     protected override ILogger Logger => logger;
 
@@ -24,57 +24,28 @@ public sealed class SyncCommand(SunnyHttpClient client, ILogger<SyncCommand> log
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
     {
-        var filePath = settings.Path
-            ?? KindleDetector.DetectClippingsPath()
-            ?? PromptForPath();
-
-        if (filePath is null)
+        var outcome = await workflow.ExecuteAsync(new ClippingsSyncOptions
         {
-            AnsiConsole.MarkupLine("[yellow]Sync cancelled.[/]");
-            return 1;
-        }
+            FilePath = settings.Path,
+            ResolvePathAsync = settings.Path is null ? ResolvePathAsync : null
+        }, cancellation).ConfigureAwait(false);
 
-        logger.LogDebug("Resolved clippings path: {FilePath}", filePath);
-
-        if (!File.Exists(filePath))
+        return outcome.Status switch
         {
-            AnsiConsole.MarkupLine($"[red]Error:[/] File not found: [yellow]{filePath}[/]");
-            return 1;
-        }
+            ClippingsSyncStatus.Cancelled => HandleCancelled(),
+            ClippingsSyncStatus.FileNotFound => HandleMissingFile(outcome),
+            ClippingsSyncStatus.ParseFailed => HandleParseFailure(outcome),
+            ClippingsSyncStatus.NoHighlightsFound => HandleNoHighlights(),
+            ClippingsSyncStatus.ServerError => HandleConnectivityFailure(outcome),
+            ClippingsSyncStatus.Succeeded => HandleSuccess(outcome),
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome.Status), outcome.Status, null)
+        };
+    }
 
-        ParseResult parseResult;
-        try
-        {
-            parseResult = await ClippingsParser.ParseAsync(filePath);
-        }
-        catch (Exception ex)
-        {
-            AnsiConsole.MarkupLine($"[red]Error parsing clippings file:[/] {ex.Message}");
-            return 1;
-        }
-
-        if (parseResult.Books.Count == 0)
-        {
-            AnsiConsole.MarkupLine("[yellow]No highlights found in the clippings file.[/]");
-            return 0;
-        }
-
-        var request = MapToSyncRequest(parseResult);
-        logger.LogDebug("Sending {BookCount} books with {HighlightCount} highlights to server",
-            request.Books.Count, request.Books.Sum(b => b.Highlights.Count));
-
-        SyncResponse response;
-        try
-        {
-            response = await client.PostSyncAsync(request, cancellation);
-        }
-        catch (HttpRequestException ex)
-        {
-            return HandleServerError(ex);
-        }
-
-        DisplaySummary(parseResult, response);
-        return 0;
+    private static ValueTask<string?> ResolvePathAsync(ClippingsPathPromptRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(!string.IsNullOrWhiteSpace(request.DetectedPath) ? request.DetectedPath : PromptForPath());
     }
 
     private static string? PromptForPath()
@@ -87,26 +58,44 @@ public sealed class SyncCommand(SunnyHttpClient client, ILogger<SyncCommand> log
         return string.IsNullOrWhiteSpace(path) ? null : path;
     }
 
-    private static SyncRequest MapToSyncRequest(ParseResult result)
+    private static int HandleCancelled()
     {
-        return new SyncRequest
-        {
-            Books = result.Books.Select(book => new SyncBookRequest
-            {
-                Title = book.Title,
-                Author = book.Author,
-                Highlights = book.Highlights.Select(h => new SyncHighlightRequest
-                {
-                    Text = h.Text,
-                    AddedOn = h.AddedOn
-                }).ToList()
-            }).ToList()
-        };
+        AnsiConsole.MarkupLine("[yellow]Sync cancelled.[/]");
+        return 1;
+    }
+
+    private static int HandleMissingFile(ClippingsSyncOutcome outcome)
+    {
+        AnsiConsole.MarkupLine($"[red]Error:[/] File not found: [yellow]{outcome.FilePath}[/]");
+        return 1;
+    }
+
+    private static int HandleParseFailure(ClippingsSyncOutcome outcome)
+    {
+        AnsiConsole.MarkupLine($"[red]Error parsing clippings file:[/] {outcome.Message}");
+        return 1;
+    }
+
+    private static int HandleNoHighlights()
+    {
+        AnsiConsole.MarkupLine("[yellow]No highlights found in the clippings file.[/]");
+        return 0;
+    }
+
+    private int HandleConnectivityFailure(ClippingsSyncOutcome outcome)
+    {
+        return HandleServerError(outcome.Error as HttpRequestException ?? new HttpRequestException(outcome.Message));
+    }
+
+    private static int HandleSuccess(ClippingsSyncOutcome outcome)
+    {
+        DisplaySummary(outcome.ParseResult!, outcome.Response!);
+        return 0;
     }
 
     private static void DisplaySummary(ParseResult parseResult, SyncResponse response)
     {
-        var totalHighlights = parseResult.Books.Sum(b => b.Highlights.Count);
+        var totalHighlights = parseResult.Books.Sum(book => book.Highlights.Count);
 
         AnsiConsole.WriteLine();
         AnsiConsole.Write(new Panel(

--- a/src/SunnySunday.Cli/Infrastructure/KindleDetector.cs
+++ b/src/SunnySunday.Cli/Infrastructure/KindleDetector.cs
@@ -21,6 +21,32 @@ public static class KindleDetector
         return null;
     }
 
+    public static string? GetSuggestedClippingsPath()
+    {
+        var detectedPath = DetectClippingsPath();
+        if (!string.IsNullOrWhiteSpace(detectedPath))
+        {
+            return detectedPath;
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return Path.Combine("/Volumes/Kindle", ClippingsRelativePath);
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return GetLinuxSuggestedPath();
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return GetWindowsSuggestedPath();
+        }
+
+        return null;
+    }
+
     private static string? ProbeMacOS()
     {
         var path = Path.Combine("/Volumes/Kindle", ClippingsRelativePath);
@@ -64,5 +90,35 @@ public static class KindleDetector
         }
 
         return null;
+    }
+
+    private static string GetLinuxSuggestedPath()
+    {
+        var userName = Environment.UserName;
+
+        foreach (var baseDir in new[] { "/media", "/run/media" })
+        {
+            var userRoot = Path.Combine(baseDir, userName);
+            if (Directory.Exists(userRoot))
+            {
+                return Path.Combine(userRoot, "Kindle", ClippingsRelativePath);
+            }
+        }
+
+        return Path.Combine("/media", userName, "Kindle", ClippingsRelativePath);
+    }
+
+    private static string GetWindowsSuggestedPath()
+    {
+        foreach (var drive in new[] { 'D', 'E', 'F', 'G' })
+        {
+            var driveRoot = $"{drive}:\\";
+            if (Directory.Exists(driveRoot))
+            {
+                return Path.Combine(driveRoot, ClippingsRelativePath);
+            }
+        }
+
+        return Path.Combine("D:\\", ClippingsRelativePath);
     }
 }

--- a/src/SunnySunday.Cli/Program.cs
+++ b/src/SunnySunday.Cli/Program.cs
@@ -10,6 +10,7 @@ using SunnySunday.Cli.Commands.Config;
 using SunnySunday.Cli.Commands.Exclude;
 using SunnySunday.Cli.Commands.Weight;
 using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Cli.Sync;
 using SunnySunday.Cli.Tui;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -41,17 +42,19 @@ string version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribu
 builder.Services.AddHttpClient<SunnyHttpClient>((sp, client) =>
 {
     var config = sp.GetRequiredService<IConfiguration>();
-    var serverUrl = config["sunny_server"]!;
-    client.BaseAddress = new Uri(serverUrl);
+    var configuredServerUrl = config["sunny_server"]!;
+    client.BaseAddress = new Uri(configuredServerUrl);
     client.Timeout = TimeSpan.FromSeconds(30);
 }).AddSunnyResilience();
+builder.Services.AddTransient<ClippingsSyncWorkflow>();
 
 using IHost host = builder.Build();
 
 if (TuiModeDetector.Detect(args, Console.IsInputRedirected) == StartupMode.Tui)
 {
     var client = host.Services.GetRequiredService<SunnyHttpClient>();
-    var tuiApp = new TuiApp(client, normalizedServerUrl, version);
+    var syncWorkflow = host.Services.GetRequiredService<ClippingsSyncWorkflow>();
+    var tuiApp = new TuiApp(client, syncWorkflow, normalizedServerUrl, version);
     await tuiApp.RunAsync(CancellationToken.None);
     return 0;
 }

--- a/src/SunnySunday.Cli/SunnySunday.Cli.csproj
+++ b/src/SunnySunday.Cli/SunnySunday.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SunnySunday.Cli/Sync/ClippingsSyncWorkflow.cs
+++ b/src/SunnySunday.Cli/Sync/ClippingsSyncWorkflow.cs
@@ -1,0 +1,188 @@
+﻿using Microsoft.Extensions.Logging;
+using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Cli.Parsing;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Cli.Sync;
+
+public sealed class ClippingsSyncWorkflow(SunnyHttpClient client, ILogger<ClippingsSyncWorkflow> logger)
+{
+    public async Task<ClippingsSyncOutcome> ExecuteAsync(ClippingsSyncOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var filePath = await ResolveFilePathAsync(options, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return ClippingsSyncOutcome.Cancelled();
+        }
+
+        filePath = filePath.Trim();
+        logger.LogDebug("Resolved clippings path: {FilePath}", filePath);
+
+        if (!File.Exists(filePath))
+        {
+            return ClippingsSyncOutcome.FileNotFound(filePath);
+        }
+
+        ParseResult parseResult;
+
+        try
+        {
+            var parseAsync = options.ParseAsync;
+            parseResult = parseAsync is null
+                ? await ClippingsParser.ParseAsync(filePath, options.ParserLogger).ConfigureAwait(false)
+                : await parseAsync(filePath, options.ParserLogger).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Failed to parse clippings file {FilePath}", filePath);
+            return ClippingsSyncOutcome.ParseFailed(filePath, ex);
+        }
+
+        if (parseResult.Books.Count == 0)
+        {
+            return ClippingsSyncOutcome.NoHighlightsFound(filePath, parseResult);
+        }
+
+        var request = CreateSyncRequest(parseResult);
+        logger.LogDebug(
+            "Sending {BookCount} books with {HighlightCount} highlights to server",
+            request.Books.Count,
+            request.Books.Sum(book => book.Highlights.Count));
+
+        try
+        {
+            var response = await client.PostSyncAsync(request, cancellationToken).ConfigureAwait(false);
+            return ClippingsSyncOutcome.Succeeded(filePath, parseResult, response);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogWarning(ex, "Failed to sync clippings from {FilePath}", filePath);
+            return ClippingsSyncOutcome.ServerError(filePath, parseResult, ex);
+        }
+    }
+
+    private static async Task<string?> ResolveFilePathAsync(ClippingsSyncOptions options, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(options.FilePath))
+        {
+            return options.FilePath;
+        }
+
+        var detectedPath = KindleDetector.DetectClippingsPath();
+        if (options.ResolvePathAsync is not null)
+        {
+            return await options.ResolvePathAsync(new ClippingsPathPromptRequest(detectedPath), cancellationToken).ConfigureAwait(false);
+        }
+
+        return detectedPath;
+    }
+
+    private static SyncRequest CreateSyncRequest(ParseResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new SyncRequest
+        {
+            Books = result.Books.Select(book => new SyncBookRequest
+            {
+                Title = book.Title,
+                Author = book.Author,
+                Highlights = book.Highlights.Select(highlight => new SyncHighlightRequest
+                {
+                    Text = highlight.Text,
+                    AddedOn = highlight.AddedOn
+                }).ToList()
+            }).ToList()
+        };
+    }
+}
+
+public sealed record ClippingsSyncOptions
+{
+    public string? FilePath { get; init; }
+
+    public Func<ClippingsPathPromptRequest, CancellationToken, ValueTask<string?>>? ResolvePathAsync { get; init; }
+
+    public Func<string, ILogger?, Task<ParseResult>>? ParseAsync { get; init; }
+
+    public ILogger? ParserLogger { get; init; }
+}
+
+public sealed record ClippingsPathPromptRequest(string? DetectedPath);
+
+public enum ClippingsSyncStatus
+{
+    Cancelled,
+    FileNotFound,
+    ParseFailed,
+    NoHighlightsFound,
+    ServerError,
+    Succeeded
+}
+
+public sealed record ClippingsSyncOutcome
+{
+    public required ClippingsSyncStatus Status { get; init; }
+
+    public string? FilePath { get; init; }
+
+    public string? Message { get; init; }
+
+    public ParseResult? ParseResult { get; init; }
+
+    public SyncResponse? Response { get; init; }
+
+    public Exception? Error { get; init; }
+
+    public int TotalHighlightsParsed => ParseResult?.Books.Sum(book => book.Highlights.Count) ?? 0;
+
+    public bool IsSuccessful => Status is ClippingsSyncStatus.NoHighlightsFound or ClippingsSyncStatus.Succeeded;
+
+    public static ClippingsSyncOutcome Cancelled() => new()
+    {
+        Status = ClippingsSyncStatus.Cancelled,
+        Message = "Sync cancelled."
+    };
+
+    public static ClippingsSyncOutcome FileNotFound(string filePath) => new()
+    {
+        Status = ClippingsSyncStatus.FileNotFound,
+        FilePath = filePath,
+        Message = $"File not found: {filePath}"
+    };
+
+    public static ClippingsSyncOutcome ParseFailed(string filePath, Exception error) => new()
+    {
+        Status = ClippingsSyncStatus.ParseFailed,
+        FilePath = filePath,
+        Message = error.Message,
+        Error = error
+    };
+
+    public static ClippingsSyncOutcome NoHighlightsFound(string filePath, ParseResult parseResult) => new()
+    {
+        Status = ClippingsSyncStatus.NoHighlightsFound,
+        FilePath = filePath,
+        Message = "No highlights found in the clippings file.",
+        ParseResult = parseResult
+    };
+
+    public static ClippingsSyncOutcome ServerError(string filePath, ParseResult parseResult, HttpRequestException error) => new()
+    {
+        Status = ClippingsSyncStatus.ServerError,
+        FilePath = filePath,
+        Message = error.Message,
+        ParseResult = parseResult,
+        Error = error
+    };
+
+    public static ClippingsSyncOutcome Succeeded(string filePath, ParseResult parseResult, SyncResponse response) => new()
+    {
+        Status = ClippingsSyncStatus.Succeeded,
+        FilePath = filePath,
+        ParseResult = parseResult,
+        Response = response
+    };
+}

--- a/src/SunnySunday.Cli/Tui/BookListScreen.cs
+++ b/src/SunnySunday.Cli/Tui/BookListScreen.cs
@@ -6,11 +6,17 @@ using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Cli.Sync;
 using SunnySunday.Cli.Tui.ViewModels;
+using SunnySunday.Core.Contracts;
 
 namespace SunnySunday.Cli.Tui;
 
-public sealed class BookListScreen(SunnyHttpClient client) : IScreen
+public sealed class BookListScreen(
+    SunnyHttpClient client,
+    ClippingsSyncWorkflow syncWorkflow,
+    Action? onConnectionFailure = null,
+    Func<CancellationToken, Task>? refreshConnectionStatusAsync = null) : IScreen
 {
     private const int PageSize = 100;
     private const int DefaultTableWidth = 80;
@@ -20,20 +26,37 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
     private const int PreferredAuthorColumnWidth = 30;
     private const int TableHorizontalPadding = 2;
     private const string SectionTitle = "Books";
-    private const string PlaceholderIdle = "type / to search";
-    private const string PlaceholderFocused = "Press Esc to return to the list";
+    private const string SearchPlaceholderIdle = "type / to search";
+    private const string SearchPlaceholderFocused = "Press Esc to return to the list";
+    private const string SyncPlaceholderDetected = "Press Enter to sync or edit the path";
+    private const string SyncPlaceholderManual = "Enter the path to My Clippings.txt";
+
     private readonly SunnyHttpClient _client = client;
+    private readonly ClippingsSyncWorkflow _syncWorkflow = syncWorkflow;
+    private readonly Action? _onConnectionFailure = onConnectionFailure;
+    private readonly Func<CancellationToken, Task>? _refreshConnectionStatusAsync = refreshConnectionStatusAsync;
+
     private List<BookViewModel> _books = [];
     private List<BookViewModel> _filteredBooks = [];
     private int _selectedIndex;
     private bool _isSearchActive;
     private string _searchQuery = string.Empty;
+    private string _syncPathInput = string.Empty;
+    private string? _detectedSyncPath;
+    private bool _hasDetectedSyncPath;
     private FrameView? _searchFrame;
     private SearchTextField? _searchField;
     private Label? _searchPlaceholder;
     private string? _errorMessage;
     private Label? _errorLabel;
+    private Label? _feedbackLabel;
     private bool _viewHasBooksList;
+    private string? _feedbackMessage;
+    private bool _feedbackIsError;
+    private Action<ScreenResult>? _navigate;
+    private Action? _refreshVisibleBooks;
+    private ShortcutListView? _listView;
+    private ToolbarMode _toolbarMode;
 
     public IReadOnlyList<BookViewModel> Books => _books;
 
@@ -43,7 +66,15 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
 
     public bool IsSearchActive => _isSearchActive;
 
+    public bool IsSyncPromptActive => _toolbarMode == ToolbarMode.SyncPath;
+
     public string SearchQuery => _searchQuery;
+
+    public string SyncPathInput => _syncPathInput;
+
+    public string? FeedbackMessage => _feedbackMessage;
+
+    public bool FeedbackIsError => _feedbackIsError;
 
     public string Title => string.Empty;
 
@@ -51,6 +82,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
     [
         ("↑↓", "Navigate"),
         ("Enter", "View"),
+        ("I", "Import"),
         ("S", "Settings"),
         ("/", "Search"),
         ("R", "Refresh"),
@@ -58,6 +90,12 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
     ];
 
     private readonly record struct TableLayout(int TitleWidth, int AuthorWidth, int HighlightsWidth);
+
+    private enum ToolbarMode
+    {
+        Search,
+        SyncPath
+    }
 
     public int ToolbarHeight => 4;
 
@@ -95,9 +133,13 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
             Width = Dim.Fill(2),
             Height = 1,
             CanFocus = true,
-            Text = _searchQuery
+            Text = GetToolbarText()
         };
         _searchField.SetScheme(CreateSearchFieldScheme(fieldAttribute));
+        _searchField.TextChanged += (_, _) => HandleToolbarTextChanged();
+        _searchField.HasFocusChanged += (_, _) => UpdateToolbarChrome();
+        _searchField.Accepting += async (_, _) => await HandleToolbarSubmitAsync().ConfigureAwait(false);
+        _searchField.KeyDown += (_, key) => HandleToolbarKeyDown(key);
 
         _searchPlaceholder = new Label
         {
@@ -106,8 +148,8 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
             Width = Dim.Fill(3),
             Height = 1,
             CanFocus = false,
-            Text = PlaceholderIdle,
-            Visible = string.IsNullOrEmpty(_searchQuery)
+            Text = GetToolbarPlaceholder(hasFocus: false),
+            Visible = string.IsNullOrEmpty(GetToolbarText())
         };
         _searchPlaceholder.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(
             new Terminal.Gui.Drawing.Color(90, 90, 90), StatusChrome.Background)));
@@ -115,6 +157,10 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         _searchFrame.Add(_searchField, _searchPlaceholder);
         container.Add(_searchFrame);
 
+        _feedbackLabel = CreateToolbarFeedbackLabel();
+        container.Add(_feedbackLabel);
+
+        UpdateToolbarChrome();
         return container;
     }
 
@@ -161,11 +207,17 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
 
             _books = EnrichBooks(BookViewModel.FromHighlights(highlights), exclusions, weights);
             _errorMessage = null;
+
+            if (_refreshConnectionStatusAsync is not null)
+            {
+                await _refreshConnectionStatusAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (HttpRequestException)
         {
             _books = [];
             _errorMessage = "Cannot reach server. Check the connection.";
+            _onConnectionFailure?.Invoke();
         }
 
         ApplyFilter();
@@ -174,6 +226,8 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Views are owned by the parent container hierarchy")]
     public View CreateView(Action<ScreenResult> navigate)
     {
+        _navigate = navigate;
+
         var container = new View
         {
             X = 0,
@@ -186,12 +240,13 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         if (_filteredBooks.Count == 0 && !_isSearchActive)
         {
             _viewHasBooksList = false;
+            _listView = null;
 
             if (_errorMessage is null)
             {
                 var emptyLabel = new Label
                 {
-                    Text = "No books imported yet. Run `sunny sync` to import.",
+                    Text = "No books imported yet. Press I to import highlights.",
                     X = Pos.Center(),
                     Y = Pos.Center()
                 };
@@ -216,10 +271,12 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
                     _errorLabel.Text = _errorMessage ?? string.Empty;
                     _errorLabel.Visible = _errorMessage is not null;
                 }
+
+                UpdateFeedbackLabel();
             }
 
-            SetupContainerKeyBindings(container, null, navigate, RefreshEmpty, null);
-            // Views are owned by the container hierarchy
+            _refreshVisibleBooks = RefreshEmpty;
+            SetupContainerKeyBindings(container, null, navigate, RefreshEmpty, BeginSearchInput, () => BeginSyncPrompt());
             return container;
         }
 
@@ -241,7 +298,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         {
             Text = FormatHeader(tableLayout),
             X = TableHorizontalPadding,
-            Y = 2,
+            Y = 1,
             Width = Dim.Fill(TableHorizontalPadding * 2)
         };
         headerLabel.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(
@@ -250,7 +307,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         var headerRuleLabel = new Label
         {
             X = TableHorizontalPadding,
-            Y = 3,
+            Y = 2,
             Width = Dim.Fill(TableHorizontalPadding * 2),
             Text = string.Empty
         };
@@ -263,7 +320,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         var listView = new ShortcutListView
         {
             X = TableHorizontalPadding,
-            Y = 4,
+            Y = 3,
             Width = Dim.Fill(TableHorizontalPadding * 2),
             Height = Dim.Fill(),
             CanFocus = true
@@ -275,7 +332,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
             listView.SelectedItem = Math.Min(_selectedIndex, _filteredBooks.Count - 1);
         }
 
-        listView.Accepting += (_, args) =>
+        listView.Accepting += (_, _) =>
         {
             var selected = GetSelectedBook();
             if (selected is not null)
@@ -302,6 +359,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
             }
 
             UpdateErrorLabel();
+            UpdateFeedbackLabel();
         }
 
         void UpdateTableLayout()
@@ -324,73 +382,15 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
             RefreshVisibleBooks();
         }
 
-        void FocusSearchField()
-        {
-            _isSearchActive = true;
-            _searchField?.SetFocus();
-            UpdateSearchChrome();
-        }
-
-        void FocusListView()
-        {
-            _isSearchActive = false;
-            if (_searchField is not null)
-            {
-                _searchQuery = _searchField.Text ?? string.Empty;
-            }
-
-            ApplyFilter();
-            RefreshVisibleBooks();
-            listView.SetFocus();
-            UpdateSearchChrome();
-        }
-
-        void UpdateSearchChrome()
-        {
-            if (_searchPlaceholder is not null && _searchField is not null)
-            {
-                _searchPlaceholder.Visible = string.IsNullOrEmpty(_searchField.Text);
-                _searchPlaceholder.Text = _searchField.HasFocus
-                    ? PlaceholderFocused
-                    : PlaceholderIdle;
-            }
-
-            if (_searchFrame is not null && _searchField is not null)
-            {
-                _searchFrame.SetScheme(CreateSearchFrameScheme(_searchField.HasFocus));
-            }
-        }
-
-        if (_searchField is not null)
-        {
-            _searchField.TextChanged += (_, _) =>
-            {
-                _searchQuery = _searchField.Text ?? string.Empty;
-                ApplyFilter();
-                RefreshVisibleBooks();
-                UpdateSearchChrome();
-            };
-
-            _searchField.HasFocusChanged += (_, _) => UpdateSearchChrome();
-
-            _searchField.KeyDown += (_, key) =>
-            {
-                if (key.KeyCode is KeyCode.Esc or KeyCode.CursorDown)
-                {
-                    FocusListView();
-                    key.Handled = true;
-                }
-            };
-        }
-
-        UpdateSearchChrome();
         UpdateTableLayout();
 
         container.SubViewsLaidOut += (_, _) => UpdateTableLayout();
         listView.ViewportChanged += (_, _) => UpdateTableLayout();
 
         container.Add(titleLabel, headerLabel, headerRuleLabel, listView);
-        SetupContainerKeyBindings(container, listView, navigate, RefreshVisibleBooks, FocusSearchField);
+        _listView = listView;
+        _refreshVisibleBooks = RefreshVisibleBooks;
+        SetupContainerKeyBindings(container, listView, navigate, RefreshVisibleBooks, BeginSearchInput, () => BeginSyncPrompt());
         listView.SetFocus();
 
         return container;
@@ -418,15 +418,142 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
 
     public void ActivateSearch()
     {
+        _toolbarMode = ToolbarMode.Search;
         _isSearchActive = true;
         ApplyFilter();
     }
 
     public void DeactivateSearch()
     {
+        _toolbarMode = ToolbarMode.Search;
         _isSearchActive = false;
         _searchQuery = string.Empty;
+
+        if (_searchField is not null)
+        {
+            _searchField.Text = string.Empty;
+        }
+
         ApplyFilter();
+        UpdateToolbarChrome();
+    }
+
+    public void BeginSyncPrompt(string? detectedPath = null)
+    {
+        _toolbarMode = ToolbarMode.SyncPath;
+        _isSearchActive = false;
+
+        var resolvedDetectedPath = detectedPath ?? KindleDetector.DetectClippingsPath();
+        _detectedSyncPath = resolvedDetectedPath;
+        _hasDetectedSyncPath = !string.IsNullOrWhiteSpace(resolvedDetectedPath);
+        _syncPathInput = ResolveDefaultSyncPath(resolvedDetectedPath) ?? string.Empty;
+
+        if (_searchField is not null)
+        {
+            _searchField.Text = _syncPathInput;
+            _searchField.SetFocus();
+            _searchField.MoveEnd();
+        }
+
+        UpdateToolbarChrome();
+    }
+
+    public void CancelSyncPrompt()
+    {
+        _toolbarMode = ToolbarMode.Search;
+        _detectedSyncPath = null;
+        _hasDetectedSyncPath = false;
+        _syncPathInput = string.Empty;
+
+        if (_searchField is null)
+        {
+            return;
+        }
+
+        RestoreToolbarAfterSyncPrompt();
+    }
+
+    private void RestoreToolbarAfterSyncPrompt()
+    {
+        ArgumentNullException.ThrowIfNull(_searchField);
+
+        _searchField.Text = _searchQuery;
+
+        if (_listView is not null)
+        {
+            _listView.SetFocus();
+        }
+        else
+        {
+            _searchField.SetFocus();
+        }
+
+        UpdateToolbarChrome();
+    }
+
+    public async Task<ClippingsSyncOutcome> SubmitSyncAsync(string? filePath = null, CancellationToken cancellationToken = default)
+    {
+        var resolvedPath = filePath ?? _syncPathInput;
+        if (string.IsNullOrWhiteSpace(resolvedPath))
+        {
+            SetFeedback("Enter a path to My Clippings.txt or press Esc to cancel.", isError: true);
+            return ClippingsSyncOutcome.Cancelled();
+        }
+
+        var hadBooksView = _viewHasBooksList;
+        var outcome = await _syncWorkflow.ExecuteAsync(new ClippingsSyncOptions
+        {
+            FilePath = resolvedPath
+        }, cancellationToken).ConfigureAwait(false);
+
+        switch (outcome.Status)
+        {
+            case ClippingsSyncStatus.FileNotFound:
+                SetFeedback($"File not found: {outcome.FilePath}", isError: true);
+                return outcome;
+
+            case ClippingsSyncStatus.ParseFailed:
+                SetFeedback($"Error parsing clippings file: {outcome.Message}", isError: true);
+                return outcome;
+
+            case ClippingsSyncStatus.ServerError:
+                _onConnectionFailure?.Invoke();
+                SetFeedback($"Sync failed: {outcome.Message}", isError: true);
+                return outcome;
+
+            case ClippingsSyncStatus.NoHighlightsFound:
+                SetFeedback("No highlights found in the clippings file.", isError: false);
+                CancelSyncPrompt();
+                return outcome;
+
+            case ClippingsSyncStatus.Succeeded:
+                await InitializeAsync(cancellationToken).ConfigureAwait(false);
+                SetFeedback(
+                    $"Sync complete. {outcome.TotalHighlightsParsed} parsed, {outcome.Response!.NewHighlights} new, {outcome.Response.DuplicateHighlights} duplicates, {outcome.Response.NewBooks} books, {outcome.Response.NewAuthors} authors.",
+                    isError: false);
+                CancelSyncPrompt();
+
+                if (_navigate is not null)
+                {
+                    if (hadBooksView || _filteredBooks.Count == 0)
+                    {
+                        _refreshVisibleBooks?.Invoke();
+                    }
+                    else
+                    {
+                        _navigate(ScreenResult.Reload());
+                    }
+                }
+                else
+                {
+                    ApplyFilter();
+                }
+
+                return outcome;
+
+            default:
+                return outcome;
+        }
     }
 
     public BookViewModel? GetSelectedBook()
@@ -445,7 +572,8 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         ShortcutListView? listView,
         Action<ScreenResult> navigate,
         Action? refreshVisibleBooks,
-        Action? focusSearchField)
+        Action? focusSearchField,
+        Action? focusSyncField)
     {
         void HandleShortcutKey(Key key)
         {
@@ -460,7 +588,7 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
                 return;
             }
 
-            if (TryHandleShortcutKey(shortcutKey.Value, navigate, refreshVisibleBooks, focusSearchField))
+            if (TryHandleShortcutKey(shortcutKey.Value, navigate, refreshVisibleBooks, focusSearchField, focusSyncField))
             {
                 key.Handled = true;
             }
@@ -470,10 +598,9 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
 
         if (listView is not null)
         {
-            // ShortcutKeyPressed fires inside OnKeyDown, BEFORE the CollectionNavigator
             listView.ShortcutKeyPressed += (_, key) => HandleShortcutKey(key);
 
-            listView.ValueChanged += (_, args) =>
+            listView.ValueChanged += (_, _) =>
             {
                 _selectedIndex = listView.SelectedItem ?? 0;
             };
@@ -484,7 +611,8 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         char shortcutKey,
         Action<ScreenResult> navigate,
         Action? refreshVisibleBooks,
-        Action? focusSearchField)
+        Action? focusSearchField,
+        Action? focusSyncField)
     {
         switch (char.ToLowerInvariant(shortcutKey))
         {
@@ -496,17 +624,19 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
                 navigate(ScreenResult.Push(new SettingsScreen(_client)));
                 return true;
 
+            case 'i':
+                focusSyncField?.Invoke();
+                return true;
+
             case 'r':
                 var hadBooksView = _viewHasBooksList;
                 InitializeAsync(CancellationToken.None).GetAwaiter().GetResult();
                 if (hadBooksView || _filteredBooks.Count == 0)
                 {
-                    // Stay in current view branch: update existing view content
                     refreshVisibleBooks?.Invoke();
                 }
                 else
                 {
-                    // Recovered from empty/error state — reload view to show books
                     navigate(ScreenResult.Reload());
                 }
 
@@ -604,9 +734,9 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
         return value[..(width - 3)] + "...";
     }
 
-    private async Task<List<SunnySunday.Core.Contracts.HighlightItemDto>> LoadAllHighlightsAsync(CancellationToken cancellationToken)
+    private async Task<List<HighlightItemDto>> LoadAllHighlightsAsync(CancellationToken cancellationToken)
     {
-        var highlights = new List<SunnySunday.Core.Contracts.HighlightItemDto>();
+        var highlights = new List<HighlightItemDto>();
         var page = 1;
 
         while (true)
@@ -631,8 +761,8 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
 
     private static List<BookViewModel> EnrichBooks(
         IEnumerable<BookViewModel> books,
-        SunnySunday.Core.Contracts.ExclusionsResponse exclusions,
-        IEnumerable<SunnySunday.Core.Contracts.WeightedHighlightDto> weights)
+        ExclusionsResponse exclusions,
+        IEnumerable<WeightedHighlightDto> weights)
     {
         var excludedHighlightIds = exclusions.Highlights.Select(highlight => highlight.Id).ToHashSet();
         var excludedBookIds = exclusions.Books
@@ -687,4 +817,164 @@ public sealed class BookListScreen(SunnyHttpClient client) : IScreen
 
         _selectedIndex = Math.Clamp(_selectedIndex, 0, _filteredBooks.Count - 1);
     }
+
+    private void BeginSearchInput()
+    {
+        _toolbarMode = ToolbarMode.Search;
+        _isSearchActive = true;
+
+        if (_searchField is not null)
+        {
+            _searchField.Text = _searchQuery;
+            _searchField.SetFocus();
+            _searchField.MoveEnd();
+        }
+
+        UpdateToolbarChrome();
+    }
+
+    private void LeaveSearchInput(Action? refreshVisibleBooks)
+    {
+        _toolbarMode = ToolbarMode.Search;
+        _isSearchActive = false;
+
+        if (_searchField is not null)
+        {
+            _searchQuery = _searchField.Text ?? string.Empty;
+        }
+
+        ApplyFilter();
+        refreshVisibleBooks?.Invoke();
+        UpdateToolbarChrome();
+    }
+
+    private void HandleToolbarTextChanged()
+    {
+        if (_searchField is null)
+        {
+            return;
+        }
+
+        if (_toolbarMode == ToolbarMode.SyncPath)
+        {
+            _syncPathInput = _searchField.Text ?? string.Empty;
+        }
+        else
+        {
+            _searchQuery = _searchField.Text ?? string.Empty;
+            ApplyFilter();
+            _refreshVisibleBooks?.Invoke();
+        }
+
+        UpdateToolbarChrome();
+    }
+
+    private void HandleToolbarKeyDown(Key key)
+    {
+        if (_toolbarMode == ToolbarMode.SyncPath)
+        {
+            if (key.KeyCode == KeyCode.Esc)
+            {
+                CancelSyncPrompt();
+                key.Handled = true;
+            }
+
+            return;
+        }
+
+        if (key.KeyCode is KeyCode.Esc or KeyCode.CursorDown)
+        {
+            LeaveSearchInput(_refreshVisibleBooks);
+            _listView?.SetFocus();
+            key.Handled = true;
+        }
+    }
+
+    private async Task HandleToolbarSubmitAsync()
+    {
+        if (_toolbarMode != ToolbarMode.SyncPath)
+        {
+            return;
+        }
+
+        await SubmitSyncAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private string GetToolbarText() => _toolbarMode == ToolbarMode.SyncPath ? _syncPathInput : _searchQuery;
+
+    private string GetToolbarPlaceholder(bool hasFocus)
+    {
+        if (_toolbarMode == ToolbarMode.SyncPath)
+        {
+            return _hasDetectedSyncPath
+                ? SyncPlaceholderDetected
+                : SyncPlaceholderManual;
+        }
+
+        return hasFocus ? SearchPlaceholderFocused : SearchPlaceholderIdle;
+    }
+
+    private static string? ResolveDefaultSyncPath(string? detectedPath)
+    {
+        return !string.IsNullOrWhiteSpace(detectedPath)
+            ? detectedPath
+            : KindleDetector.GetSuggestedClippingsPath();
+    }
+
+    private void UpdateToolbarChrome()
+    {
+        if (_searchField is null || _searchPlaceholder is null || _searchFrame is null)
+        {
+            return;
+        }
+
+        _searchFrame.Title = _toolbarMode == ToolbarMode.SyncPath ? " Import " : string.Empty;
+        _searchPlaceholder.Visible = string.IsNullOrEmpty(_searchField.Text);
+        _searchPlaceholder.Text = GetToolbarPlaceholder(_searchField.HasFocus);
+        _searchFrame.SetScheme(CreateSearchFrameScheme(_searchField.HasFocus));
+    }
+
+    private Label CreateToolbarFeedbackLabel()
+    {
+        var feedbackLabel = new Label
+        {
+            X = 2,
+            Y = 3,
+            Width = Dim.Fill(3),
+            Height = 1,
+            Visible = !string.IsNullOrWhiteSpace(_feedbackMessage),
+            Text = _feedbackMessage ?? string.Empty,
+            CanFocus = false
+        };
+
+        ApplyFeedbackLabelState(feedbackLabel);
+        return feedbackLabel;
+    }
+
+    private void SetFeedback(string message, bool isError)
+    {
+        _feedbackMessage = message;
+        _feedbackIsError = isError;
+        UpdateFeedbackLabel();
+    }
+
+    private void UpdateFeedbackLabel()
+    {
+        if (_feedbackLabel is null)
+        {
+            return;
+        }
+
+        ApplyFeedbackLabelState(_feedbackLabel);
+    }
+
+    private void ApplyFeedbackLabelState(Label feedbackLabel)
+    {
+        feedbackLabel.Text = _feedbackMessage ?? string.Empty;
+        feedbackLabel.Visible = !string.IsNullOrWhiteSpace(_feedbackMessage);
+        feedbackLabel.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(
+            _feedbackIsError ? new Terminal.Gui.Drawing.Color(255, 100, 100) : new Terminal.Gui.Drawing.Color(150, 190, 230),
+            StatusChrome.Background)));
+    }
+
 }

--- a/src/SunnySunday.Cli/Tui/ShortcutListView.cs
+++ b/src/SunnySunday.Cli/Tui/ShortcutListView.cs
@@ -4,13 +4,12 @@ using Terminal.Gui.Views;
 namespace SunnySunday.Cli.Tui;
 
 /// <summary>
-/// A <see cref="ListView"/> that intercepts single-letter shortcut keys (Q, S, R, /)
-/// before the built-in <see cref="CollectionNavigator"/> can consume them for type-search.
+/// A <see cref="ListView"/> that routes printable character keys through
+/// <see cref="ShortcutKeyPressed"/> before the built-in <see cref="CollectionNavigator"/>
+/// can consume them for type-search.
 /// </summary>
 internal sealed class ShortcutListView : ListView
 {
-    private static readonly HashSet<char> ShortcutChars = ['q', 'a', 'r', 's', 't', '/'];
-
     /// <summary>
     /// Raised when a shortcut key is pressed. Set <see cref="Key.Handled"/> to true
     /// to prevent the key from reaching the <see cref="CollectionNavigator"/>.
@@ -19,22 +18,23 @@ internal sealed class ShortcutListView : ListView
 
     protected override bool OnKeyDown(Key key)
     {
-        if (!key.Handled)
+        if (key.Handled)
         {
-            var ch = GetShortcutChar(key);
-
-            if (ch is not null && ShortcutChars.Contains(ch.Value))
-            {
-                ShortcutKeyPressed?.Invoke(this, key);
-
-                if (key.Handled)
-                {
-                    return true;
-                }
-            }
+            return true;
         }
 
-        return base.OnKeyDown(key);
+        var shortcutChar = GetShortcutChar(key);
+        if (shortcutChar is null || ShortcutKeyPressed is null)
+        {
+            return base.OnKeyDown(key);
+        }
+
+        ShortcutKeyPressed.Invoke(this, key);
+
+        // Disable the built-in type-to-select behavior when a screen is explicitly
+        // using shortcut handling for printable keys.
+        key.Handled = true;
+        return true;
     }
 
     private static char? GetShortcutChar(Key key)

--- a/src/SunnySunday.Cli/Tui/TuiApp.cs
+++ b/src/SunnySunday.Cli/Tui/TuiApp.cs
@@ -2,10 +2,11 @@
 using Terminal.Gui.Drawing;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
+using SunnySunday.Cli.Sync;
 
 namespace SunnySunday.Cli.Tui;
 
-public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client, string serverUrl, string version)
+public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client, ClippingsSyncWorkflow syncWorkflow, string serverUrl, string version)
 {
     private const int SplashTopPadding = 1;
 
@@ -35,6 +36,7 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
     private static readonly Color FooterLabelColor = new(190, 190, 190);
 
     private readonly SunnySunday.Cli.Infrastructure.SunnyHttpClient _client = client;
+    private readonly ClippingsSyncWorkflow _syncWorkflow = syncWorkflow;
     private readonly StatusChrome _chrome = new(serverUrl, version);
     private readonly Stack<IScreen> _screens = new();
     private IApplication? _app;
@@ -47,16 +49,8 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
     {
         if (_screens.Count == 0)
         {
-            var initialScreen = new BookListScreen(_client);
-            try
-            {
-                await initialScreen.InitializeAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (HttpRequestException)
-            {
-                _chrome.SetDisconnected();
-            }
-
+            var initialScreen = new BookListScreen(_client, _syncWorkflow, HandleConnectionFailure, RefreshChromeAsync);
+            await initialScreen.InitializeAsync(cancellationToken).ConfigureAwait(false);
             _screens.Push(initialScreen);
         }
 
@@ -65,7 +59,6 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
 
         try
         {
-            // T026: Check minimum terminal size before starting the normal layout
             var cols = Console.IsOutputRedirected ? 80 : Console.WindowWidth;
             var rows = Console.IsOutputRedirected ? 24 : Console.WindowHeight;
             if (cols < 80 || rows < 24)
@@ -111,11 +104,7 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
 
             ShowCurrentScreen();
 
-            _ = Task.Run(async () =>
-            {
-                await _chrome.RefreshAsync(_client, cancellationToken);
-                _app.Invoke(() => _chrome.UpdateLabels());
-            });
+            _ = Task.Run(() => RefreshChromeAsync(cancellationToken));
 
             _app.Run(_window);
         }
@@ -138,7 +127,7 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
         win.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(Color.White, StatusChrome.Background)));
 
         var line1 = new Label { Text = "Terminal too small.", X = Pos.Center(), Y = Pos.AnchorEnd(4) };
-        var line2 = new Label { Text = "Please resize to at least 80\u00d724 and restart.", X = Pos.Center(), Y = Pos.AnchorEnd(3) };
+        var line2 = new Label { Text = "Please resize to at least 80×24 and restart.", X = Pos.Center(), Y = Pos.AnchorEnd(3) };
         var line3 = new Label { Text = "Press any key to exit.", X = Pos.Center(), Y = Pos.AnchorEnd(2) };
         line3.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(new Color(128, 128, 128), StatusChrome.Background)));
         win.Add(line1, line2, line3);
@@ -234,12 +223,12 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
             for (var width = 2; width <= maxWidth; width += 2)
             {
                 ct.ThrowIfCancellationRequested();
-                var w = Math.Min(width, maxWidth);
+                var currentWidth = Math.Min(width, maxWidth);
 
                 for (var i = 0; i < SplashLines.Length; i++)
                 {
                     var line = SplashLines[i];
-                    labels[i].Text = line[..Math.Min(w, line.Length)];
+                    labels[i].Text = line[..Math.Min(currentWidth, line.Length)];
                 }
 
                 _app.LayoutAndDraw(true);
@@ -267,7 +256,6 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
         }
         catch (OperationCanceledException)
         {
-            // user quit before animation finished — safe to ignore
         }
         finally
         {
@@ -292,12 +280,11 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
                 {
                     try
                     {
-                        await result.Next.InitializeAsync(CancellationToken.None);
+                        await result.Next.InitializeAsync(CancellationToken.None).ConfigureAwait(false);
                     }
                     catch (HttpRequestException)
                     {
-                        _chrome.SetDisconnected();
-                        _app?.Invoke(() => _chrome.UpdateLabels());
+                        HandleConnectionFailure();
                     }
 
                     _app?.Invoke(() =>
@@ -317,11 +304,22 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
                 break;
             case ScreenAction.Quit:
                 _app?.RequestStop();
-
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(result.Action), result.Action, null);
         }
+    }
+
+    private void HandleConnectionFailure()
+    {
+        _chrome.SetDisconnected();
+        _app?.Invoke(() => _chrome.UpdateLabels());
+    }
+
+    private async Task RefreshChromeAsync(CancellationToken cancellationToken)
+    {
+        await _chrome.RefreshAsync(_client, cancellationToken).ConfigureAwait(false);
+        _app?.Invoke(() => _chrome.UpdateLabels());
     }
 
     private void ShowCurrentScreen()
@@ -333,14 +331,12 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
 
         var screen = _screens.Peek();
 
-        // Remove previous toolbar if any
         if (_toolbarView is not null)
         {
             _window.Remove(_toolbarView);
             _toolbarView = null;
         }
 
-        // Add toolbar if the screen provides one
         var toolbarHeight = screen.ToolbarHeight;
         _toolbarView = screen.CreateToolbarView(Navigate);
 
@@ -357,7 +353,6 @@ public sealed class TuiApp(SunnySunday.Cli.Infrastructure.SunnyHttpClient client
             toolbarHeight = 0;
         }
 
-        // Adjust content frame position
         _contentFrame.Y = StatusChrome.LogoHeight + toolbarHeight;
 
         _contentFrame.RemoveAll();

--- a/src/SunnySunday.Tests/Cli/ClippingsSyncWorkflowTests.cs
+++ b/src/SunnySunday.Tests/Cli/ClippingsSyncWorkflowTests.cs
@@ -1,0 +1,220 @@
+﻿using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Cli.Sync;
+using SunnySunday.Core.Contracts;
+
+namespace SunnySunday.Tests.Cli;
+
+public sealed class ClippingsSyncWorkflowTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ClippingsSyncWorkflowTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"sunny-sync-workflow-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidFile_ReturnsSuccessAndPreservesSyncPayload()
+    {
+        var filePath = CreateClippingsFile(SampleClippings);
+        using var handler = new CapturingHandler(_ => JsonResponse("""
+            {"newHighlights":5,"duplicateHighlights":2,"newBooks":3,"newAuthors":2}
+            """));
+        using var harness = CreateWorkflowHarness(handler);
+
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        {
+            FilePath = filePath
+        }, CancellationToken.None);
+
+        Assert.Equal(ClippingsSyncStatus.Succeeded, outcome.Status);
+        Assert.NotNull(outcome.ParseResult);
+        Assert.NotNull(outcome.Response);
+        Assert.Equal(5, outcome.Response!.NewHighlights);
+        Assert.Equal(5, outcome.TotalHighlightsParsed);
+
+        var requestBody = await handler.LastRequest!.Content!.ReadAsStringAsync();
+        var request = JsonSerializer.Deserialize<SyncRequest>(requestBody, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(request);
+        Assert.Collection(request!.Books,
+            pragmatic =>
+            {
+                Assert.Equal("The Pragmatic Programmer", pragmatic.Title);
+                Assert.Equal("David Thomas;Andrew Hunt", pragmatic.Author);
+                Assert.Equal(2, pragmatic.Highlights.Count);
+                Assert.Equal("Care About Your Craft", pragmatic.Highlights[0].Text);
+                Assert.Equal("Think! About Your Work", pragmatic.Highlights[1].Text);
+            },
+            cleanCode =>
+            {
+                Assert.Equal("Clean Code", cleanCode.Title);
+                Assert.Equal("Robert C. Martin", cleanCode.Author);
+                Assert.Equal(3, cleanCode.Highlights.Count);
+                Assert.Equal("Clean code is simple and direct.", cleanCode.Highlights[0].Text);
+                Assert.Equal("The ratio of time spent reading versus writing is well over 10 to 1.", cleanCode.Highlights[1].Text);
+                Assert.Equal("Leave the campground cleaner than you found it.", cleanCode.Highlights[2].Text);
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyFile_ReturnsNoHighlightsFoundWithoutUploading()
+    {
+        var filePath = CreateClippingsFile(string.Empty);
+        using var handler = new CapturingHandler(_ => throw new Xunit.Sdk.XunitException("Upload should not be attempted for an empty clippings file."));
+        using var harness = CreateWorkflowHarness(handler);
+
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        {
+            FilePath = filePath
+        }, CancellationToken.None);
+
+        Assert.Equal(ClippingsSyncStatus.NoHighlightsFound, outcome.Status);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResolverReturningMissingFile_ReturnsFileNotFound()
+    {
+        using var handler = new CapturingHandler(_ => throw new Xunit.Sdk.XunitException("Upload should not be attempted for a missing clippings file."));
+        using var harness = CreateWorkflowHarness(handler);
+
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        {
+            ResolvePathAsync = (_, _) => ValueTask.FromResult<string?>("/missing/My Clippings.txt")
+        }, CancellationToken.None);
+
+        Assert.Equal(ClippingsSyncStatus.FileNotFound, outcome.Status);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenParserThrows_ReturnsParseFailed()
+    {
+        var filePath = CreateClippingsFile(SampleClippings);
+        using var handler = new CapturingHandler(_ => throw new Xunit.Sdk.XunitException("Upload should not be attempted when parsing fails."));
+        using var harness = CreateWorkflowHarness(handler);
+
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        {
+            FilePath = filePath,
+            ParseAsync = static (_, _) => throw new InvalidDataException("boom")
+        }, CancellationToken.None);
+
+        Assert.Equal(ClippingsSyncStatus.ParseFailed, outcome.Status);
+        Assert.Equal("boom", outcome.Message);
+        Assert.IsType<InvalidDataException>(outcome.Error);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServerIsUnreachable_ReturnsServerError()
+    {
+        var filePath = CreateClippingsFile(SampleClippings);
+        using var handler = new CapturingHandler(_ => throw new HttpRequestException("Connection refused"));
+        using var harness = CreateWorkflowHarness(handler);
+
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        {
+            FilePath = filePath
+        }, CancellationToken.None);
+
+        Assert.Equal(ClippingsSyncStatus.ServerError, outcome.Status);
+        Assert.Equal("Connection refused", outcome.Message);
+        Assert.IsType<HttpRequestException>(outcome.Error);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    private static WorkflowHarness CreateWorkflowHarness(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        return new WorkflowHarness(httpClient, new ClippingsSyncWorkflow(new SunnyHttpClient(httpClient), NullLogger<ClippingsSyncWorkflow>.Instance));
+    }
+
+    private string CreateClippingsFile(string content)
+    {
+        var filePath = Path.Combine(_tempDir, "My Clippings.txt");
+        File.WriteAllText(filePath, content);
+        return filePath;
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class WorkflowHarness(HttpClient httpClient, ClippingsSyncWorkflow workflow) : IDisposable
+    {
+        public ClippingsSyncWorkflow Workflow { get; } = workflow;
+
+        public void Dispose()
+        {
+            httpClient.Dispose();
+        }
+    }
+
+    private const string SampleClippings = """
+        The Pragmatic Programmer (David Thomas;Andrew Hunt)
+        - Your Highlight on Location 150-152 | Added on Monday, January 15, 2024 12:30:00 PM
+
+        Care About Your Craft
+        ==========
+        The Pragmatic Programmer (David Thomas;Andrew Hunt)
+        - Your Highlight on Location 200-205 | Added on Monday, January 15, 2024 1:00:00 PM
+
+        Think! About Your Work
+        ==========
+        Clean Code (Robert C. Martin)
+        - Your Highlight on Location 50-55 | Added on Tuesday, January 16, 2024 9:00:00 AM
+
+        Clean code is simple and direct.
+        ==========
+        Clean Code (Robert C. Martin)
+        - Your Highlight on Location 100-110 | Added on Tuesday, January 16, 2024 9:30:00 AM
+
+        The ratio of time spent reading versus writing is well over 10 to 1.
+        ==========
+        Clean Code (Robert C. Martin)
+        - Your Highlight on Location 150-160 | Added on Tuesday, January 16, 2024 10:00:00 AM
+
+        Leave the campground cleaner than you found it.
+        ==========
+        """;
+}

--- a/src/SunnySunday.Tests/Cli/SyncCommandTests.cs
+++ b/src/SunnySunday.Tests/Cli/SyncCommandTests.cs
@@ -3,6 +3,7 @@ using RichardSzalay.MockHttp;
 using Spectre.Console.Cli;
 using SunnySunday.Cli.Commands;
 using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Cli.Sync;
 
 namespace SunnySunday.Tests.Cli;
 
@@ -81,6 +82,7 @@ public sealed class SyncCommandTests : IDisposable
             httpClient.BaseAddress = new Uri("http://localhost:5000");
             return new SunnyHttpClient(httpClient);
         });
+        services.AddTransient<ClippingsSyncWorkflow>();
 
         var registrar = new TypeRegistrar(services.BuildServiceProvider());
         var app = new CommandApp(registrar);

--- a/src/SunnySunday.Tests/Tui/BookListScreenTests.cs
+++ b/src/SunnySunday.Tests/Tui/BookListScreenTests.cs
@@ -1,5 +1,8 @@
-﻿using RichardSzalay.MockHttp;
+﻿using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using RichardSzalay.MockHttp;
 using SunnySunday.Cli.Infrastructure;
+using SunnySunday.Cli.Sync;
 using SunnySunday.Cli.Tui;
 
 namespace SunnySunday.Tests.Tui;
@@ -7,8 +10,22 @@ namespace SunnySunday.Tests.Tui;
 public sealed class BookListScreenTests : IDisposable
 {
     private readonly MockHttpMessageHandler _mockHttp = new();
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"sunny-book-screen-{Guid.NewGuid():N}");
 
-    public void Dispose() => _mockHttp.Dispose();
+    public BookListScreenTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        _mockHttp.Dispose();
+
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
 
     [Fact]
     public async Task MoveSelection_DownAndUp_MovesWithinBounds()
@@ -75,7 +92,7 @@ public sealed class BookListScreenTests : IDisposable
         var screen = await CreateScreenAsync();
         ScreenResult? result = null;
 
-        var handled = screen.TryHandleShortcutKey('q', navigate => result = navigate, null, null);
+        var handled = screen.TryHandleShortcutKey('q', navigate => result = navigate, null, null, null);
 
         Assert.True(handled);
         Assert.NotNull(result);
@@ -88,10 +105,22 @@ public sealed class BookListScreenTests : IDisposable
         var screen = await CreateScreenAsync();
         var focusedSearchField = false;
 
-        var handled = screen.TryHandleShortcutKey('/', _ => { }, null, () => focusedSearchField = true);
+        var handled = screen.TryHandleShortcutKey('/', _ => { }, null, () => focusedSearchField = true, null);
 
         Assert.True(handled);
         Assert.True(focusedSearchField);
+    }
+
+    [Fact]
+    public async Task TryHandleShortcutKey_I_FocusesSyncField()
+    {
+        var screen = await CreateScreenAsync();
+        var focusedSyncField = false;
+
+        var handled = screen.TryHandleShortcutKey('i', _ => { }, null, null, () => focusedSyncField = true);
+
+        Assert.True(handled);
+        Assert.True(focusedSyncField);
     }
 
     [Fact]
@@ -132,14 +161,13 @@ public sealed class BookListScreenTests : IDisposable
 
         ConfigureSupplementaryEndpoints(mockHttp);
 
-        var httpClient = mockHttp.ToHttpClient();
-        httpClient.BaseAddress = new Uri("http://localhost:5000");
-
-        var screen = new BookListScreen(new SunnyHttpClient(httpClient));
+        var sunnyClient = CreateSunnyClient(mockHttp);
+        var workflow = new ClippingsSyncWorkflow(sunnyClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var screen = new BookListScreen(sunnyClient, workflow);
         await screen.InitializeAsync(CancellationToken.None);
 
         var refreshedVisibleBooks = false;
-        var handled = screen.TryHandleShortcutKey('r', _ => { }, () => refreshedVisibleBooks = true, null);
+        var handled = screen.TryHandleShortcutKey('r', _ => { }, () => refreshedVisibleBooks = true, null, null);
 
         Assert.True(handled);
         Assert.Empty(screen.Books);
@@ -147,7 +175,144 @@ public sealed class BookListScreenTests : IDisposable
         mockHttp.VerifyNoOutstandingExpectation();
     }
 
+    [Fact]
+    public async Task CancelSyncPrompt_LeavesScreenStable()
+    {
+        var screen = await CreateScreenAsync();
+
+        SetSyncPromptState(screen, syncPathInput: "/tmp/My Clippings.txt");
+        screen.CancelSyncPrompt();
+
+        Assert.False(screen.IsSyncPromptActive);
+    }
+
+    [Fact]
+    public async Task SubmitSyncAsync_WithBlankPath_SetsValidationFeedback()
+    {
+        var screen = await CreateScreenAsync();
+
+        SetSyncPromptState(screen, syncPathInput: string.Empty);
+        var outcome = await screen.SubmitSyncAsync(string.Empty);
+
+        Assert.Equal(ClippingsSyncStatus.Cancelled, outcome.Status);
+        Assert.Equal("Enter a path to My Clippings.txt or press Esc to cancel.", screen.FeedbackMessage);
+        Assert.True(screen.FeedbackIsError);
+        Assert.True(screen.IsSyncPromptActive);
+    }
+
+    [Fact]
+    public async Task SubmitSyncAsync_OnSuccess_RefreshesBooksAndClosesPrompt()
+    {
+        using var mockHttp = new MockHttpMessageHandler(BackendDefinitionBehavior.Always);
+
+        mockHttp.Expect(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+            .Respond("application/json", """
+                {
+                  "total": 0,
+                  "page": 1,
+                  "pageSize": 100,
+                  "items": []
+                }
+                """);
+
+        mockHttp.Expect(HttpMethod.Post, "http://localhost:5000/sync")
+            .Respond("application/json", """
+                {
+                  "newHighlights": 1,
+                  "duplicateHighlights": 0,
+                  "newBooks": 1,
+                  "newAuthors": 1
+                }
+                """);
+
+        mockHttp.Expect(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+            .Respond("application/json", """
+                {
+                  "total": 1,
+                  "page": 1,
+                  "pageSize": 100,
+                  "items": [
+                    {
+                      "id": 1,
+                      "bookId": 10,
+                      "authorId": 7,
+                      "text": "Psychohistory is built on large numbers.",
+                      "bookTitle": "Foundation",
+                      "authorName": "Isaac Asimov"
+                    }
+                  ]
+                }
+                """);
+
+        ConfigureSupplementaryEndpoints(mockHttp);
+
+        var sunnyClient = CreateSunnyClient(mockHttp);
+        var workflow = new ClippingsSyncWorkflow(sunnyClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var screen = new BookListScreen(sunnyClient, workflow);
+        await screen.InitializeAsync(CancellationToken.None);
+
+        var filePath = CreateClippingsFile();
+        SetSyncPromptState(screen, detectedPath: filePath, syncPathInput: filePath);
+        var outcome = await screen.SubmitSyncAsync(filePath);
+
+        Assert.Equal(ClippingsSyncStatus.Succeeded, outcome.Status);
+        Assert.Single(screen.Books);
+        Assert.False(screen.IsSyncPromptActive);
+        Assert.False(screen.FeedbackIsError);
+        Assert.Contains("Sync complete.", screen.FeedbackMessage);
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task SubmitSyncAsync_OnServerError_ShowsRetryableFeedback()
+    {
+        using var mockHttp = new MockHttpMessageHandler(BackendDefinitionBehavior.Always);
+        ConfigureHighlightEndpoints(mockHttp);
+        ConfigureSupplementaryEndpoints(mockHttp);
+
+        mockHttp.When(HttpMethod.Post, "http://localhost:5000/sync")
+            .Throw(new HttpRequestException("Connection refused"));
+
+        var sunnyClient = CreateSunnyClient(mockHttp);
+        var workflow = new ClippingsSyncWorkflow(sunnyClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var screen = new BookListScreen(sunnyClient, workflow);
+        await screen.InitializeAsync(CancellationToken.None);
+
+        var filePath = CreateClippingsFile();
+        SetSyncPromptState(screen, detectedPath: filePath, syncPathInput: filePath);
+        var outcome = await screen.SubmitSyncAsync(filePath);
+
+        Assert.Equal(ClippingsSyncStatus.ServerError, outcome.Status);
+        Assert.True(screen.IsSyncPromptActive);
+        Assert.True(screen.FeedbackIsError);
+        Assert.Equal("Sync failed: Connection refused", screen.FeedbackMessage);
+    }
+
     private async Task<BookListScreen> CreateScreenAsync(int total = 3, string? itemsJson = null)
+    {
+        return await CreateScreenAsync(_mockHttp, total, itemsJson).ConfigureAwait(false);
+    }
+
+    private static async Task<BookListScreen> CreateScreenAsync(MockHttpMessageHandler mockHttp, int total = 3, string? itemsJson = null)
+    {
+        ConfigureHighlightEndpoints(mockHttp, total, itemsJson);
+        ConfigureSupplementaryEndpoints(mockHttp);
+
+        var sunnyClient = CreateSunnyClient(mockHttp);
+        var workflow = new ClippingsSyncWorkflow(sunnyClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var screen = new BookListScreen(sunnyClient, workflow);
+        await screen.InitializeAsync(CancellationToken.None);
+        return screen;
+    }
+
+    private static SunnyHttpClient CreateSunnyClient(MockHttpMessageHandler mockHttp)
+    {
+        var httpClient = mockHttp.ToHttpClient();
+        httpClient.BaseAddress = new Uri("http://localhost:5000");
+        return new SunnyHttpClient(httpClient);
+    }
+
+    private static void ConfigureHighlightEndpoints(MockHttpMessageHandler mockHttp, int total = 3, string? itemsJson = null)
     {
         itemsJson ??= """
             [
@@ -178,7 +343,7 @@ public sealed class BookListScreenTests : IDisposable
             ]
             """;
 
-        _mockHttp.When(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+        mockHttp.When(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
             .Respond("application/json", $$"""
                 {
                   "total": {{total}},
@@ -187,15 +352,6 @@ public sealed class BookListScreenTests : IDisposable
                   "items": {{itemsJson}}
                 }
                 """);
-
-        ConfigureSupplementaryEndpoints(_mockHttp);
-
-        var httpClient = _mockHttp.ToHttpClient();
-        httpClient.BaseAddress = new Uri("http://localhost:5000");
-
-        var screen = new BookListScreen(new SunnyHttpClient(httpClient));
-        await screen.InitializeAsync(CancellationToken.None);
-        return screen;
     }
 
     private static void ConfigureSupplementaryEndpoints(MockHttpMessageHandler mockHttp)
@@ -227,4 +383,39 @@ public sealed class BookListScreenTests : IDisposable
                 ]
                 """);
     }
+
+    private string CreateClippingsFile()
+    {
+        var filePath = Path.Combine(_tempDir, "My Clippings.txt");
+        File.WriteAllText(filePath, SampleClippings);
+        return filePath;
+    }
+
+    private static void SetSyncPromptState(BookListScreen screen, string? detectedPath = null, string? syncPathInput = null)
+    {
+        var screenType = typeof(BookListScreen);
+        var toolbarModeField = screenType.GetField("_toolbarMode", BindingFlags.Instance | BindingFlags.NonPublic);
+        var detectedSyncPathField = screenType.GetField("_detectedSyncPath", BindingFlags.Instance | BindingFlags.NonPublic);
+        var syncPathInputField = screenType.GetField("_syncPathInput", BindingFlags.Instance | BindingFlags.NonPublic);
+        var isSearchActiveField = screenType.GetField("_isSearchActive", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(toolbarModeField);
+        Assert.NotNull(detectedSyncPathField);
+        Assert.NotNull(syncPathInputField);
+        Assert.NotNull(isSearchActiveField);
+
+        var syncPathMode = Enum.Parse(toolbarModeField!.FieldType, "SyncPath");
+        toolbarModeField.SetValue(screen, syncPathMode);
+        detectedSyncPathField!.SetValue(screen, detectedPath);
+        syncPathInputField!.SetValue(screen, syncPathInput ?? string.Empty);
+        isSearchActiveField!.SetValue(screen, false);
+    }
+
+    private const string SampleClippings = """
+        The Pragmatic Programmer (David Thomas;Andrew Hunt)
+        - Your Highlight on Location 150-152 | Added on Monday, January 15, 2024 12:30:00 PM
+
+        Care About Your Craft
+        ==========
+        """;
 }


### PR DESCRIPTION
## Summary
- extract clippings sync orchestration into a shared ClippingsSyncWorkflow
- wire CLI sync command to the shared workflow while preserving prompts and output
- add in-TUI import via I, disable list type-to-select interference, and improve import feedback/default path behavior
- update and add tests for CLI workflow and TUI import behavior
- mark US9 tasks as completed in specs/007-evolve-cli-to-tui/tasks.md

## Validation
- dotnet test src/SunnySunday.Tests/SunnySunday.Tests.csproj -v normal

Closes #220
