### PR TITLE
Improve settings management in TUI

### DIFF
--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -16,6 +16,9 @@ public sealed class SettingsScreen : IScreen
     private const int MinWeight = 1;
     private const int MaxWeight = 15;
 
+    private static readonly string[] ScheduleOptions = ["daily", "weekly"];
+    private static readonly string[] DayOfWeekOptions = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
+
     private static readonly (string Key, string Label)[] NormalKeyHints =
     [
         ("↑↓", "Navigate"),
@@ -32,6 +35,9 @@ public sealed class SettingsScreen : IScreen
     private SettingsResponse? _settings;
     private int _selectedField;
     private bool _isEditing;
+    private bool _isSelectMode;
+    private List<string> _selectOptions = [];
+    private int _selectIndex;
     private string _editBuffer = string.Empty;
     private string? _statusMessage;
     private bool _statusIsError;
@@ -73,6 +79,14 @@ public sealed class SettingsScreen : IScreen
     public async Task InitializeAsync(CancellationToken cancellationToken)
     {
         _settings = await _client.GetSettingsAsync(cancellationToken).ConfigureAwait(false);
+
+        var localTimezone = TimeZoneInfo.Local.Id;
+        if (!string.Equals(_settings.Timezone, localTimezone, StringComparison.Ordinal))
+        {
+            var request = new UpdateSettingsRequest { Timezone = localTimezone };
+            _settings = await _client.PutSettingsAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
         RebuildFields();
     }
 
@@ -155,6 +169,28 @@ public sealed class SettingsScreen : IScreen
             {
                 CancelEdit();
                 key.Handled = true;
+                return;
+            }
+
+            if (_isSelectMode)
+            {
+                switch (key.KeyCode)
+                {
+                    case KeyCode.CursorLeft:
+                    case KeyCode.CursorUp:
+                        CycleSelect(-1);
+                        key.Handled = true;
+                        break;
+                    case KeyCode.CursorRight:
+                    case KeyCode.CursorDown:
+                        CycleSelect(1);
+                        key.Handled = true;
+                        break;
+                    default:
+                        if (key.KeyCode != KeyCode.Enter)
+                            key.Handled = true;
+                        break;
+                }
             }
         };
 
@@ -218,6 +254,7 @@ public sealed class SettingsScreen : IScreen
         if (_fields.Count == 0)
             return ScreenResult.Stay();
         _selectedField = Math.Clamp(_selectedField + delta, 0, _fields.Count - 1);
+        ClearStatus();
         return ScreenResult.Stay();
     }
 
@@ -241,19 +278,30 @@ public sealed class SettingsScreen : IScreen
     {
         _isEditing = true;
         _editBuffer = field.Value;
+        ClearStatus();
+
+        var hasOptions = field.Options is { Count: > 0 };
+        _isSelectMode = hasOptions;
+
+        if (hasOptions)
+        {
+            _selectOptions = [.. field.Options!];
+            _selectIndex = Math.Max(0, _selectOptions.IndexOf(field.Value));
+        }
 
         if (_editPromptLabel is not null)
         {
-            _editPromptLabel.Text = $"Edit {field.Label}:";
+            _editPromptLabel.Text = field.Hint ?? $"Edit {field.Label}:";
             _editPromptLabel.Visible = true;
         }
 
         if (_editField is not null)
         {
-            _editField.Text = _editBuffer;
+            _editField.Text = hasOptions ? _selectOptions[_selectIndex] : _editBuffer;
             _editField.Visible = true;
             _editField.SetFocus();
-            _editField.MoveEnd();
+            if (!hasOptions)
+                _editField.MoveEnd();
         }
 
         if (_editOverlay is not null)
@@ -265,6 +313,9 @@ public sealed class SettingsScreen : IScreen
     private void CancelEdit()
     {
         _isEditing = false;
+        _isSelectMode = false;
+        _selectOptions = [];
+        _selectIndex = 0;
         _editBuffer = string.Empty;
 
         if (_editPromptLabel is not null)
@@ -282,6 +333,8 @@ public sealed class SettingsScreen : IScreen
     {
         if (!_isEditing || _fields.Count == 0)
             return;
+
+        ClearStatus();
 
         var field = _fields[_selectedField];
         var newValue = _editField?.Text?.Trim() ?? string.Empty;
@@ -383,32 +436,19 @@ public sealed class SettingsScreen : IScreen
         return ScreenResult.Stay();
     }
 
-    private static string? ValidateField(SettingsField field, string value)
+    public static string? ValidateField(SettingsField field, string value)
     {
         return field.FieldId switch
         {
             "kindleEmail" => !value.Contains('@') ? "Email must contain '@'." : null,
             "schedule" => value is not "daily" and not "weekly" ? "Schedule must be 'daily' or 'weekly'." : null,
+            "deliveryDay" => !DayOfWeekOptions.Contains(value, StringComparer.OrdinalIgnoreCase) ? "Invalid day of week." : null,
             "deliveryTime" => !TimeOnly.TryParseExact(value, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out _)
                 ? "Time must be in HH:mm format." : null,
             "count" => !int.TryParse(value, out var c) || c < MinWeight || c > MaxWeight
                 ? $"Count must be an integer between {MinWeight} and {MaxWeight}." : null,
-            "timezone" => !IsValidTimezone(value) ? "Invalid IANA timezone identifier." : null,
             _ => null
         };
-    }
-
-    private static bool IsValidTimezone(string value)
-    {
-        try
-        {
-            TimeZoneInfo.FindSystemTimeZoneById(value.Trim());
-            return true;
-        }
-        catch (TimeZoneNotFoundException)
-        {
-            return false;
-        }
     }
 
     private static UpdateSettingsRequest BuildUpdateRequest(SettingsField field, string value)
@@ -417,9 +457,9 @@ public sealed class SettingsScreen : IScreen
         {
             "kindleEmail" => new UpdateSettingsRequest { KindleEmail = value },
             "schedule" => new UpdateSettingsRequest { Schedule = value },
+            "deliveryDay" => new UpdateSettingsRequest { DeliveryDay = value },
             "deliveryTime" => new UpdateSettingsRequest { DeliveryTime = value },
             "count" => new UpdateSettingsRequest { Count = int.Parse(value, CultureInfo.InvariantCulture) },
-            "timezone" => new UpdateSettingsRequest { Timezone = value },
             _ => new UpdateSettingsRequest()
         };
     }
@@ -431,11 +471,22 @@ public sealed class SettingsScreen : IScreen
         if (_settings is null)
             return;
 
-        _fields.Add(new SettingsField("Kindle Email", _settings.KindleEmail, "kindleEmail", FieldKind.Editable));
-        _fields.Add(new SettingsField("Schedule", _settings.Schedule, "schedule", FieldKind.Editable));
-        _fields.Add(new SettingsField("Delivery Time", _settings.DeliveryTime, "deliveryTime", FieldKind.Editable));
-        _fields.Add(new SettingsField("Timezone", _settings.Timezone, "timezone", FieldKind.Editable));
-        _fields.Add(new SettingsField("Highlights per Recap", _settings.Count.ToString(CultureInfo.InvariantCulture), "count", FieldKind.Editable));
+        _fields.Add(new SettingsField("Kindle Email", _settings.KindleEmail, "kindleEmail", FieldKind.Editable,
+            Hint: "Insert a valid email address"));
+        _fields.Add(new SettingsField("Schedule", _settings.Schedule, "schedule", FieldKind.Editable,
+            Hint: "◀ ▶ to change, Enter to confirm", Options: ScheduleOptions));
+
+        if (string.Equals(_settings.Schedule, "weekly", StringComparison.OrdinalIgnoreCase))
+        {
+            var dayValue = string.IsNullOrWhiteSpace(_settings.DeliveryDay) ? "monday" : _settings.DeliveryDay;
+            _fields.Add(new SettingsField("Delivery Day", dayValue, "deliveryDay", FieldKind.Editable,
+                Hint: "◀ ▶ to change, Enter to confirm", Options: DayOfWeekOptions));
+        }
+
+        _fields.Add(new SettingsField("Delivery Time", _settings.DeliveryTime, "deliveryTime", FieldKind.Editable,
+            Hint: "HH:mm format (e.g. 09:30)", DisplaySuffix: $"({_settings.Timezone})"));
+        _fields.Add(new SettingsField("Highlights per Recap", _settings.Count.ToString(CultureInfo.InvariantCulture), "count", FieldKind.Editable,
+            Hint: $"A number between {MinWeight} and {MaxWeight}"));
         _fields.Add(new SettingsField("▶ Send test email", string.Empty, "test-email", FieldKind.Action));
 
         if (_isDevelopment)
@@ -452,6 +503,23 @@ public sealed class SettingsScreen : IScreen
         _statusMessage = message;
         _statusIsError = isError;
         UpdateViewStateIfCreated();
+    }
+
+    private void ClearStatus()
+    {
+        _statusMessage = null;
+        _statusIsError = false;
+        UpdateViewStateIfCreated();
+    }
+
+    private void CycleSelect(int delta)
+    {
+        if (_selectOptions.Count == 0)
+            return;
+
+        _selectIndex = (_selectIndex + delta + _selectOptions.Count) % _selectOptions.Count;
+        if (_editField is not null)
+            _editField.Text = _selectOptions[_selectIndex];
     }
 
     private void UpdateViewStateIfCreated()
@@ -498,7 +566,8 @@ public sealed class SettingsScreen : IScreen
             return $"  {field.Label}";
 
         var label = field.Label.PadRight(LabelColumnWidth);
-        return $"  {label}{field.Value}";
+        var displayValue = field.DisplaySuffix is not null ? $"{field.Value} {field.DisplaySuffix}" : field.Value;
+        return $"  {label}{displayValue}";
     }
 
     private static Scheme CreateEditFieldScheme(Terminal.Gui.Drawing.Attribute attribute) => new(attribute)
@@ -605,7 +674,14 @@ public sealed class SettingsScreen : IScreen
             _navigate?.Invoke(result);
     }
 
-    public sealed record SettingsField(string Label, string Value, string FieldId, FieldKind Kind)
+    public sealed record SettingsField(
+        string Label,
+        string Value,
+        string FieldId,
+        FieldKind Kind,
+        string? Hint = null,
+        IReadOnlyList<string>? Options = null,
+        string? DisplaySuffix = null)
     {
         public string? ActionId => Kind == FieldKind.Action ? FieldId : null;
     }

--- a/src/Relego.Tests/Tui/SettingsScreenTests.cs
+++ b/src/Relego.Tests/Tui/SettingsScreenTests.cs
@@ -14,21 +14,22 @@ public sealed class SettingsScreenTests
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    private static readonly SettingsResponse DefaultSettings = new()
+    private static SettingsResponse CreateDefaultSettings(string? timezone = null) => new()
     {
         Schedule = "daily",
         DeliveryTime = "18:00",
         Count = 5,
         KindleEmail = "user@kindle.com",
-        Timezone = "UTC"
+        Timezone = timezone ?? TimeZoneInfo.Local.Id
     };
 
     [Fact]
     public async Task InitializeAsync_LoadsSettingsAndBuildsFields()
     {
+        var settings = CreateDefaultSettings();
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
@@ -36,22 +37,140 @@ public sealed class SettingsScreenTests
 
         Assert.NotNull(screen.Settings);
         Assert.Equal("user@kindle.com", screen.Settings.KindleEmail);
-        Assert.Equal(6, screen.Fields.Count); // 5 editable + 1 action (test email)
+        Assert.Equal(5, screen.Fields.Count); // 4 editable + 1 action (schedule=daily, no delivery day, no timezone)
     }
 
     [Fact]
     public async Task InitializeAsync_WithDevelopment_ShowsTriggerRecapAction()
     {
+        var settings = CreateDefaultSettings();
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient), isDevelopment: true);
         await screen.InitializeAsync(CancellationToken.None);
 
-        Assert.Equal(7, screen.Fields.Count); // 5 editable + 2 actions
+        Assert.Equal(6, screen.Fields.Count); // 4 editable + 2 actions
         Assert.Contains(screen.Fields, f => f.ActionId == "trigger-recap");
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WeeklySchedule_ShowsDeliveryDayField()
+    {
+        var settings = CreateDefaultSettings();
+        settings.Schedule = "weekly";
+        settings.DeliveryDay = "wednesday";
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/settings")
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+
+        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        await screen.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(6, screen.Fields.Count); // 5 editable (includes delivery day) + 1 action
+        Assert.Contains(screen.Fields, f => f.FieldId == "deliveryDay");
+        Assert.Equal("wednesday", screen.Fields.First(f => f.FieldId == "deliveryDay").Value);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WeeklySchedule_NullDeliveryDay_DefaultsToMonday()
+    {
+        var settings = CreateDefaultSettings();
+        settings.Schedule = "weekly";
+        settings.DeliveryDay = null;
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/settings")
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+
+        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        await screen.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal("monday", screen.Fields.First(f => f.FieldId == "deliveryDay").Value);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AutoDetectsAndSavesTimezone()
+    {
+        var settings = CreateDefaultSettings(timezone: "America/New_York");
+        var updatedSettings = CreateDefaultSettings(); // will have local timezone
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/settings")
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
+        mockHttp.When(HttpMethod.Put, "http://localhost/settings")
+            .Respond("application/json", JsonSerializer.Serialize(updatedSettings, CamelCaseOptions));
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+
+        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        await screen.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(TimeZoneInfo.Local.Id, screen.Settings!.Timezone);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_SkipsTimezoneUpdate_WhenAlreadyLocal()
+    {
+        var settings = CreateDefaultSettings(); // already local timezone
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/settings")
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
+        // No PUT mock — if a PUT is attempted, it would fail
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+
+        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        await screen.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(TimeZoneInfo.Local.Id, screen.Settings!.Timezone);
+    }
+
+    [Fact]
+    public async Task Fields_DoNotContainTimezone()
+    {
+        var screen = await CreateInitializedScreen();
+
+        Assert.DoesNotContain(screen.Fields, f => f.FieldId == "timezone");
+    }
+
+    [Fact]
+    public async Task Fields_DeliveryTimeShowsTimezoneInDisplaySuffix()
+    {
+        var screen = await CreateInitializedScreen();
+
+        var dtField = screen.Fields.First(f => f.FieldId == "deliveryTime");
+        Assert.NotNull(dtField.DisplaySuffix);
+        Assert.Contains(TimeZoneInfo.Local.Id, dtField.DisplaySuffix);
+    }
+
+    [Fact]
+    public async Task Fields_ScheduleHasOptions()
+    {
+        var screen = await CreateInitializedScreen();
+
+        var scheduleField = screen.Fields.First(f => f.FieldId == "schedule");
+        Assert.NotNull(scheduleField.Options);
+        Assert.Contains("daily", scheduleField.Options);
+        Assert.Contains("weekly", scheduleField.Options);
+    }
+
+    [Fact]
+    public async Task Fields_KindleEmailHasHint()
+    {
+        var screen = await CreateInitializedScreen();
+
+        var emailField = screen.Fields.First(f => f.FieldId == "kindleEmail");
+        Assert.Equal("Insert a valid email address", emailField.Hint);
+    }
+
+    [Fact]
+    public async Task Fields_CountHasHint()
+    {
+        var screen = await CreateInitializedScreen();
+
+        var countField = screen.Fields.First(f => f.FieldId == "count");
+        Assert.Contains("between 1 and 15", countField.Hint);
     }
 
     [Fact]
@@ -70,6 +189,20 @@ public sealed class SettingsScreenTests
             await screen.HandleKeyAsync(Key(ConsoleKey.UpArrow), CancellationToken.None);
 
         Assert.Equal(0, screen.SelectedField);
+    }
+
+    [Fact]
+    public async Task HandleKeyAsync_NavigationClearsStatusMessage()
+    {
+        var screen = await CreateInitializedScreenWithTestEmail();
+
+        // Generate a status message via test email
+        await screen.HandleKeyAsync(Key(ConsoleKey.T, 't'), CancellationToken.None);
+        Assert.NotNull(screen.StatusMessage);
+
+        // Navigate — status should clear
+        await screen.HandleKeyAsync(Key(ConsoleKey.DownArrow), CancellationToken.None);
+        Assert.Null(screen.StatusMessage);
     }
 
     [Fact]
@@ -100,9 +233,6 @@ public sealed class SettingsScreenTests
         // First field is Kindle Email (editable), verify it's editable
         Assert.Equal(SettingsScreen.FieldKind.Editable, screen.Fields[screen.SelectedField].Kind);
 
-        // HandleKeyAsync delegates to HandleEnterAsync → StartEdit which touches
-        // Terminal.Gui view references. In headless test we verify the field is
-        // editable and the action field path works (tested separately).
         // Direct state assertion: editing is not active before Enter.
         Assert.False(screen.IsEditing);
     }
@@ -110,15 +240,7 @@ public sealed class SettingsScreenTests
     [Fact]
     public async Task HandleKeyAsync_TestEmailSendsPostRequest()
     {
-        using var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
-        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
-            .Respond(HttpStatusCode.OK, "application/json", "{\"message\":\"Test email sent successfully.\"}");
-        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
-
-        var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
-        await screen.InitializeAsync(CancellationToken.None);
+        var screen = await CreateInitializedScreenWithTestEmail();
 
         var result = await screen.HandleKeyAsync(Key(ConsoleKey.T, 't'), CancellationToken.None);
 
@@ -130,9 +252,10 @@ public sealed class SettingsScreenTests
     [Fact]
     public async Task HandleKeyAsync_TestEmailFailure_ShowsError()
     {
+        var settings = CreateDefaultSettings();
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
             .Respond(HttpStatusCode.UnprocessableEntity, "application/json", "{\"errors\":{\"kindleEmail\":[\"Kindle email must be configured.\"]}}");
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
@@ -149,9 +272,10 @@ public sealed class SettingsScreenTests
     [Fact]
     public async Task HandleKeyAsync_RefreshReloadsSettings()
     {
+        var settings = CreateDefaultSettings();
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
@@ -177,16 +301,14 @@ public sealed class SettingsScreenTests
     [InlineData("deliveryTime", "25:00", false)]
     [InlineData("deliveryTime", "09:30", true)]
     [InlineData("deliveryTime", "nottime", false)]
+    [InlineData("deliveryDay", "monday", true)]
+    [InlineData("deliveryDay", "sunday", true)]
+    [InlineData("deliveryDay", "invalid", false)]
     public void ValidateField_ReturnsExpectedResult(string fieldId, string value, bool shouldBeValid)
     {
         var field = new SettingsScreen.SettingsField("Test", string.Empty, fieldId, SettingsScreen.FieldKind.Editable);
 
-        // Use reflection to access the private static method
-        var method = typeof(SettingsScreen).GetMethod("ValidateField",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        Assert.NotNull(method);
-
-        var result = (string?)method.Invoke(null, [field, value]);
+        var result = SettingsScreen.ValidateField(field, value);
 
         if (shouldBeValid)
             Assert.Null(result);
@@ -212,9 +334,10 @@ public sealed class SettingsScreenTests
     [Fact]
     public async Task HandleKeyAsync_EnterOnActionField_ExecutesAction()
     {
+        var settings = CreateDefaultSettings();
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
             .Respond(HttpStatusCode.OK, "application/json", "{\"message\":\"ok\"}");
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
@@ -222,8 +345,8 @@ public sealed class SettingsScreenTests
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
-        // Navigate to the "Send test email" action (index 5)
-        for (var i = 0; i < 5; i++)
+        // Navigate to the "Send test email" action (index 4 with daily schedule)
+        for (var i = 0; i < 4; i++)
             await screen.HandleKeyAsync(Key(ConsoleKey.DownArrow), CancellationToken.None);
 
         Assert.Equal("test-email", screen.Fields[screen.SelectedField].ActionId);
@@ -236,9 +359,26 @@ public sealed class SettingsScreenTests
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Test helper; MockHttp and HttpClient outlive the helper call")]
     private static async Task<SettingsScreen> CreateInitializedScreen()
     {
+        var settings = CreateDefaultSettings();
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
-            .Respond("application/json", JsonSerializer.Serialize(DefaultSettings, CamelCaseOptions));
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
+        var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+
+        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        await screen.InitializeAsync(CancellationToken.None);
+        return screen;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Test helper")]
+    private static async Task<SettingsScreen> CreateInitializedScreenWithTestEmail()
+    {
+        var settings = CreateDefaultSettings();
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/settings")
+            .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
+        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
+            .Respond(HttpStatusCode.OK, "application/json", "{\"message\":\"Test email sent successfully.\"}");
         var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient));

--- a/src/Relego.Tests/Tui/SettingsScreenTests.cs
+++ b/src/Relego.Tests/Tui/SettingsScreenTests.cs
@@ -67,7 +67,7 @@ public sealed class SettingsScreenTests
             .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
-        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
         Assert.Equal(6, screen.Fields.Count); // 5 editable (includes delivery day) + 1 action
@@ -86,7 +86,7 @@ public sealed class SettingsScreenTests
             .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
-        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
         Assert.Equal("monday", screen.Fields.First(f => f.FieldId == "deliveryDay").Value);
@@ -104,7 +104,7 @@ public sealed class SettingsScreenTests
             .Respond("application/json", JsonSerializer.Serialize(updatedSettings, CamelCaseOptions));
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
-        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
         Assert.Equal(TimeZoneInfo.Local.Id, screen.Settings!.Timezone);
@@ -120,7 +120,7 @@ public sealed class SettingsScreenTests
         // No PUT mock — if a PUT is attempted, it would fail
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
-        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
         Assert.Equal(TimeZoneInfo.Local.Id, screen.Settings!.Timezone);
@@ -365,7 +365,7 @@ public sealed class SettingsScreenTests
             .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
         var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
-        var screen = new SettingsScreen(new SunnyHttpClient(httpClient));
+        var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
         return screen;
     }


### PR DESCRIPTION
Addresses several UX improvements for the settings page in the TUI:

- **Validation error persistence**: Status messages now clear when navigating to another field or starting a new edit
- **Input constraint hints**: Kindle email shows 'Insert a valid email address', delivery time shows 'HH:mm format', highlights count shows 'A number between 1 and 15'
- **Schedule selector**: Replaced free-form text with arrow key selector (daily/weekly only)
- **Day-of-week selector**: When schedule is weekly, a delivery day field appears with arrow selector for days of the week
- **Timezone as readonly inline**: Removed timezone as a separate editable field; now shown inline with delivery time. Auto-detects and saves the user's local timezone on initialization
- **Highlights per recap hint**: Shows constraint text above the text field when editing

Closes #224