### PR TITLE
Add landing page CI pipeline (GitHub Actions + GitHub Pages)

### DIFF
--- a/.github/workflows/landing-page.yml
+++ b/.github/workflows/landing-page.yml
@@ -1,0 +1,83 @@
+name: Landing Page
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/landing/**'
+      - '.github/workflows/landing-page.yml'
+  pull_request:
+    paths:
+      - 'src/landing/**'
+      - '.github/workflows/landing-page.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/landing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: src/landing/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: src/landing/test-results/
+          retention-days: 7
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: src/landing/dist/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/specs/008-landing-page/tasks.md
+++ b/specs/008-landing-page/tasks.md
@@ -153,9 +153,9 @@
 
 **Purpose**: Create a dedicated CI workflow for the landing page that builds, tests, and deploys to GitHub Pages
 
-- [ ] T040 Create `.github/workflows/landing-page.yml` with: trigger on push to `main` with path filter `src/landing/**`; trigger on pull requests with same path filter (build + test only, no deploy); Node.js 24 setup; `cd src/landing && npm ci`; `npm run build`; `npx playwright install --with-deps chromium && npx playwright test`; on push to `main`: upload `dist/` as Pages artifact via `actions/upload-pages-artifact@v4` and deploy via `actions/deploy-pages@v4`; set `permissions: pages: write, id-token: write` for OIDC deployment
-- [ ] T041 [P] Add `.github/workflows/landing-page.yml` concurrency group to prevent overlapping deployments: `concurrency: { group: "pages", cancel-in-progress: false }`
-- [ ] T042 Verify CI workflow syntax: run `cd /workspaces/sunny-sunday && cat .github/workflows/landing-page.yml | head -5` and validate YAML structure is correct
+- [X] T040 Create `.github/workflows/landing-page.yml` with: trigger on push to `main` with path filter `src/landing/**`; trigger on pull requests with same path filter (build + test only, no deploy); Node.js 24 setup; `cd src/landing && npm ci`; `npm run build`; `npx playwright install --with-deps chromium && npx playwright test`; on push to `main`: upload `dist/` as Pages artifact via `actions/upload-pages-artifact@v4` and deploy via `actions/deploy-pages@v4`; set `permissions: pages: write, id-token: write` for OIDC deployment
+- [X] T041 [P] Add `.github/workflows/landing-page.yml` concurrency group to prevent overlapping deployments: `concurrency: { group: "pages", cancel-in-progress: false }`
+- [X] T042 Verify CI workflow syntax: run `cd /workspaces/sunny-sunday && cat .github/workflows/landing-page.yml | head -5` and validate YAML structure is correct
 
 **Checkpoint**: CI pipeline created. Builds, tests, and deploys the landing page to GitHub Pages on push to main.
 


### PR DESCRIPTION
## Summary

Create a dedicated CI workflow for the landing page that builds, tests with Playwright, and deploys to GitHub Pages.

### Changes
- **`.github/workflows/landing-page.yml`**: New workflow with:
  - Push to `main` (path filter `src/landing/**`): build → test → deploy to GitHub Pages
  - Pull requests (same path filter): build → test only
  - Node.js 24 setup with npm cache
  - Playwright E2E tests with Chromium
  - `actions/upload-pages-artifact@v4` + `actions/deploy-pages@v4` for OIDC deployment
  - Concurrency group `pages` with `cancel-in-progress: false`
- **`specs/008-landing-page/tasks.md`**: Mark T040–T042 as completed

### Tasks
- [x] T040 — Create `.github/workflows/landing-page.yml`
- [x] T041 — Add concurrency group
- [x] T042 — Verify YAML syntax

Closes #235