### PR TITLE
Update quit keybinding to confirm before exiting

### DIFF
--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.10.2</Version>
+    <Version>0.10.3</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -618,7 +618,7 @@ public sealed class BookListScreen(
         switch (char.ToLowerInvariant(shortcutKey))
         {
             case 'q':
-                navigate(ScreenResult.Quit());
+                navigate(ScreenResult.ConfirmQuit());
                 return true;
 
             case 's':

--- a/src/Relego.Cli/Tui/HighlightDetailScreen.cs
+++ b/src/Relego.Cli/Tui/HighlightDetailScreen.cs
@@ -386,7 +386,7 @@ public sealed class HighlightDetailScreen : IScreen
             ConsoleKey.Enter => OpenHighlightPreview(),
             ConsoleKey.A => OpenActionMenu(),
             ConsoleKey.R => await RefreshAsync(cancellationToken).ConfigureAwait(false),
-            ConsoleKey.Q => ScreenResult.Quit(),
+            ConsoleKey.Q => ScreenResult.ConfirmQuit(),
             ConsoleKey.Escape => ScreenResult.Pop(),
             ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control) => ScreenResult.Quit(),
             _ => ScreenResult.Stay()
@@ -493,7 +493,7 @@ public sealed class HighlightDetailScreen : IScreen
             ConsoleKey.DownArrow => MoveActionSelection(1),
             ConsoleKey.Escape => CloseActionMenu(),
             ConsoleKey.Enter => await ExecuteSelectedActionAsync(cancellationToken).ConfigureAwait(false),
-            ConsoleKey.Q => ScreenResult.Quit(),
+            ConsoleKey.Q => ScreenResult.ConfirmQuit(),
             ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control) => ScreenResult.Quit(),
             _ => ScreenResult.Stay()
         };
@@ -530,7 +530,7 @@ public sealed class HighlightDetailScreen : IScreen
             case ConsoleKey.NumPad5:
                 return SelectPendingWeight(5);
             case ConsoleKey.Q:
-                return ScreenResult.Quit();
+                return ScreenResult.ConfirmQuit();
             case ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control):
                 return ScreenResult.Quit();
             default:
@@ -545,7 +545,7 @@ public sealed class HighlightDetailScreen : IScreen
             ConsoleKey.Escape => CloseHighlightPreview(),
             ConsoleKey.Enter => CloseHighlightPreview(),
             ConsoleKey.A => CloseHighlightPreview(),
-            ConsoleKey.Q => ScreenResult.Quit(),
+            ConsoleKey.Q => ScreenResult.ConfirmQuit(),
             ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control) => ScreenResult.Quit(),
             _ => ScreenResult.Stay()
         };
@@ -564,7 +564,7 @@ public sealed class HighlightDetailScreen : IScreen
                 await DeleteSelectedHighlightAsync(cancellationToken).ConfigureAwait(false);
                 return ScreenResult.Stay();
             case ConsoleKey.Q:
-                return ScreenResult.Quit();
+                return ScreenResult.ConfirmQuit();
             case ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control):
                 return ScreenResult.Quit();
             default:

--- a/src/Relego.Cli/Tui/IScreen.cs
+++ b/src/Relego.Cli/Tui/IScreen.cs
@@ -22,6 +22,7 @@ public enum ScreenAction
     None,
     Push,
     Pop,
+    ConfirmQuit,
     Quit,
     Reload
 }
@@ -33,6 +34,8 @@ public sealed record ScreenResult(ScreenAction Action, IScreen? Next = null)
     public static ScreenResult Push(IScreen next) => new(ScreenAction.Push, next);
 
     public static ScreenResult Pop() => new(ScreenAction.Pop);
+
+    public static ScreenResult ConfirmQuit() => new(ScreenAction.ConfirmQuit);
 
     public static ScreenResult Quit() => new(ScreenAction.Quit);
 

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -239,7 +239,7 @@ public sealed class SettingsScreen : IScreen
             ConsoleKey.Enter => await HandleEnterAsync(cancellationToken).ConfigureAwait(false),
             ConsoleKey.T => await HandleTestEmailAsync(cancellationToken).ConfigureAwait(false),
             ConsoleKey.R => await HandleRefreshAsync(cancellationToken).ConfigureAwait(false),
-            ConsoleKey.Q => ScreenResult.Quit(),
+            ConsoleKey.Q => ScreenResult.ConfirmQuit(),
             ConsoleKey.Escape => ScreenResult.Pop(),
             ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control) => ScreenResult.Quit(),
             _ => ScreenResult.Stay()

--- a/src/Relego.Cli/Tui/TuiApp.cs
+++ b/src/Relego.Cli/Tui/TuiApp.cs
@@ -1,5 +1,7 @@
 ﻿using Terminal.Gui.App;
 using Terminal.Gui.Drawing;
+using Terminal.Gui.Drivers;
+using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using Relego.Cli.Infrastructure;
@@ -10,6 +12,15 @@ namespace Relego.Cli.Tui;
 public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWorkflow, string serverUrl, string version)
 {
     private const int SplashTopPadding = 1;
+    private const int ExitConfirmationWidth = 56;
+    private const int ExitConfirmationHeight = 5;
+
+    private static readonly IReadOnlyList<(string Key, string Label)> ExitConfirmationHints =
+    [
+        ("Y", "Confirm"),
+        ("N", "Cancel"),
+        ("Esc", "Cancel")
+    ];
 
     private static readonly string[] SplashLines =
     [
@@ -30,6 +41,9 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWo
     private View? _toolbarView;
     private View? _statusBar;
     private Window? _window;
+    private FrameView? _exitConfirmationFrame;
+    private bool _isExitConfirmationOpen;
+    private IReadOnlyList<(string Key, string Label)> _currentHints = [];
 
     public async Task RunAsync(CancellationToken cancellationToken)
     {
@@ -88,6 +102,14 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWo
             };
             _statusBar.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.TextMuted, palette.Background)));
             _window.Add(_statusBar);
+
+            _window.KeyDown += (_, key) =>
+            {
+                if (HandleExitConfirmationKey(key))
+                {
+                    key.Handled = true;
+                }
+            };
 
             ShowCurrentScreen();
 
@@ -245,6 +267,9 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWo
             case ScreenAction.Reload:
                 ShowCurrentScreen();
                 return;
+            case ScreenAction.ConfirmQuit:
+                OpenExitConfirmation();
+                return;
             case ScreenAction.Push when result.Next is not null:
                 _ = Task.Run(async () =>
                 {
@@ -332,7 +357,110 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWo
         _contentFrame.Add(view);
         view.SetFocus();
 
-        UpdateStatusBar(screen.KeyHints);
+        _currentHints = screen.KeyHints;
+        UpdateStatusBar(_isExitConfirmationOpen ? ExitConfirmationHints : _currentHints);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Views are owned by the window hierarchy")]
+    private void EnsureExitConfirmationView()
+    {
+        if (_window is null || _exitConfirmationFrame is not null)
+        {
+            return;
+        }
+
+        var palette = TuiTheme.Palette;
+        _exitConfirmationFrame = new FrameView
+        {
+            X = Pos.Center() - (ExitConfirmationWidth / 2),
+            Y = Pos.Center() - (ExitConfirmationHeight / 2),
+            Width = ExitConfirmationWidth,
+            Height = ExitConfirmationHeight,
+            Title = "Confirm Exit",
+            CanFocus = true,
+            Visible = false
+        };
+        _exitConfirmationFrame.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.BorderFocus, palette.Background)));
+
+        var message = new Label
+        {
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill(2),
+            Height = 1,
+            Text = "Exit Relego? Press Y to confirm or N/Esc to cancel.",
+            CanFocus = false
+        };
+        message.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.Text, palette.Background)));
+
+        _exitConfirmationFrame.Add(message);
+        _window.Add(_exitConfirmationFrame);
+    }
+
+    private void OpenExitConfirmation()
+    {
+        if (_isExitConfirmationOpen)
+        {
+            return;
+        }
+
+        EnsureExitConfirmationView();
+        if (_exitConfirmationFrame is null)
+        {
+            return;
+        }
+
+        _isExitConfirmationOpen = true;
+        _exitConfirmationFrame.Visible = true;
+        _exitConfirmationFrame.SetFocus();
+        UpdateStatusBar(ExitConfirmationHints);
+    }
+
+    private void CloseExitConfirmation()
+    {
+        if (!_isExitConfirmationOpen)
+        {
+            return;
+        }
+
+        _isExitConfirmationOpen = false;
+        if (_exitConfirmationFrame is not null)
+        {
+            _exitConfirmationFrame.Visible = false;
+        }
+
+        if (_contentFrame?.SubViews.FirstOrDefault() is { } currentView)
+        {
+            currentView.SetFocus();
+        }
+
+        UpdateStatusBar(_currentHints);
+    }
+
+    private bool HandleExitConfirmationKey(Key key)
+    {
+        if (!_isExitConfirmationOpen)
+        {
+            return false;
+        }
+
+        var rune = key.AsRune.Value;
+        var confirm = rune is 'y' or 'Y' || key.KeyCode == KeyCode.Enter;
+        var cancel = rune is 'n' or 'N' || key.KeyCode == KeyCode.Esc;
+
+        if (confirm)
+        {
+            _app?.RequestStop();
+            return true;
+        }
+
+        if (cancel)
+        {
+            CloseExitConfirmation();
+            return true;
+        }
+
+        return true;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Labels are owned by the footer view")]

--- a/src/Relego.Tests/Tui/BookListScreenTests.cs
+++ b/src/Relego.Tests/Tui/BookListScreenTests.cs
@@ -87,7 +87,7 @@ public sealed class BookListScreenTests : IDisposable
     }
 
     [Fact]
-    public async Task TryHandleShortcutKey_Q_RequestsQuit()
+    public async Task TryHandleShortcutKey_Q_RequestsQuitConfirmation()
     {
         var screen = await CreateScreenAsync();
         ScreenResult? result = null;
@@ -96,7 +96,7 @@ public sealed class BookListScreenTests : IDisposable
 
         Assert.True(handled);
         Assert.NotNull(result);
-        Assert.Equal(ScreenAction.Quit, result!.Action);
+        Assert.Equal(ScreenAction.ConfirmQuit, result!.Action);
     }
 
     [Fact]

--- a/src/Relego.Tests/Tui/HighlightDetailScreenTests.cs
+++ b/src/Relego.Tests/Tui/HighlightDetailScreenTests.cs
@@ -154,13 +154,25 @@ public sealed class HighlightDetailScreenTests
     }
 
     [Fact]
-    public async Task HandleKeyAsync_QQuitsScreen()
+    public async Task HandleKeyAsync_QRequestsQuitConfirmation()
     {
         using var mockHttp = new MockHttpMessageHandler();
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
         var screen = CreateScreen(new RelegoHttpClient(httpClient));
 
         var result = await screen.HandleKeyAsync(Key(ConsoleKey.Q, 'q'), CancellationToken.None);
+
+        Assert.Equal(ScreenAction.ConfirmQuit, result.Action);
+    }
+
+    [Fact]
+    public async Task HandleKeyAsync_CtrlCQuitsScreenImmediately()
+    {
+        using var mockHttp = new MockHttpMessageHandler();
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+        var screen = CreateScreen(new RelegoHttpClient(httpClient));
+
+        var result = await screen.HandleKeyAsync(new ConsoleKeyInfo('c', ConsoleKey.C, false, false, true), CancellationToken.None);
 
         Assert.Equal(ScreenAction.Quit, result.Action);
     }

--- a/src/Relego.Tests/Tui/SettingsScreenTests.cs
+++ b/src/Relego.Tests/Tui/SettingsScreenTests.cs
@@ -216,11 +216,21 @@ public sealed class SettingsScreenTests
     }
 
     [Fact]
-    public async Task HandleKeyAsync_QReturnsQuit()
+    public async Task HandleKeyAsync_QReturnsConfirmQuit()
     {
         var screen = await CreateInitializedScreen();
 
         var result = await screen.HandleKeyAsync(Key(ConsoleKey.Q, 'q'), CancellationToken.None);
+
+        Assert.Equal(ScreenAction.ConfirmQuit, result.Action);
+    }
+
+    [Fact]
+    public async Task HandleKeyAsync_CtrlCReturnsQuit()
+    {
+        var screen = await CreateInitializedScreen();
+
+        var result = await screen.HandleKeyAsync(new ConsoleKeyInfo('c', ConsoleKey.C, false, false, true), CancellationToken.None);
 
         Assert.Equal(ScreenAction.Quit, result.Action);
     }


### PR DESCRIPTION
Change the quit keybinding to require confirmation before exiting the application. Update related tests to reflect this new behavior. Increment version number to 0.10.3.

Close #277