### PR TITLE
TUI + CLI + Server: add end-to-end book rename capability

### DIFF
--- a/src/Relego.Cli/Commands/RenameBookCommand.cs
+++ b/src/Relego.Cli/Commands/RenameBookCommand.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Relego.Cli.Infrastructure;
+using Relego.Core.Contracts;
+
+namespace Relego.Cli.Commands;
+
+/// <summary>
+/// Renames a book stored in the server.
+/// Usage: relego rename-book &lt;id&gt; &lt;new-title&gt;
+/// </summary>
+public sealed class RenameBookCommand(RelegoHttpClient client, ILogger<RenameBookCommand> logger)
+    : ServerCommand<RenameBookCommand.Settings>
+{
+    protected override ILogger Logger => logger;
+
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<id>")]
+        [Description("ID of the book to rename.")]
+        public int Id { get; set; }
+
+        [CommandArgument(1, "<title>")]
+        [Description("New title for the book.")]
+        public string Title { get; set; } = string.Empty;
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var newTitle = settings.Title.Trim();
+
+        if (string.IsNullOrWhiteSpace(newTitle))
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] Title must not be empty.");
+            return 1;
+        }
+
+        logger.LogDebug("Renaming book {Id} to {Title}", settings.Id, newTitle);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.RenameBookAsync(settings.Id, new RenameBookRequest { Title = newTitle }, cancellation);
+        }
+        catch (HttpRequestException ex)
+        {
+            return HandleServerError(ex);
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Book with ID [yellow]{settings.Id}[/] not found.");
+            return 1;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] A book titled [yellow]{Markup.Escape(newTitle)}[/] by the same author already exists.");
+            return 1;
+        }
+
+        response.EnsureSuccessStatusCode();
+        AnsiConsole.MarkupLine($"[green]✓[/] Book [bold]{settings.Id}[/] renamed to [bold]{Markup.Escape(newTitle)}[/].");
+        return 0;
+    }
+}

--- a/src/Relego.Cli/Infrastructure/RelegoHttpClient.cs
+++ b/src/Relego.Cli/Infrastructure/RelegoHttpClient.cs
@@ -76,6 +76,9 @@ public sealed class RelegoHttpClient(HttpClient http)
     public Task<HttpResponseMessage> DeleteHighlightAsync(int id, CancellationToken ct = default)
         => http.DeleteAsync($"/highlights/{id}", ct);
 
+    public Task<HttpResponseMessage> RenameBookAsync(int bookId, RenameBookRequest request, CancellationToken ct = default)
+        => http.PutAsJsonAsync($"/books/{bookId}/title", request, RelegoJsonContext.Default.RenameBookRequest, ct);
+
     public async Task<List<WeightedHighlightDto>> GetWeightsAsync(CancellationToken ct = default)
         => (await http.GetFromJsonAsync("/highlights/weights", RelegoJsonContext.Default.ListWeightedHighlightDto, ct).ConfigureAwait(false))!;
 }

--- a/src/Relego.Cli/Infrastructure/RelegoJsonContext.cs
+++ b/src/Relego.Cli/Infrastructure/RelegoJsonContext.cs
@@ -18,4 +18,5 @@ namespace Relego.Cli.Infrastructure;
 [JsonSerializable(typeof(HighlightItemDto))]
 [JsonSerializable(typeof(SetWeightRequest))]
 [JsonSerializable(typeof(List<WeightedHighlightDto>))]
+[JsonSerializable(typeof(RenameBookRequest))]
 internal partial class RelegoJsonContext : JsonSerializerContext;

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -107,6 +107,9 @@ app.Configure(config =>
         wgt.AddCommand<WeightListCommand>("list")
             .WithDescription("List all highlights with custom weights.");
     });
+
+    config.AddCommand<RenameBookCommand>("rename-book")
+        .WithDescription("Rename a book by its ID.");
 });
 
 return await app.RunAsync(args);

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.10.4</Version>
+    <Version>0.11.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -30,6 +30,7 @@ public sealed class BookListScreen(
     private const string SearchPlaceholderFocused = "Press Esc to return to the list";
     private const string SyncPlaceholderDetected = "Press Enter to sync or edit the path";
     private const string SyncPlaceholderManual = "Enter the path to My Clippings.txt";
+    private const string RenamePlaceholder = "Enter new title, press Enter to confirm or Esc to cancel";
 
     private readonly RelegoHttpClient _client = client;
     private readonly ClippingsSyncWorkflow _syncWorkflow = syncWorkflow;
@@ -41,6 +42,7 @@ public sealed class BookListScreen(
     private bool _isSearchActive;
     private string _searchQuery = string.Empty;
     private string _syncPathInput = string.Empty;
+    private string _renameInput = string.Empty;
     private string? _detectedSyncPath;
     private bool _hasDetectedSyncPath;
     private FrameView? _searchFrame;
@@ -67,6 +69,8 @@ public sealed class BookListScreen(
 
     public bool IsSyncPromptActive => _toolbarMode == ToolbarMode.SyncPath;
 
+    public bool IsRenamePromptActive => _toolbarMode == ToolbarMode.Rename;
+
     public string SearchQuery => _searchQuery;
 
     public string SyncPathInput => _syncPathInput;
@@ -82,6 +86,7 @@ public sealed class BookListScreen(
         ("↑↓", "Navigate"),
         ("Enter", "View"),
         ("I", "Import"),
+        ("N", "Rename"),
         ("S", "Settings"),
         ("/", "Search"),
         ("R", "Refresh"),
@@ -93,7 +98,8 @@ public sealed class BookListScreen(
     private enum ToolbarMode
     {
         Search,
-        SyncPath
+        SyncPath,
+        Rename
     }
 
     public int ToolbarHeight => 4;
@@ -492,6 +498,96 @@ public sealed class BookListScreen(
         UpdateToolbarChrome();
     }
 
+    public void BeginRenamePrompt(BookViewModel book)
+    {
+        _toolbarMode = ToolbarMode.Rename;
+        _isSearchActive = false;
+        _renameInput = book.Title;
+
+        if (_searchField is not null)
+        {
+            _searchField.Text = _renameInput;
+            _searchField.SetFocus();
+            _searchField.MoveEnd();
+        }
+
+        UpdateToolbarChrome();
+    }
+
+    public void CancelRenamePrompt()
+    {
+        _toolbarMode = ToolbarMode.Search;
+        _renameInput = string.Empty;
+
+        if (_searchField is null)
+        {
+            return;
+        }
+
+        _searchField.Text = _searchQuery;
+
+        if (_listView is not null)
+            _listView.SetFocus();
+        else
+            _searchField.SetFocus();
+
+        UpdateToolbarChrome();
+    }
+
+    public async Task SubmitRenameAsync(string? newTitle = null, CancellationToken cancellationToken = default)
+    {
+        var resolvedTitle = (newTitle ?? _renameInput).Trim();
+
+        if (string.IsNullOrWhiteSpace(resolvedTitle))
+        {
+            SetFeedback("Enter a title or press Esc to cancel.", isError: true);
+            return;
+        }
+
+        var book = GetSelectedBook();
+        if (book is null)
+        {
+            CancelRenamePrompt();
+            return;
+        }
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _client.RenameBookAsync(book.BookId, new Core.Contracts.RenameBookRequest { Title = resolvedTitle }, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException)
+        {
+            SetFeedback("Cannot reach server.", isError: true);
+            CancelRenamePrompt();
+            return;
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            SetFeedback($"Book {book.BookId} not found.", isError: true);
+            CancelRenamePrompt();
+            return;
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            SetFeedback($"A book titled \"{resolvedTitle}\" by the same author already exists.", isError: true);
+            CancelRenamePrompt();
+            return;
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        CancelRenamePrompt();
+        SetFeedback($"Book renamed to \"{resolvedTitle}\".", isError: false);
+
+        // Reload so the list reflects the new title
+        await InitializeAsync(cancellationToken).ConfigureAwait(false);
+        _refreshVisibleBooks?.Invoke();
+    }
+
     public async Task<ClippingsSyncOutcome> SubmitSyncAsync(string? filePath = null, CancellationToken cancellationToken = default)
     {
         var resolvedPath = filePath ?? _syncPathInput;
@@ -627,6 +723,12 @@ public sealed class BookListScreen(
 
             case 'i':
                 focusSyncField?.Invoke();
+                return true;
+
+            case 'n':
+                var bookToRename = GetSelectedBook();
+                if (bookToRename is not null)
+                    BeginRenamePrompt(bookToRename);
                 return true;
 
             case 'r':
@@ -860,6 +962,10 @@ public sealed class BookListScreen(
         {
             _syncPathInput = _searchField.Text ?? string.Empty;
         }
+        else if (_toolbarMode == ToolbarMode.Rename)
+        {
+            _renameInput = _searchField.Text ?? string.Empty;
+        }
         else
         {
             _searchQuery = _searchField.Text ?? string.Empty;
@@ -883,6 +989,17 @@ public sealed class BookListScreen(
             return;
         }
 
+        if (_toolbarMode == ToolbarMode.Rename)
+        {
+            if (key.KeyCode == KeyCode.Esc)
+            {
+                CancelRenamePrompt();
+                key.Handled = true;
+            }
+
+            return;
+        }
+
         if (key.KeyCode is KeyCode.Esc or KeyCode.CursorDown)
         {
             LeaveSearchInput(_refreshVisibleBooks);
@@ -893,6 +1010,12 @@ public sealed class BookListScreen(
 
     private async Task HandleToolbarSubmitAsync()
     {
+        if (_toolbarMode == ToolbarMode.Rename)
+        {
+            await SubmitRenameAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            return;
+        }
+
         if (_toolbarMode != ToolbarMode.SyncPath)
         {
             return;
@@ -901,7 +1024,12 @@ public sealed class BookListScreen(
         await SubmitSyncAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
     }
 
-    private string GetToolbarText() => _toolbarMode == ToolbarMode.SyncPath ? _syncPathInput : _searchQuery;
+    private string GetToolbarText() => _toolbarMode switch
+    {
+        ToolbarMode.SyncPath => _syncPathInput,
+        ToolbarMode.Rename => _renameInput,
+        _ => _searchQuery
+    };
 
     private string GetToolbarPlaceholder(bool hasFocus)
     {
@@ -911,6 +1039,9 @@ public sealed class BookListScreen(
                 ? SyncPlaceholderDetected
                 : SyncPlaceholderManual;
         }
+
+        if (_toolbarMode == ToolbarMode.Rename)
+            return RenamePlaceholder;
 
         return hasFocus ? SearchPlaceholderFocused : SearchPlaceholderIdle;
     }
@@ -929,7 +1060,12 @@ public sealed class BookListScreen(
             return;
         }
 
-        _searchFrame.Title = _toolbarMode == ToolbarMode.SyncPath ? " Import " : string.Empty;
+        _searchFrame.Title = _toolbarMode switch
+        {
+            ToolbarMode.SyncPath => " Import ",
+            ToolbarMode.Rename => " Rename ",
+            _ => string.Empty
+        };
         _searchPlaceholder.Visible = string.IsNullOrEmpty(_searchField.Text);
         _searchPlaceholder.Text = GetToolbarPlaceholder(_searchField.HasFocus);
         _searchFrame.SetScheme(CreateSearchFrameScheme(_searchField.HasFocus));

--- a/src/Relego.Core/Contracts/RenameBookRequest.cs
+++ b/src/Relego.Core/Contracts/RenameBookRequest.cs
@@ -1,0 +1,12 @@
+namespace Relego.Core.Contracts;
+
+/// <summary>
+/// Request body for renaming a book.
+/// </summary>
+public sealed record RenameBookRequest
+{
+    /// <summary>
+    /// New title for the book. Must be non-empty.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+}

--- a/src/Relego.Core/Relego.Core.csproj
+++ b/src/Relego.Core/Relego.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Relego.Server/Data/BookRepository.cs
+++ b/src/Relego.Server/Data/BookRepository.cs
@@ -1,0 +1,43 @@
+using System.Data;
+using Dapper;
+
+namespace Relego.Server.Data;
+
+public sealed class BookRepository(IDbConnection connection)
+{
+    /// <summary>
+    /// Renames a book title.
+    /// Returns <see langword="true"/> when the book was found and updated,
+    /// <see langword="false"/> when no book with <paramref name="bookId"/> belongs to <paramref name="userId"/>,
+    /// and <see langword="null"/> when the new title already exists for the same author and user.
+    /// </summary>
+    public async Task<bool?> RenameAsync(int userId, int bookId, string newTitle)
+    {
+        // Verify the book exists and belongs to the user
+        var authorId = await connection.QuerySingleOrDefaultAsync<int?>(
+            "SELECT author_id FROM books WHERE id = @BookId AND user_id = @UserId",
+            new { BookId = bookId, UserId = userId }).ConfigureAwait(false);
+
+        if (authorId is null)
+            return false;
+
+        // Check for a duplicate title under the same author
+        var duplicate = await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT COUNT(*) FROM books
+            WHERE user_id = @UserId AND author_id = @AuthorId AND title = @Title AND id != @BookId
+            """,
+            new { UserId = userId, AuthorId = authorId.Value, Title = newTitle, BookId = bookId })
+            .ConfigureAwait(false);
+
+        if (duplicate > 0)
+            return null;
+
+        await connection.ExecuteAsync(
+            "UPDATE books SET title = @Title WHERE id = @BookId AND user_id = @UserId",
+            new { Title = newTitle, BookId = bookId, UserId = userId })
+            .ConfigureAwait(false);
+
+        return true;
+    }
+}

--- a/src/Relego.Server/Endpoints/BookEndpoints.cs
+++ b/src/Relego.Server/Endpoints/BookEndpoints.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using Relego.Core.Contracts;
+using Relego.Server.Data;
+
+namespace Relego.Server.Endpoints;
+
+public static class BookEndpoints
+{
+    public static WebApplication MapBookEndpoints(this WebApplication app)
+    {
+        app.MapPut("/books/{id:int}/title", async (
+            int id,
+            [FromBody] RenameBookRequest request,
+            [FromServices] UserRepository userRepo,
+            [FromServices] BookRepository bookRepo) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Title))
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "title", ["title must not be empty."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var userId = await userRepo.EnsureUserAsync();
+            var result = await bookRepo.RenameAsync(userId, id, request.Title.Trim());
+
+            return result switch
+            {
+                true => Results.NoContent(),
+                false => Results.Problem(detail: $"Book {id} not found.", statusCode: StatusCodes.Status404NotFound),
+                null => Results.Problem(detail: $"A book titled \"{request.Title.Trim()}\" by the same author already exists.", statusCode: StatusCodes.Status409Conflict),
+            };
+        })
+        .WithSummary("Rename a book.")
+        .WithDescription("Updates the title of a book. Returns 409 Conflict when a book by the same author already has the requested title.")
+        .Produces(StatusCodes.Status204NoContent)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status409Conflict);
+
+        return app;
+    }
+}

--- a/src/Relego.Server/Program.cs
+++ b/src/Relego.Server/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddScoped<ExclusionRepository>();
 builder.Services.AddScoped<WeightRepository>();
 builder.Services.AddScoped<RecapRepository>();
 builder.Services.AddScoped<HighlightRepository>();
+builder.Services.AddScoped<BookRepository>();
 
 builder.Services.AddQuartz(q =>
 {
@@ -118,6 +119,7 @@ app.MapStatusEndpoints();
 app.MapExclusionEndpoints();
 app.MapWeightEndpoints();
 app.MapHighlightEndpoints();
+app.MapBookEndpoints();
 
 var schemaBootstrap = new SchemaBootstrap();
 await schemaBootstrap.ApplyAsync(dbPath);

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Tests/Api/BookEndpointTests.cs
+++ b/src/Relego.Tests/Api/BookEndpointTests.cs
@@ -1,0 +1,187 @@
+using System.Data;
+using System.Net;
+using System.Net.Http.Json;
+using Dapper;
+using Microsoft.Extensions.DependencyInjection;
+using Relego.Core.Contracts;
+
+namespace Relego.Tests.Api;
+
+public sealed class BookEndpointTests : IDisposable
+{
+    private readonly RelegoTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public BookEndpointTests()
+    {
+        _factory = new RelegoTestApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task PutBookTitle_ValidTitle_Returns204AndPersists()
+    {
+        await SeedLibraryAsync();
+        var bookId = await GetBookIdAsync("Alpha");
+
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{bookId}/title",
+            new RenameBookRequest { Title = "Alpha Renamed" });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var storedTitle = await GetBookTitleAsync(bookId);
+        Assert.Equal("Alpha Renamed", storedTitle);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_TitleWithWhitespace_TrimsAndPersists()
+    {
+        await SeedLibraryAsync();
+        var bookId = await GetBookIdAsync("Alpha");
+
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{bookId}/title",
+            new RenameBookRequest { Title = "  Trimmed Title  " });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var storedTitle = await GetBookTitleAsync(bookId);
+        Assert.Equal("Trimmed Title", storedTitle);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_EmptyTitle_Returns422()
+    {
+        await SeedLibraryAsync();
+        var bookId = await GetBookIdAsync("Alpha");
+
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{bookId}/title",
+            new RenameBookRequest { Title = "" });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("title", body);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_WhitespaceOnlyTitle_Returns422()
+    {
+        await SeedLibraryAsync();
+        var bookId = await GetBookIdAsync("Alpha");
+
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{bookId}/title",
+            new RenameBookRequest { Title = "   " });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_MissingBook_Returns404()
+    {
+        var response = await _client.PutAsJsonAsync(
+            "/books/999/title",
+            new RenameBookRequest { Title = "Anything" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Book 999 not found.", body);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_DuplicateTitleSameAuthor_Returns409()
+    {
+        await SeedLibraryAsync();
+        var bookId = await GetBookIdAsync("Alpha");
+
+        // "Alpha 2" is by the same "Author Alpha"
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{bookId}/title",
+            new RenameBookRequest { Title = "Alpha 2" });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_SameTitleDifferentAuthor_Returns204()
+    {
+        await SeedLibraryAsync();
+        var alphaBookId = await GetBookIdAsync("Alpha");
+
+        // "Beta" is by "Author Beta" — using its title on an "Author Alpha" book is fine
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{alphaBookId}/title",
+            new RenameBookRequest { Title = "Beta" });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutBookTitle_SameTitle_Returns204()
+    {
+        await SeedLibraryAsync();
+        var bookId = await GetBookIdAsync("Alpha");
+
+        var response = await _client.PutAsJsonAsync(
+            $"/books/{bookId}/title",
+            new RenameBookRequest { Title = "Alpha" });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private async Task SeedLibraryAsync()
+    {
+        var response = await _client.PostAsJsonAsync("/sync", new SyncRequest
+        {
+            Books =
+            [
+                new SyncBookRequest
+                {
+                    Title = "Alpha",
+                    Author = "Author Alpha",
+                    Highlights = [new SyncHighlightRequest { Text = "Alpha highlight 1" }]
+                },
+                new SyncBookRequest
+                {
+                    Title = "Alpha 2",
+                    Author = "Author Alpha",
+                    Highlights = [new SyncHighlightRequest { Text = "Alpha 2 highlight 1" }]
+                },
+                new SyncBookRequest
+                {
+                    Title = "Beta",
+                    Author = "Author Beta",
+                    Highlights = [new SyncHighlightRequest { Text = "Beta highlight 1" }]
+                },
+            ]
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<int> GetBookIdAsync(string title)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var connection = scope.ServiceProvider.GetRequiredService<IDbConnection>();
+        return await connection.QuerySingleAsync<int>(
+            "SELECT id FROM books WHERE title = @Title",
+            new { Title = title });
+    }
+
+    private async Task<string> GetBookTitleAsync(int bookId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var connection = scope.ServiceProvider.GetRequiredService<IDbConnection>();
+        return await connection.QuerySingleAsync<string>(
+            "SELECT title FROM books WHERE id = @Id",
+            new { Id = bookId });
+    }
+}


### PR DESCRIPTION
## Summary

### Server (`0.13.0 → 0.14.0`)
- New `PUT /books/{id}/title` endpoint accepting `{ "title": "..." }`
- Returns `204 No Content` on success, `422` for empty title, `404` if book not found, `409 Conflict` if the new title already exists for the same author
- New `BookRepository.RenameAsync` handles the DB update with duplicate detection
- `BookRepository` registered in DI and endpoint registered via `MapBookEndpoints()`

### CLI (`0.10.4 → 0.11.0`)
- New `relego rename-book <id> <title>` command (registered in `app.Configure`)
- `RelegoHttpClient.RenameBookAsync` typed method using source-generated JSON serialization
- `RenameBookRequest` added to `RelegoJsonContext`

### TUI (BookListScreen)
- New `ToolbarMode.Rename` toggled by pressing **N** on any selected book
- Toolbar frame title changes to " Rename ", pre-populated with the current book title
- **Enter** submits → calls API, refreshes list, shows feedback
- **Esc** cancels → restores search mode
- **N** hint added to the key bar

### Tests
- 8 new `BookEndpointTests` covering: happy path, trim, empty title (422), whitespace-only (422), missing book (404), duplicate title same author (409), different author OK (204), same title idempotent (204)
- All 273 existing tests continue to pass

Closes #274