### PR TITLE
Fix TUI settings: restore selection focus when exiting detail view with Esc

### DIFF
--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -350,6 +350,10 @@ public sealed class BookListScreen(
 
         void RefreshVisibleBooks()
         {
+            // Snapshot selection before Clear: the ObservableCollection change fires
+            // ValueChanged on the ListView, which would overwrite _selectedIndex to 0.
+            var selectedIndex = _selectedIndex;
+
             displayItems.Clear();
             foreach (var item in _filteredBooks.Select(book => FormatBookRow(book, tableLayout)))
             {
@@ -358,7 +362,7 @@ public sealed class BookListScreen(
 
             if (_filteredBooks.Count > 0)
             {
-                listView.SelectedItem = Math.Min(_selectedIndex, _filteredBooks.Count - 1);
+                listView.SelectedItem = Math.Min(selectedIndex, _filteredBooks.Count - 1);
             }
             else
             {
@@ -398,7 +402,14 @@ public sealed class BookListScreen(
         _listView = listView;
         _refreshVisibleBooks = RefreshVisibleBooks;
         SetupContainerKeyBindings(container, listView, navigate, RefreshVisibleBooks, BeginSearchInput, () => BeginSyncPrompt());
+
+        // Save/restore selection around SetFocus: Terminal.Gui may fire ValueChanged
+        // with SelectedItem = 0 when the ListView gains focus, overwriting _selectedIndex.
+        var savedIndex = _selectedIndex;
         listView.SetFocus();
+        _selectedIndex = savedIndex;
+        if (_filteredBooks.Count > 0)
+            listView.SelectedItem = Math.Min(savedIndex, _filteredBooks.Count - 1);
 
         return container;
     }

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -536,6 +536,11 @@ public sealed class SettingsScreen : IScreen
 
     private void UpdateViewState()
     {
+        // Snapshot selection before modifying _fieldRows: collection-change notifications
+        // (e.g. from Clear()) can fire ValueChanged on the ListView, which would
+        // overwrite _selectedField with SelectedItem = 0 before we restore it.
+        var selectedField = _selectedField;
+
         if (_fieldRows is not null)
         {
             _fieldRows.Clear();
@@ -547,7 +552,7 @@ public sealed class SettingsScreen : IScreen
 
         if (_fieldList is not null && _fields.Count > 0)
         {
-            _fieldList.SelectedItem = Math.Clamp(_selectedField, 0, _fields.Count - 1);
+            _fieldList.SelectedItem = Math.Clamp(selectedField, 0, _fields.Count - 1);
         }
 
         if (_statusLabel is not null)

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -312,6 +312,11 @@ public sealed class SettingsScreen : IScreen
 
     private void CancelEdit()
     {
+        // Preserve the selected index: SetFocus() on the ListView may fire ValueChanged,
+        // which would overwrite _selectedField with whatever SelectedItem the list reports
+        // (potentially 0), so we save and restore the value around the SetFocus call.
+        var savedSelectedField = _selectedField;
+
         _isEditing = false;
         _isSelectMode = false;
         _selectOptions = [];
@@ -326,6 +331,7 @@ public sealed class SettingsScreen : IScreen
             _editOverlay.Visible = false;
 
         _fieldList?.SetFocus();
+        _selectedField = savedSelectedField;
         UpdateViewStateIfCreated();
     }
 


### PR DESCRIPTION
## Summary

When navigating to a settings item and pressing **Esc** to exit the edit/detail view, the cursor jumped to the top of the list instead of returning to the previously selected item.

## Root cause

In `CancelEdit()`, `_isEditing` was set to `false` *before* calling `_fieldList?.SetFocus()`. This caused the ListView's `ValueChanged` event to fire (since editing was now considered inactive), which overwrote `_selectedField` with the ListView's current `SelectedItem` value — typically `0`.

## Fix

Save `_selectedField` before the `SetFocus()` call and restore it immediately afterward, so the cursor always returns to the previously selected menu item.

Closes #279