### PR TITLE
TUI highlights table: reorder columns and improve excluded-state styling

### DIFF
--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/HighlightDetailScreen.cs
+++ b/src/Relego.Cli/Tui/HighlightDetailScreen.cs
@@ -40,7 +40,9 @@ public sealed class HighlightDetailScreen : IScreen
     private ShortcutListView? _highlightList;
     private Label? _titleLabel;
     private Label? _authorLabel;
-    private Label? _summaryLabel;
+    private Label? _summaryCountLabel;
+    private Label? _summaryBookLabel;
+    private Label? _summaryAuthorLabel;
     private Label? _headerLabel;
     private Label? _headerRuleLabel;
     private Label? _statusLabel;
@@ -153,11 +155,31 @@ public sealed class HighlightDetailScreen : IScreen
         _authorLabel.SetScheme(new Terminal.Gui.Drawing.Scheme(new Terminal.Gui.Drawing.Attribute(
             TuiTheme.Palette.TextMuted, TuiTheme.Palette.Background)));
 
-        _summaryLabel = new Label
+        _summaryCountLabel = new Label
         {
             X = TableHorizontalPadding,
             Y = 2,
-            Width = Dim.Fill(TableHorizontalPadding * 2),
+            Width = Dim.Auto(),
+            Height = 1,
+            CanFocus = false
+        };
+        _summaryCountLabel.SetScheme(new Terminal.Gui.Drawing.Scheme(new Terminal.Gui.Drawing.Attribute(
+            TuiTheme.Palette.TextMuted, TuiTheme.Palette.Background)));
+
+        _summaryBookLabel = new Label
+        {
+            X = Pos.Right(_summaryCountLabel),
+            Y = 2,
+            Width = Dim.Auto(),
+            Height = 1,
+            CanFocus = false
+        };
+
+        _summaryAuthorLabel = new Label
+        {
+            X = Pos.Right(_summaryBookLabel),
+            Y = 2,
+            Width = Dim.Auto(),
             Height = 1,
             CanFocus = false
         };
@@ -332,7 +354,9 @@ public sealed class HighlightDetailScreen : IScreen
         container.Add(
             _titleLabel,
             _authorLabel,
-            _summaryLabel,
+            _summaryCountLabel,
+            _summaryBookLabel,
+            _summaryAuthorLabel,
             _headerLabel,
             _headerRuleLabel,
             _highlightList,
@@ -893,9 +917,27 @@ public sealed class HighlightDetailScreen : IScreen
                 _authorLabel.Text = $"by {_authorName}";
             }
 
-            if (_summaryLabel is not null)
+            var highlightCount = _highlights.Count == 1 ? "1 highlight" : $"{_highlights.Count.ToString(CultureInfo.InvariantCulture)} highlights";
+
+            if (_summaryCountLabel is not null)
             {
-                _summaryLabel.Text = BuildSummaryText();
+                _summaryCountLabel.Text = highlightCount;
+            }
+
+            if (_summaryBookLabel is not null)
+            {
+                _summaryBookLabel.Text = $"  |  Book: {(_isBookExcluded ? "excluded" : "included")}";
+                _summaryBookLabel.SetScheme(new Terminal.Gui.Drawing.Scheme(new Terminal.Gui.Drawing.Attribute(
+                    _isBookExcluded ? TuiTheme.Palette.Error : TuiTheme.Palette.TextMuted,
+                    TuiTheme.Palette.Background)));
+            }
+
+            if (_summaryAuthorLabel is not null)
+            {
+                _summaryAuthorLabel.Text = $"  |  Author: {(_isAuthorExcluded ? "excluded" : "included")}";
+                _summaryAuthorLabel.SetScheme(new Terminal.Gui.Drawing.Scheme(new Terminal.Gui.Drawing.Attribute(
+                    _isAuthorExcluded ? TuiTheme.Palette.Error : TuiTheme.Palette.TextMuted,
+                    TuiTheme.Palette.Background)));
             }
 
             if (_headerLabel is not null)
@@ -1036,14 +1078,6 @@ public sealed class HighlightDetailScreen : IScreen
         }
     }
 
-    private string BuildSummaryText()
-    {
-        var highlightCount = _highlights.Count == 1 ? "1 highlight" : $"{_highlights.Count.ToString(CultureInfo.InvariantCulture)} highlights";
-        var bookState = _isBookExcluded ? "excluded" : "included";
-        var authorState = _isAuthorExcluded ? "excluded" : "included";
-        return $"{highlightCount}  |  Book: {bookState}  |  Author: {authorState}";
-    }
-
     private IEnumerable<string> BuildHighlightRows()
     {
         if (_highlights.Count == 0)
@@ -1060,11 +1094,16 @@ public sealed class HighlightDetailScreen : IScreen
 
     private string FormatHighlightRow(HighlightViewModel highlight)
     {
+        var excluded = IsEffectivelyExcluded(highlight);
         var text = FitCell(highlight.Text.ReplaceLineEndings(" "), _tableLayout.HighlightWidth);
+        var displayText = excluded ? ApplyStrikethrough(text) : text;
         var weight = (highlight.Weight ?? DefaultWeight).ToString(CultureInfo.InvariantCulture).PadLeft(_tableLayout.WeightWidth);
-        var state = IsEffectivelyExcluded(highlight) ? "Excluded" : "Included";
-        return $"{text}  {weight}  {FitCell(state, _tableLayout.StatusWidth)}";
+        var statusText = excluded ? FitCell("Excluded", _tableLayout.StatusWidth) : string.Empty;
+        return $"{weight}  {displayText}  {statusText}".TrimEnd();
     }
+
+    private static string ApplyStrikethrough(string text)
+        => string.Concat(text.Select(c => $"{c}\u0336"));
 
     private string BuildWeightScale()
         => string.Join("  ", Enumerable.Range(MinimumWeight, MaximumWeight)
@@ -1126,7 +1165,7 @@ public sealed class HighlightDetailScreen : IScreen
     }
 
     private static string FormatHeader(TableLayout tableLayout)
-        => $"{FitCell("HIGHLIGHT", tableLayout.HighlightWidth)}  {FitCell("WEIGHT", tableLayout.WeightWidth)}  {FitCell("STATUS", tableLayout.StatusWidth)}";
+        => $"{FitCell("WEIGHT", tableLayout.WeightWidth)}  {FitCell("HIGHLIGHT", tableLayout.HighlightWidth)}  {FitCell("STATUS", tableLayout.StatusWidth)}";
 
     private void ApplyNavigation(ScreenResult result)
     {

--- a/src/Relego.Cli/Tui/HighlightDetailScreen.cs
+++ b/src/Relego.Cli/Tui/HighlightDetailScreen.cs
@@ -1285,12 +1285,12 @@ public sealed class HighlightDetailScreen : IScreen
 
     private static TableLayout CalculateTableLayout(int availableWidth)
     {
-        const int spacingWidth = 4;
+        const int SpacingWidth = 4;
 
-        var highlightWidth = availableWidth - WeightColumnWidth - DotColumnWidth - spacingWidth;
+        var highlightWidth = availableWidth - WeightColumnWidth - DotColumnWidth - SpacingWidth;
         if (highlightWidth < MinimumHighlightColumnWidth)
         {
-            highlightWidth = Math.Max(0, availableWidth - WeightColumnWidth - DotColumnWidth - spacingWidth);
+            highlightWidth = Math.Max(0, availableWidth - WeightColumnWidth - DotColumnWidth - SpacingWidth);
         }
 
         return new TableLayout(

--- a/src/Relego.Cli/Tui/HighlightDetailScreen.cs
+++ b/src/Relego.Cli/Tui/HighlightDetailScreen.cs
@@ -20,7 +20,7 @@ public sealed class HighlightDetailScreen : IScreen
     private const int MinimumWeight = 1;
     private const int MaximumWeight = 5;
     private const int WeightColumnWidth = 8;
-    private const int MinimumStateColumnWidth = 10;
+    private const int DotColumnWidth = 1;
     private const int MinimumHighlightColumnWidth = 18;
     private const int WeightEditorWidth = 52;
     private const int WeightEditorHeight = 7;
@@ -61,7 +61,7 @@ public sealed class HighlightDetailScreen : IScreen
     private bool _updatingViewState;
     private TableLayout _tableLayout = CalculateTableLayout(DefaultTableWidth);
 
-    private readonly record struct TableLayout(int HighlightWidth, int WeightWidth, int StatusWidth);
+    private readonly record struct TableLayout(int HighlightWidth, int WeightWidth);
 
     public HighlightDetailScreen(BookViewModel book, RelegoHttpClient client)
     {
@@ -1095,15 +1095,11 @@ public sealed class HighlightDetailScreen : IScreen
     private string FormatHighlightRow(HighlightViewModel highlight)
     {
         var excluded = IsEffectivelyExcluded(highlight);
+        var dot = excluded ? "\u2022" : " ";
         var text = FitCell(highlight.Text.ReplaceLineEndings(" "), _tableLayout.HighlightWidth);
-        var displayText = excluded ? ApplyStrikethrough(text) : text;
         var weight = (highlight.Weight ?? DefaultWeight).ToString(CultureInfo.InvariantCulture).PadLeft(_tableLayout.WeightWidth);
-        var statusText = excluded ? FitCell("Excluded", _tableLayout.StatusWidth) : string.Empty;
-        return $"{weight}  {displayText}  {statusText}".TrimEnd();
+        return $"{weight}  {dot}  {text}".TrimEnd();
     }
-
-    private static string ApplyStrikethrough(string text)
-        => string.Concat(text.Select(c => $"{c}\u0336"));
 
     private string BuildWeightScale()
         => string.Join("  ", Enumerable.Range(MinimumWeight, MaximumWeight)
@@ -1165,7 +1161,7 @@ public sealed class HighlightDetailScreen : IScreen
     }
 
     private static string FormatHeader(TableLayout tableLayout)
-        => $"{FitCell("WEIGHT", tableLayout.WeightWidth)}  {FitCell("HIGHLIGHT", tableLayout.HighlightWidth)}  {FitCell("STATUS", tableLayout.StatusWidth)}";
+        => $"{FitCell("WEIGHT", tableLayout.WeightWidth)}  {" ",DotColumnWidth}  {FitCell("HIGHLIGHT", tableLayout.HighlightWidth)}";
 
     private void ApplyNavigation(ScreenResult result)
     {
@@ -1291,17 +1287,15 @@ public sealed class HighlightDetailScreen : IScreen
     {
         const int spacingWidth = 4;
 
-        var statusWidth = MinimumStateColumnWidth;
-        var highlightWidth = availableWidth - WeightColumnWidth - statusWidth - spacingWidth;
+        var highlightWidth = availableWidth - WeightColumnWidth - DotColumnWidth - spacingWidth;
         if (highlightWidth < MinimumHighlightColumnWidth)
         {
-            highlightWidth = Math.Max(0, availableWidth - WeightColumnWidth - statusWidth - spacingWidth);
+            highlightWidth = Math.Max(0, availableWidth - WeightColumnWidth - DotColumnWidth - spacingWidth);
         }
 
         return new TableLayout(
             Math.Max(0, highlightWidth),
-            WeightColumnWidth,
-            statusWidth);
+            WeightColumnWidth);
     }
 
     private static string FitCell(string value, int width)


### PR DESCRIPTION
## Summary

Implements visual improvements to the highlights detail screen.

### Column reorder
Column order changed from `highlight | weight | status` → `weight | highlight | status`.

### Status only for excluded rows
The STATUS cell is now populated only for excluded rows. Included rows show an empty cell (trailing whitespace trimmed), keeping the table unobtrusive.

### Strikethrough for excluded rows
Excluded highlight text is rendered with the Unicode combining strikethrough character (U+0336), applied after column-width fitting so alignment is preserved.

### Summary metadata color
The single summary label is replaced with three chained labels:
- **count** — always muted
- **Book: included/excluded** — muted when included, Error red when excluded
- **Author: included/excluded** — muted when included, Error red when excluded

Closes #273