### PR TITLE
TUI settings: improve email test UX, warnings, and status box layout

### DIFF
--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -35,9 +35,10 @@ var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
 
 Assembly assembly = typeof(SyncCommand).Assembly;
 string applicationName = "relego";
-string version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+string version = (assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
     ?? assembly.GetName().Version?.ToString()
-    ?? "unknown";
+    ?? "unknown")
+    .Split('+')[0];
 
 builder.Services.AddHttpClient<RelegoHttpClient>((sp, client) =>
 {

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.2</Version>
+    <Version>0.11.3</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -729,7 +729,7 @@ public sealed class BookListScreen(
                 return true;
 
             case 's':
-                navigate(ScreenResult.Push(new SettingsScreen(_client)));
+                navigate(ScreenResult.Push(new SettingsScreen(_client, refreshChromeAsync: _refreshConnectionStatusAsync)));
                 return true;
 
             case 'i':

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -23,7 +23,7 @@ public sealed class SettingsScreen : IScreen
     [
         ("↑↓", "Navigate"),
         ("Enter", "Edit"),
-        ("T", "Test email"),
+        ("T", "Test email settings"),
         ("R", "Refresh"),
         ("Esc", "Go Back"),
         ("Q", "Quit")
@@ -52,10 +52,13 @@ public sealed class SettingsScreen : IScreen
     private Action<ScreenResult>? _navigate;
     private bool _viewCreated;
 
-    public SettingsScreen(RelegoHttpClient client, bool isDevelopment = false)
+    private readonly Func<CancellationToken, Task>? _refreshChromeAsync;
+
+    public SettingsScreen(RelegoHttpClient client, bool isDevelopment = false, Func<CancellationToken, Task>? refreshChromeAsync = null)
     {
         _client = client;
         _isDevelopment = isDevelopment;
+        _refreshChromeAsync = refreshChromeAsync;
     }
 
     public string Title => "";
@@ -360,6 +363,9 @@ public sealed class SettingsScreen : IScreen
             RebuildFields();
             CancelEdit();
             SetStatus($"{field.Label} updated.", isError: false);
+
+            if (field.FieldId == "kindleEmail" && _refreshChromeAsync is not null)
+                _ = Task.Run(() => _refreshChromeAsync(CancellationToken.None));
         }
         catch (HttpRequestException ex)
         {
@@ -369,6 +375,12 @@ public sealed class SettingsScreen : IScreen
 
     private async Task<ScreenResult> HandleTestEmailAsync(CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(_settings?.KindleEmail))
+        {
+            SetStatus("Kindle email is not configured. Please set it first.", isError: true);
+            return ScreenResult.Stay();
+        }
+
         SetStatus("Sending test email...", isError: false);
         UpdateViewStateIfCreated();
 
@@ -493,7 +505,6 @@ public sealed class SettingsScreen : IScreen
             Hint: "HH:mm format (e.g. 09:30)", DisplaySuffix: $"({_settings.Timezone})"));
         _fields.Add(new SettingsField("Highlights per Recap", _settings.Count.ToString(CultureInfo.InvariantCulture), "count", FieldKind.Editable,
             Hint: $"A number between {MinWeight} and {MaxWeight}"));
-        _fields.Add(new SettingsField("▶ Send test email", string.Empty, "test-email", FieldKind.Action));
 
         if (_isDevelopment)
         {

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -394,8 +394,12 @@ public sealed class SettingsScreen : IScreen
             }
             else
             {
-                var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                SetStatus($"Test email failed: {body}", isError: true);
+                var message = response.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.BadGateway => "SMTP delivery failed. Check your server SMTP configuration.",
+                    _ => "Test email failed. Check server configuration."
+                };
+                SetStatus(message, isError: true);
             }
         }
         catch (HttpRequestException ex)

--- a/src/Relego.Cli/Tui/StatusChrome.cs
+++ b/src/Relego.Cli/Tui/StatusChrome.cs
@@ -79,21 +79,11 @@ public sealed class StatusChrome(string serverUrl, string version)
         };
         infoFrame.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.Border, bg)));
 
-        var versionLabel = new Label
-        {
-            Text = $"Relego v{version}",
-            X = 1,
-            Y = 0,
-            Width = Dim.Fill(1),
-            TextAlignment = Alignment.End
-        };
-        versionLabel.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.TextMuted, bg)));
-
         _connectionLabel = new Label
         {
             Text = $"⟳ Checking...  {serverUrl}",
             X = 1,
-            Y = 1,
+            Y = 0,
             Width = Dim.Fill(1),
             TextAlignment = Alignment.End
         };
@@ -102,12 +92,22 @@ public sealed class StatusChrome(string serverUrl, string version)
         {
             Text = string.Empty,
             X = 1,
-            Y = 2,
+            Y = 1,
             Width = Dim.Fill(1),
             TextAlignment = Alignment.End
         };
 
-        infoFrame.Add(versionLabel, _connectionLabel, _warningLabel);
+        var versionLabel = new Label
+        {
+            Text = $"relego v{version}",
+            X = 1,
+            Y = 2,
+            Width = Dim.Fill(1),
+            TextAlignment = Alignment.End
+        };
+        versionLabel.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.TextMuted, bg)));
+
+        infoFrame.Add(_connectionLabel, _warningLabel, versionLabel);
         container.Add(infoFrame);
 
         return container;

--- a/src/Relego.Cli/Tui/StatusChrome.cs
+++ b/src/Relego.Cli/Tui/StatusChrome.cs
@@ -149,8 +149,8 @@ public sealed class StatusChrome(string serverUrl, string version)
         if (_connectionLabel is not null)
         {
             _connectionLabel.Text = IsConnected
-                ? $"● Connected  {serverUrl}"
-                : $"● Disconnected  {serverUrl}";
+                ? $"● Connected to {serverUrl}"
+                : $"● Disconnected {serverUrl}";
 
             _connectionLabel.SetScheme(IsConnected
                 ? new Scheme(new Terminal.Gui.Drawing.Attribute(palette.Success, bg))

--- a/src/Relego.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SettingsEndpoints.cs
@@ -98,12 +98,20 @@ public static partial class SettingsEndpoints
                     title: "SMTP delivery failed.",
                     statusCode: StatusCodes.Status502BadGateway);
             }
+            catch (Exception)
+            {
+                return Results.Problem(
+                    detail: null,
+                    title: "Test email failed due to an internal error.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
         })
         .WithSummary("Send a plain-text test email.")
         .WithDescription("Sends a simple verification email to the configured Kindle email address without generating a recap.")
         .Produces(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
-        .ProducesProblem(StatusCodes.Status502BadGateway);
+        .ProducesProblem(StatusCodes.Status502BadGateway)
+        .ProducesProblem(StatusCodes.Status500InternalServerError);
 
         return app;
     }

--- a/src/Relego.Server/Program.cs
+++ b/src/Relego.Server/Program.cs
@@ -102,6 +102,18 @@ builder.Services.AddScoped<IRecapService, RecapService>();
 
 var app = builder.Build();
 
+app.UseExceptionHandler(err =>
+{
+    err.Run(async context =>
+    {
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        context.Response.ContentType = "application/problem+json";
+        await context.Response.WriteAsJsonAsync(
+            new { type = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.1", title = "An unexpected error occurred.", status = 500 },
+            cancellationToken: context.RequestAborted);
+    });
+});
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.14.0</Version>
+    <Version>0.14.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -68,16 +68,31 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
         Assert.Contains("SMTP delivery failed", body);
     }
 
+    [Fact]
+    public async Task PostTestEmail_WhenUnexpectedErrorOccurs_Returns500()
+    {
+        await _client.PutAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+        _fakeMail.ShouldThrowUnexpected = true;
+
+        var response = await _client.PostAsync("/settings/test-email", null);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
     private sealed class FakeMailDeliveryService : IMailDeliveryService
     {
         public string? LastTestEmailAddress { get; private set; }
         public bool ShouldThrow { get; set; }
+        public bool ShouldThrowUnexpected { get; set; }
 
         public Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
 
         public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         {
+            if (ShouldThrowUnexpected)
+                throw new InvalidOperationException("Unexpected configuration error.");
+
             if (ShouldThrow)
                 throw new System.Net.Sockets.SocketException(10061);
 

--- a/src/Relego.Tests/Tui/SettingsScreenTests.cs
+++ b/src/Relego.Tests/Tui/SettingsScreenTests.cs
@@ -37,7 +37,7 @@ public sealed class SettingsScreenTests
 
         Assert.NotNull(screen.Settings);
         Assert.Equal("user@kindle.com", screen.Settings.KindleEmail);
-        Assert.Equal(5, screen.Fields.Count); // 4 editable + 1 action (schedule=daily, no delivery day, no timezone)
+        Assert.Equal(4, screen.Fields.Count); // 4 editable (schedule=daily, no delivery day, no timezone)
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public sealed class SettingsScreenTests
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient), isDevelopment: true);
         await screen.InitializeAsync(CancellationToken.None);
 
-        Assert.Equal(6, screen.Fields.Count); // 4 editable + 2 actions
+        Assert.Equal(5, screen.Fields.Count); // 4 editable + 1 action (trigger-recap only)
         Assert.Contains(screen.Fields, f => f.ActionId == "trigger-recap");
     }
 
@@ -70,7 +70,7 @@ public sealed class SettingsScreenTests
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
-        Assert.Equal(6, screen.Fields.Count); // 5 editable (includes delivery day) + 1 action
+        Assert.Equal(5, screen.Fields.Count); // 5 editable (includes delivery day)
         Assert.Contains(screen.Fields, f => f.FieldId == "deliveryDay");
         Assert.Equal("wednesday", screen.Fields.First(f => f.FieldId == "deliveryDay").Value);
     }
@@ -335,35 +335,30 @@ public sealed class SettingsScreenTests
 
         Assert.Contains(screen.KeyHints, hint => hint is ("↑↓", "Navigate"));
         Assert.Contains(screen.KeyHints, hint => hint is ("Enter", "Edit"));
-        Assert.Contains(screen.KeyHints, hint => hint is ("T", "Test email"));
+        Assert.Contains(screen.KeyHints, hint => hint is ("T", "Test email settings"));
         Assert.Contains(screen.KeyHints, hint => hint is ("R", "Refresh"));
         Assert.Contains(screen.KeyHints, hint => hint is ("Esc", "Go Back"));
         Assert.Contains(screen.KeyHints, hint => hint is ("Q", "Quit"));
     }
 
     [Fact]
-    public async Task HandleKeyAsync_EnterOnActionField_ExecutesAction()
+    public async Task HandleKeyAsync_TestEmail_WhenKindleEmailNotConfigured_ShowsError()
     {
         var settings = CreateDefaultSettings();
+        settings.KindleEmail = string.Empty;
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
             .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
-        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
-            .Respond(HttpStatusCode.OK, "application/json", "{\"message\":\"ok\"}");
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
         var screen = new SettingsScreen(new RelegoHttpClient(httpClient));
         await screen.InitializeAsync(CancellationToken.None);
 
-        // Navigate to the "Send test email" action (index 4 with daily schedule)
-        for (var i = 0; i < 4; i++)
-            await screen.HandleKeyAsync(Key(ConsoleKey.DownArrow), CancellationToken.None);
-
-        Assert.Equal("test-email", screen.Fields[screen.SelectedField].ActionId);
-
-        var result = await screen.HandleKeyAsync(Key(ConsoleKey.Enter), CancellationToken.None);
+        var result = await screen.HandleKeyAsync(Key(ConsoleKey.T, 't'), CancellationToken.None);
 
         Assert.Equal(ScreenAction.None, result.Action);
+        Assert.True(screen.StatusIsError);
+        Assert.NotNull(screen.StatusMessage);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Test helper; MockHttp and HttpClient outlive the helper call")]


### PR DESCRIPTION
## Summary

Implements all tasks from #270.

- **Guard test email**: pressing `T` when Kindle email is not configured shows an inline error instead of silently sending (or failing server-side).
- **Remove explicit action field**: the "▶ Send test email" row is removed from the settings list; `T` is the sole trigger.
- **Key hint label**: renamed from "Test email" to "Test email settings".
- **Stale warning fix**: after saving the Kindle email field, the chrome's `refreshChromeAsync` callback is fired immediately so the "⚠ Kindle email not configured" warning disappears without a manual refresh.
- **Status box layout**: reordered to connection → warning → `relego vX.Y.Z` (version last), ensuring the version is always readable and never overlapped by warnings.
- **Version bump**: `0.11.2` → `0.11.3` (patch).

Closes #270