### PR TITLE
Standardize import naming: rename sync command to import across CLI, TUI, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## How it works
 
-1. Connect your Kindle via USB and run `relego sync` — highlights are imported from `My Clippings.txt`
+1. Connect your Kindle via USB and run `relego import` — highlights are imported from `My Clippings.txt`
 2. The server selects a daily or weekly subset of highlights using spaced repetition (weighted by your preferences)
 3. A recap document is sent to your Kindle email address via Amazon's Send-to-Kindle service
 4. Open the recap on your Kindle like any other book
@@ -68,7 +68,7 @@ Replace the `SMTP_*` values with those for your provider.
 >
 > Use a free SMTP relay like [Resend](https://resend.com/docs/send-with-smtp), [MailerSend](https://www.mailersend.com/help/smtp-relay) or [Mailgun](https://www.mailgun.com/features/smtp-server/) instead. They offer a free tier with a generous limit of free emails. Otherwise, you can use your own SMPT relay server.
 
-### 3. Sync the Kindle highlights
+### 3. Import the Kindle highlights
 
 Upload highlights to the server using the CLI. It automatically detects the path to your Kindle:
 
@@ -83,7 +83,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
     --network relego `
     -e RELEGO_SERVER="http://relego-server:8080" `
     ghcr.io/krusty93/relego.cli:latest `
-    sync "/kindle/My Clippings.txt"
+    import "/kindle/My Clippings.txt"
   ```
 
   > NB: Follow the [WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/connect-usb) to allow WSL to access the Kindle device. Another simpler option is to copy the `My Clippings.txt` file to your PC (e.g. local path) and mounting the volume:
@@ -94,7 +94,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
     --network relego `
     -e RELEGO_SERVER="http://relego-server:8080" `
     ghcr.io/krusty93/relego.cli:latest `
-    sync "/kindle/My Clippings.txt"
+    import "/kindle/My Clippings.txt"
   ```
 
   **macOS** (Kindle mounts at `/Volumes/Kindle`):
@@ -104,7 +104,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
     -v "/Volumes/Kindle/documents:/kindle:ro" \
     -e RELEGO_SERVER="http://relego-server:8080" \
     ghcr.io/krusty93/relego.cli:latest \
-    sync "/kindle/My Clippings.txt"
+    import "/kindle/My Clippings.txt"
   ```
 
   **Linux** (Kindle mounts at `/media/$USER/Kindle`):
@@ -114,7 +114,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
     -v "/media/$USER/Kindle/documents:/kindle:ro" \
     -e RELEGO_SERVER="http://relego-server:8080" \
     ghcr.io/krusty93/relego.cli:latest \
-    sync "/kindle/My Clippings.txt"
+    import "/kindle/My Clippings.txt"
   ```
 
 </details>
@@ -126,7 +126,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
 
   ```sh
   winget install Krusty93.Relego
-  relego sync
+  relego import
   ```
 
 #### Binary
@@ -135,7 +135,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
 
   ```powershell
   curl -L https://github.com/Krusty93/relego/releases/download/cli%2Fv<version>/relego-<version>-win-x64 -o ./relego.exe
-  ./relego.exe sync
+  ./relego.exe import
   ```
 
 </details>
@@ -150,7 +150,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
   ```sh
   curl -L https://github.com/Krusty93/relego/releases/download/cli%2Fv<version>/relego-<version>-osx-arm64 -o /usr/local/bin/relego
   chmod +x /usr/local/bin/relego
-  relego sync
+  relego import
   ```
 
 #### Intel
@@ -158,7 +158,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
   ```sh
   curl -L https://github.com/Krusty93/relego/releases/download/cli%2Fv<version>/relego-<version>-osx-amd64 -o /usr/local/bin/relego
   chmod +x /usr/local/bin/relego
-  relego sync
+  relego import
   ```
 
 </details>
@@ -171,7 +171,7 @@ Upload highlights to the server using the CLI. It automatically detects the path
   ```sh
   curl -L https://github.com/Krusty93/relego/releases/download/cli%2Fv<version>/relego-<version>-linux-x64 -o /usr/local/bin/relego
   chmod +x /usr/local/bin/relego
-  relego sync
+  relego import
   ```
 
 </details>
@@ -181,12 +181,12 @@ The client automatically connects to `http://localhost:8080`. If you ran the ser
 ```sh
 # binary
 export RELEGO_SERVER=http://192.168.1.10:8080
-relego sync
+relego import
 
 # Docker
 docker run \
   -e RELEGO_SERVER=http://192.168.1.10:8080 \
-  ghcr.io/krusty93/relego.cli:latest sync
+  ghcr.io/krusty93/relego.cli:latest import
 ```
 
 That's it. Your first recap will arrive on the next scheduled delivery (default: every day at 18:00).
@@ -194,7 +194,7 @@ That's it. Your first recap will arrive on the next scheduled delivery (default:
 > **My Clippings.txt on a different path?** Override the default location using:
 >
 > ```sh
-> relego sync <path>
+> relego import <path>
 > ```
 >
 
@@ -209,7 +209,7 @@ Running `relego` with no arguments in an interactive terminal opens a full-scree
 |                   Command                        |              Description                  |
 |--------------------------------------------------|-------------------------------------------|
 | `relego`                                         | Open interactive TUI                      |
-| `relego sync [path]`                             | Import highlights from `My Clippings.txt` |
+| `relego import [path]`                           | Import highlights from `My Clippings.txt` |
 | `relego status`                                  | Show server status and next recap         |
 | `relego config schedule <daily\|weekly> [HH:MM]` | Set recap schedule                        |
 | `relego config schedule show`                    | Show current schedule                     |

--- a/src/Relego.Cli/Commands/ImportCommand.cs
+++ b/src/Relego.Cli/Commands/ImportCommand.cs
@@ -3,15 +3,15 @@ using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using Relego.Cli.Parsing;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 using Relego.Core.Contracts;
 
 namespace Relego.Cli.Commands;
 
 /// <summary>
-/// Parses a Kindle clippings file and syncs highlights to the server.
+/// Parses a Kindle clippings file and imports highlights to the server.
 /// </summary>
-public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncCommand> logger) : ServerCommand<SyncCommand.Settings>
+public sealed class ImportCommand(ClippingsImportWorkflow workflow, ILogger<ImportCommand> logger) : ServerCommand<ImportCommand.Settings>
 {
     protected override ILogger Logger => logger;
 
@@ -24,7 +24,7 @@ public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncComm
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
     {
-        var outcome = await workflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await workflow.ExecuteAsync(new ClippingsImportOptions
         {
             FilePath = settings.Path,
             ResolvePathAsync = settings.Path is null ? ResolvePathAsync : null
@@ -32,17 +32,17 @@ public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncComm
 
         return outcome.Status switch
         {
-            ClippingsSyncStatus.Cancelled => HandleCancelled(),
-            ClippingsSyncStatus.FileNotFound => HandleMissingFile(outcome),
-            ClippingsSyncStatus.ParseFailed => HandleParseFailure(outcome),
-            ClippingsSyncStatus.NoHighlightsFound => HandleNoHighlights(),
-            ClippingsSyncStatus.ServerError => HandleConnectivityFailure(outcome),
-            ClippingsSyncStatus.Succeeded => HandleSuccess(outcome),
+            ClippingsImportStatus.Cancelled => HandleCancelled(),
+            ClippingsImportStatus.FileNotFound => HandleMissingFile(outcome),
+            ClippingsImportStatus.ParseFailed => HandleParseFailure(outcome),
+            ClippingsImportStatus.NoHighlightsFound => HandleNoHighlights(),
+            ClippingsImportStatus.ServerError => HandleConnectivityFailure(outcome),
+            ClippingsImportStatus.Succeeded => HandleSuccess(outcome),
             _ => throw new ArgumentOutOfRangeException(nameof(outcome.Status), outcome.Status, null)
         };
     }
 
-    private static ValueTask<string?> ResolvePathAsync(ClippingsPathPromptRequest request, CancellationToken cancellationToken)
+    private static ValueTask<string?> ResolvePathAsync(ClippingsImportPathPromptRequest request, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return ValueTask.FromResult(!string.IsNullOrWhiteSpace(request.DetectedPath) ? request.DetectedPath : PromptForPath());
@@ -60,17 +60,17 @@ public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncComm
 
     private static int HandleCancelled()
     {
-        AnsiConsole.MarkupLine("[yellow]Sync cancelled.[/]");
+        AnsiConsole.MarkupLine("[yellow]Import cancelled.[/]");
         return 1;
     }
 
-    private static int HandleMissingFile(ClippingsSyncOutcome outcome)
+    private static int HandleMissingFile(ClippingsImportOutcome outcome)
     {
         AnsiConsole.MarkupLine($"[red]Error:[/] File not found: [yellow]{outcome.FilePath}[/]");
         return 1;
     }
 
-    private static int HandleParseFailure(ClippingsSyncOutcome outcome)
+    private static int HandleParseFailure(ClippingsImportOutcome outcome)
     {
         AnsiConsole.MarkupLine($"[red]Error parsing clippings file:[/] {outcome.Message}");
         return 1;
@@ -82,12 +82,12 @@ public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncComm
         return 0;
     }
 
-    private int HandleConnectivityFailure(ClippingsSyncOutcome outcome)
+    private int HandleConnectivityFailure(ClippingsImportOutcome outcome)
     {
         return HandleServerError(outcome.Error as HttpRequestException ?? new HttpRequestException(outcome.Message));
     }
 
-    private static int HandleSuccess(ClippingsSyncOutcome outcome)
+    private static int HandleSuccess(ClippingsImportOutcome outcome)
     {
         DisplaySummary(outcome.ParseResult!, outcome.Response!);
         return 0;
@@ -104,7 +104,7 @@ public sealed class SyncCommand(ClippingsSyncWorkflow workflow, ILogger<SyncComm
                 new Markup($"[green]✓[/] [bold]{response.NewHighlights}[/] new highlights imported ([grey]{response.DuplicateHighlights} duplicates skipped[/])"),
                 new Markup($"[green]✓[/] [bold]{response.NewBooks}[/] new books, [bold]{response.NewAuthors}[/] new authors")
             ))
-            .Header("[green]Sync Complete[/]")
+            .Header("[green]Import Complete[/]")
             .Border(BoxBorder.Rounded));
     }
 }

--- a/src/Relego.Cli/Import/ClippingsImportWorkflow.cs
+++ b/src/Relego.Cli/Import/ClippingsImportWorkflow.cs
@@ -3,18 +3,18 @@ using Relego.Cli.Infrastructure;
 using Relego.Cli.Parsing;
 using Relego.Core.Contracts;
 
-namespace Relego.Cli.Sync;
+namespace Relego.Cli.Import;
 
-public sealed class ClippingsSyncWorkflow(RelegoHttpClient client, ILogger<ClippingsSyncWorkflow> logger)
+public sealed class ClippingsImportWorkflow(RelegoHttpClient client, ILogger<ClippingsImportWorkflow> logger)
 {
-    public async Task<ClippingsSyncOutcome> ExecuteAsync(ClippingsSyncOptions options, CancellationToken cancellationToken = default)
+    public async Task<ClippingsImportOutcome> ExecuteAsync(ClippingsImportOptions options, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(options);
 
         var filePath = await ResolveFilePathAsync(options, cancellationToken).ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(filePath))
         {
-            return ClippingsSyncOutcome.Cancelled();
+            return ClippingsImportOutcome.Cancelled();
         }
 
         filePath = filePath.Trim();
@@ -22,7 +22,7 @@ public sealed class ClippingsSyncWorkflow(RelegoHttpClient client, ILogger<Clipp
 
         if (!File.Exists(filePath))
         {
-            return ClippingsSyncOutcome.FileNotFound(filePath);
+            return ClippingsImportOutcome.FileNotFound(filePath);
         }
 
         ParseResult parseResult;
@@ -37,12 +37,12 @@ public sealed class ClippingsSyncWorkflow(RelegoHttpClient client, ILogger<Clipp
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogWarning(ex, "Failed to parse clippings file {FilePath}", filePath);
-            return ClippingsSyncOutcome.ParseFailed(filePath, ex);
+            return ClippingsImportOutcome.ParseFailed(filePath, ex);
         }
 
         if (parseResult.Books.Count == 0)
         {
-            return ClippingsSyncOutcome.NoHighlightsFound(filePath, parseResult);
+            return ClippingsImportOutcome.NoHighlightsFound(filePath, parseResult);
         }
 
         var request = CreateSyncRequest(parseResult);
@@ -54,16 +54,16 @@ public sealed class ClippingsSyncWorkflow(RelegoHttpClient client, ILogger<Clipp
         try
         {
             var response = await client.PostSyncAsync(request, cancellationToken).ConfigureAwait(false);
-            return ClippingsSyncOutcome.Succeeded(filePath, parseResult, response);
+            return ClippingsImportOutcome.Succeeded(filePath, parseResult, response);
         }
         catch (HttpRequestException ex)
         {
-            logger.LogWarning(ex, "Failed to sync clippings from {FilePath}", filePath);
-            return ClippingsSyncOutcome.ServerError(filePath, parseResult, ex);
+            logger.LogWarning(ex, "Failed to import clippings from {FilePath}", filePath);
+            return ClippingsImportOutcome.ServerError(filePath, parseResult, ex);
         }
     }
 
-    private static async Task<string?> ResolveFilePathAsync(ClippingsSyncOptions options, CancellationToken cancellationToken)
+    private static async Task<string?> ResolveFilePathAsync(ClippingsImportOptions options, CancellationToken cancellationToken)
     {
         if (!string.IsNullOrWhiteSpace(options.FilePath))
         {
@@ -73,7 +73,7 @@ public sealed class ClippingsSyncWorkflow(RelegoHttpClient client, ILogger<Clipp
         var detectedPath = KindleDetector.DetectClippingsPath();
         if (options.ResolvePathAsync is not null)
         {
-            return await options.ResolvePathAsync(new ClippingsPathPromptRequest(detectedPath), cancellationToken).ConfigureAwait(false);
+            return await options.ResolvePathAsync(new ClippingsImportPathPromptRequest(detectedPath), cancellationToken).ConfigureAwait(false);
         }
 
         return detectedPath;
@@ -99,20 +99,20 @@ public sealed class ClippingsSyncWorkflow(RelegoHttpClient client, ILogger<Clipp
     }
 }
 
-public sealed record ClippingsSyncOptions
+public sealed record ClippingsImportOptions
 {
     public string? FilePath { get; init; }
 
-    public Func<ClippingsPathPromptRequest, CancellationToken, ValueTask<string?>>? ResolvePathAsync { get; init; }
+    public Func<ClippingsImportPathPromptRequest, CancellationToken, ValueTask<string?>>? ResolvePathAsync { get; init; }
 
     public Func<string, ILogger?, Task<ParseResult>>? ParseAsync { get; init; }
 
     public ILogger? ParserLogger { get; init; }
 }
 
-public sealed record ClippingsPathPromptRequest(string? DetectedPath);
+public sealed record ClippingsImportPathPromptRequest(string? DetectedPath);
 
-public enum ClippingsSyncStatus
+public enum ClippingsImportStatus
 {
     Cancelled,
     FileNotFound,
@@ -122,9 +122,9 @@ public enum ClippingsSyncStatus
     Succeeded
 }
 
-public sealed record ClippingsSyncOutcome
+public sealed record ClippingsImportOutcome
 {
-    public required ClippingsSyncStatus Status { get; init; }
+    public required ClippingsImportStatus Status { get; init; }
 
     public string? FilePath { get; init; }
 
@@ -138,49 +138,49 @@ public sealed record ClippingsSyncOutcome
 
     public int TotalHighlightsParsed => ParseResult?.Books.Sum(book => book.Highlights.Count) ?? 0;
 
-    public bool IsSuccessful => Status is ClippingsSyncStatus.NoHighlightsFound or ClippingsSyncStatus.Succeeded;
+    public bool IsSuccessful => Status is ClippingsImportStatus.NoHighlightsFound or ClippingsImportStatus.Succeeded;
 
-    public static ClippingsSyncOutcome Cancelled() => new()
+    public static ClippingsImportOutcome Cancelled() => new()
     {
-        Status = ClippingsSyncStatus.Cancelled,
-        Message = "Sync cancelled."
+        Status = ClippingsImportStatus.Cancelled,
+        Message = "Import cancelled."
     };
 
-    public static ClippingsSyncOutcome FileNotFound(string filePath) => new()
+    public static ClippingsImportOutcome FileNotFound(string filePath) => new()
     {
-        Status = ClippingsSyncStatus.FileNotFound,
+        Status = ClippingsImportStatus.FileNotFound,
         FilePath = filePath,
         Message = $"File not found: {filePath}"
     };
 
-    public static ClippingsSyncOutcome ParseFailed(string filePath, Exception error) => new()
+    public static ClippingsImportOutcome ParseFailed(string filePath, Exception error) => new()
     {
-        Status = ClippingsSyncStatus.ParseFailed,
+        Status = ClippingsImportStatus.ParseFailed,
         FilePath = filePath,
         Message = error.Message,
         Error = error
     };
 
-    public static ClippingsSyncOutcome NoHighlightsFound(string filePath, ParseResult parseResult) => new()
+    public static ClippingsImportOutcome NoHighlightsFound(string filePath, ParseResult parseResult) => new()
     {
-        Status = ClippingsSyncStatus.NoHighlightsFound,
+        Status = ClippingsImportStatus.NoHighlightsFound,
         FilePath = filePath,
         Message = "No highlights found in the clippings file.",
         ParseResult = parseResult
     };
 
-    public static ClippingsSyncOutcome ServerError(string filePath, ParseResult parseResult, HttpRequestException error) => new()
+    public static ClippingsImportOutcome ServerError(string filePath, ParseResult parseResult, HttpRequestException error) => new()
     {
-        Status = ClippingsSyncStatus.ServerError,
+        Status = ClippingsImportStatus.ServerError,
         FilePath = filePath,
         Message = error.Message,
         ParseResult = parseResult,
         Error = error
     };
 
-    public static ClippingsSyncOutcome Succeeded(string filePath, ParseResult parseResult, SyncResponse response) => new()
+    public static ClippingsImportOutcome Succeeded(string filePath, ParseResult parseResult, SyncResponse response) => new()
     {
-        Status = ClippingsSyncStatus.Succeeded,
+        Status = ClippingsImportStatus.Succeeded,
         FilePath = filePath,
         ParseResult = parseResult,
         Response = response

--- a/src/Relego.Cli/Import/ClippingsImportWorkflow.cs
+++ b/src/Relego.Cli/Import/ClippingsImportWorkflow.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Relego.Cli.Infrastructure;
 using Relego.Cli.Parsing;
 using Relego.Core.Contracts;

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -10,7 +10,7 @@ using Relego.Cli.Commands.Config;
 using Relego.Cli.Commands.Exclude;
 using Relego.Cli.Commands.Weight;
 using Relego.Cli.Infrastructure;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 using Relego.Cli.Tui;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -33,7 +33,7 @@ if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
 
 var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
 
-Assembly assembly = typeof(SyncCommand).Assembly;
+Assembly assembly = typeof(ImportCommand).Assembly;
 string applicationName = "relego";
 string version = (assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
     ?? assembly.GetName().Version?.ToString()
@@ -48,14 +48,14 @@ builder.Services.AddHttpClient<RelegoHttpClient>((sp, client) =>
     client.BaseAddress = new Uri(serverUrl);
     client.Timeout = TimeSpan.FromSeconds(30);
 }).AddRelegoResilience();
-builder.Services.AddTransient<ClippingsSyncWorkflow>();
+builder.Services.AddTransient<ClippingsImportWorkflow>();
 
 using IHost host = builder.Build();
 
 if (TuiModeDetector.Detect(args, Console.IsInputRedirected) == StartupMode.Tui)
 {
     var client = host.Services.GetRequiredService<RelegoHttpClient>();
-    var syncWorkflow = host.Services.GetRequiredService<ClippingsSyncWorkflow>();
+    var syncWorkflow = host.Services.GetRequiredService<ClippingsImportWorkflow>();
     var tuiApp = new TuiApp(client, syncWorkflow, normalizedServerUrl, version);
     await tuiApp.RunAsync(CancellationToken.None);
     return 0;
@@ -70,8 +70,8 @@ app.Configure(config =>
     config.SetApplicationName(applicationName);
     config.SetApplicationVersion(version);
 
-    config.AddCommand<SyncCommand>("sync")
-        .WithDescription("Parse and sync highlights from My Clippings.txt to the server.");
+    config.AddCommand<ImportCommand>("import")
+        .WithDescription("Parse and import highlights from My Clippings.txt to the server.");
 
     config.AddCommand<StatusCommand>("status")
         .WithDescription("Display server health and aggregate state.");

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -6,7 +6,7 @@ using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using Relego.Cli.Infrastructure;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 using Relego.Cli.Tui.ViewModels;
 using Relego.Core.Contracts;
 
@@ -14,7 +14,7 @@ namespace Relego.Cli.Tui;
 
 public sealed class BookListScreen(
     RelegoHttpClient client,
-    ClippingsSyncWorkflow syncWorkflow,
+    ClippingsImportWorkflow syncWorkflow,
     Action? onConnectionFailure = null,
     Func<CancellationToken, Task>? refreshConnectionStatusAsync = null) : IScreen
 {
@@ -28,12 +28,12 @@ public sealed class BookListScreen(
     private const string SectionTitle = "Books";
     private const string SearchPlaceholderIdle = "type / to search";
     private const string SearchPlaceholderFocused = "Press Esc to return to the list";
-    private const string SyncPlaceholderDetected = "Press Enter to sync or edit the path";
+    private const string SyncPlaceholderDetected = "Press Enter to import or edit the path";
     private const string SyncPlaceholderManual = "Enter the path to My Clippings.txt";
     private const string RenamePlaceholder = "Enter new title, press Enter to confirm or Esc to cancel";
 
     private readonly RelegoHttpClient _client = client;
-    private readonly ClippingsSyncWorkflow _syncWorkflow = syncWorkflow;
+    private readonly ClippingsImportWorkflow _syncWorkflow = syncWorkflow;
     private readonly Action? _onConnectionFailure = onConnectionFailure;
     private readonly Func<CancellationToken, Task>? _refreshConnectionStatusAsync = refreshConnectionStatusAsync;
     private List<BookViewModel> _books = [];
@@ -67,13 +67,13 @@ public sealed class BookListScreen(
 
     public bool IsSearchActive => _isSearchActive;
 
-    public bool IsSyncPromptActive => _toolbarMode == ToolbarMode.SyncPath;
+    public bool IsImportPromptActive => _toolbarMode == ToolbarMode.SyncPath;
 
     public bool IsRenamePromptActive => _toolbarMode == ToolbarMode.Rename;
 
     public string SearchQuery => _searchQuery;
 
-    public string SyncPathInput => _syncPathInput;
+    public string ImportPathInput => _syncPathInput;
 
     public string? FeedbackMessage => _feedbackMessage;
 
@@ -283,7 +283,7 @@ public sealed class BookListScreen(
             }
 
             _refreshVisibleBooks = RefreshEmpty;
-            SetupContainerKeyBindings(container, null, navigate, RefreshEmpty, BeginSearchInput, () => BeginSyncPrompt());
+            SetupContainerKeyBindings(container, null, navigate, RefreshEmpty, BeginSearchInput, () => BeginImportPrompt());
             return container;
         }
 
@@ -401,7 +401,7 @@ public sealed class BookListScreen(
         container.Add(titleLabel, headerLabel, headerRuleLabel, listView);
         _listView = listView;
         _refreshVisibleBooks = RefreshVisibleBooks;
-        SetupContainerKeyBindings(container, listView, navigate, RefreshVisibleBooks, BeginSearchInput, () => BeginSyncPrompt());
+        SetupContainerKeyBindings(container, listView, navigate, RefreshVisibleBooks, BeginSearchInput, () => BeginImportPrompt());
 
         // Save/restore selection around SetFocus: Terminal.Gui may fire ValueChanged
         // with SelectedItem = 0 when the ListView gains focus, overwriting _selectedIndex.
@@ -456,7 +456,7 @@ public sealed class BookListScreen(
         UpdateToolbarChrome();
     }
 
-    public void BeginSyncPrompt(string? detectedPath = null)
+    public void BeginImportPrompt(string? detectedPath = null)
     {
         _toolbarMode = ToolbarMode.SyncPath;
         _isSearchActive = false;
@@ -476,7 +476,7 @@ public sealed class BookListScreen(
         UpdateToolbarChrome();
     }
 
-    public void CancelSyncPrompt()
+    public void CancelImportPrompt()
     {
         _toolbarMode = ToolbarMode.Search;
         _detectedSyncPath = null;
@@ -488,10 +488,10 @@ public sealed class BookListScreen(
             return;
         }
 
-        RestoreToolbarAfterSyncPrompt();
+        RestoreToolbarAfterImportPrompt();
     }
 
-    private void RestoreToolbarAfterSyncPrompt()
+    private void RestoreToolbarAfterImportPrompt()
     {
         ArgumentNullException.ThrowIfNull(_searchField);
 
@@ -599,47 +599,47 @@ public sealed class BookListScreen(
         _refreshVisibleBooks?.Invoke();
     }
 
-    public async Task<ClippingsSyncOutcome> SubmitSyncAsync(string? filePath = null, CancellationToken cancellationToken = default)
+    public async Task<ClippingsImportOutcome> SubmitImportAsync(string? filePath = null, CancellationToken cancellationToken = default)
     {
         var resolvedPath = filePath ?? _syncPathInput;
         if (string.IsNullOrWhiteSpace(resolvedPath))
         {
             SetFeedback("Enter a path to My Clippings.txt or press Esc to cancel.", isError: true);
-            return ClippingsSyncOutcome.Cancelled();
+            return ClippingsImportOutcome.Cancelled();
         }
 
         var hadBooksView = _viewHasBooksList;
-        var outcome = await _syncWorkflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await _syncWorkflow.ExecuteAsync(new ClippingsImportOptions
         {
             FilePath = resolvedPath
         }, cancellationToken).ConfigureAwait(false);
 
         switch (outcome.Status)
         {
-            case ClippingsSyncStatus.FileNotFound:
+            case ClippingsImportStatus.FileNotFound:
                 SetFeedback($"File not found: {outcome.FilePath}", isError: true);
                 return outcome;
 
-            case ClippingsSyncStatus.ParseFailed:
+            case ClippingsImportStatus.ParseFailed:
                 SetFeedback($"Error parsing clippings file: {outcome.Message}", isError: true);
                 return outcome;
 
-            case ClippingsSyncStatus.ServerError:
+            case ClippingsImportStatus.ServerError:
                 _onConnectionFailure?.Invoke();
-                SetFeedback($"Sync failed: {outcome.Message}", isError: true);
+                SetFeedback($"Import failed: {outcome.Message}", isError: true);
                 return outcome;
 
-            case ClippingsSyncStatus.NoHighlightsFound:
+            case ClippingsImportStatus.NoHighlightsFound:
                 SetFeedback("No highlights found in the clippings file.", isError: false);
-                CancelSyncPrompt();
+                CancelImportPrompt();
                 return outcome;
 
-            case ClippingsSyncStatus.Succeeded:
+            case ClippingsImportStatus.Succeeded:
                 await InitializeAsync(cancellationToken).ConfigureAwait(false);
                 SetFeedback(
-                    $"Sync complete. {outcome.TotalHighlightsParsed} parsed, {outcome.Response!.NewHighlights} new, {outcome.Response.DuplicateHighlights} duplicates, {outcome.Response.NewBooks} books, {outcome.Response.NewAuthors} authors.",
+                    $"Import complete. {outcome.TotalHighlightsParsed} parsed, {outcome.Response!.NewHighlights} new, {outcome.Response.DuplicateHighlights} duplicates, {outcome.Response.NewBooks} books, {outcome.Response.NewAuthors} authors.",
                     isError: false);
-                CancelSyncPrompt();
+                CancelImportPrompt();
 
                 if (_navigate is not null)
                 {
@@ -993,7 +993,7 @@ public sealed class BookListScreen(
         {
             if (key.KeyCode == KeyCode.Esc)
             {
-                CancelSyncPrompt();
+                CancelImportPrompt();
                 key.Handled = true;
             }
 
@@ -1032,7 +1032,7 @@ public sealed class BookListScreen(
             return;
         }
 
-        await SubmitSyncAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        await SubmitImportAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
     }
 
     private string GetToolbarText() => _toolbarMode switch

--- a/src/Relego.Cli/Tui/TuiApp.cs
+++ b/src/Relego.Cli/Tui/TuiApp.cs
@@ -5,11 +5,11 @@ using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using Relego.Cli.Infrastructure;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 
 namespace Relego.Cli.Tui;
 
-public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWorkflow, string serverUrl, string version)
+public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow syncWorkflow, string serverUrl, string version)
 {
     private const int SplashTopPadding = 1;
     private const int ExitConfirmationWidth = 56;
@@ -33,7 +33,7 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsSyncWorkflow syncWo
     ];
 
     private readonly RelegoHttpClient _client = client;
-    private readonly ClippingsSyncWorkflow _syncWorkflow = syncWorkflow;
+    private readonly ClippingsImportWorkflow _syncWorkflow = syncWorkflow;
     private readonly StatusChrome _chrome = new(serverUrl, version);
     private readonly Stack<IScreen> _screens = new();
     private IApplication? _app;

--- a/src/Relego.Tests/Cli/ClippingsImportWorkflowTests.cs
+++ b/src/Relego.Tests/Cli/ClippingsImportWorkflowTests.cs
@@ -3,18 +3,18 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Relego.Cli.Infrastructure;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 using Relego.Core.Contracts;
 
 namespace Relego.Tests.Cli;
 
-public sealed class ClippingsSyncWorkflowTests : IDisposable
+public sealed class ClippingsImportWorkflowTests : IDisposable
 {
     private readonly string _tempDir;
 
-    public ClippingsSyncWorkflowTests()
+    public ClippingsImportWorkflowTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"relego-sync-workflow-{Guid.NewGuid():N}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"relego-import-workflow-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }
 
@@ -35,12 +35,12 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
             """));
         using var harness = CreateWorkflowHarness(handler);
 
-        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsImportOptions
         {
             FilePath = filePath
         }, CancellationToken.None);
 
-        Assert.Equal(ClippingsSyncStatus.Succeeded, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.Succeeded, outcome.Status);
         Assert.NotNull(outcome.ParseResult);
         Assert.NotNull(outcome.Response);
         Assert.Equal(5, outcome.Response!.NewHighlights);
@@ -80,12 +80,12 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
         using var handler = new CapturingHandler(_ => throw new Xunit.Sdk.XunitException("Upload should not be attempted for an empty clippings file."));
         using var harness = CreateWorkflowHarness(handler);
 
-        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsImportOptions
         {
             FilePath = filePath
         }, CancellationToken.None);
 
-        Assert.Equal(ClippingsSyncStatus.NoHighlightsFound, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.NoHighlightsFound, outcome.Status);
         Assert.Equal(0, handler.RequestCount);
     }
 
@@ -95,12 +95,12 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
         using var handler = new CapturingHandler(_ => throw new Xunit.Sdk.XunitException("Upload should not be attempted for a missing clippings file."));
         using var harness = CreateWorkflowHarness(handler);
 
-        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsImportOptions
         {
             ResolvePathAsync = (_, _) => ValueTask.FromResult<string?>("/missing/My Clippings.txt")
         }, CancellationToken.None);
 
-        Assert.Equal(ClippingsSyncStatus.FileNotFound, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.FileNotFound, outcome.Status);
         Assert.Equal(0, handler.RequestCount);
     }
 
@@ -111,13 +111,13 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
         using var handler = new CapturingHandler(_ => throw new Xunit.Sdk.XunitException("Upload should not be attempted when parsing fails."));
         using var harness = CreateWorkflowHarness(handler);
 
-        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsImportOptions
         {
             FilePath = filePath,
             ParseAsync = static (_, _) => throw new InvalidDataException("boom")
         }, CancellationToken.None);
 
-        Assert.Equal(ClippingsSyncStatus.ParseFailed, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.ParseFailed, outcome.Status);
         Assert.Equal("boom", outcome.Message);
         Assert.IsType<InvalidDataException>(outcome.Error);
         Assert.Equal(0, handler.RequestCount);
@@ -130,12 +130,12 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
         using var handler = new CapturingHandler(_ => throw new HttpRequestException("Connection refused"));
         using var harness = CreateWorkflowHarness(handler);
 
-        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsSyncOptions
+        var outcome = await harness.Workflow.ExecuteAsync(new ClippingsImportOptions
         {
             FilePath = filePath
         }, CancellationToken.None);
 
-        Assert.Equal(ClippingsSyncStatus.ServerError, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.ServerError, outcome.Status);
         Assert.Equal("Connection refused", outcome.Message);
         Assert.IsType<HttpRequestException>(outcome.Error);
         Assert.Equal(1, handler.RequestCount);
@@ -148,7 +148,7 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
             BaseAddress = new Uri("http://localhost:5000")
         };
 
-        return new WorkflowHarness(httpClient, new ClippingsSyncWorkflow(new RelegoHttpClient(httpClient), NullLogger<ClippingsSyncWorkflow>.Instance));
+        return new WorkflowHarness(httpClient, new ClippingsImportWorkflow(new RelegoHttpClient(httpClient), NullLogger<ClippingsImportWorkflow>.Instance));
     }
 
     private string CreateClippingsFile(string content)
@@ -180,9 +180,9 @@ public sealed class ClippingsSyncWorkflowTests : IDisposable
         }
     }
 
-    private sealed class WorkflowHarness(HttpClient httpClient, ClippingsSyncWorkflow workflow) : IDisposable
+    private sealed class WorkflowHarness(HttpClient httpClient, ClippingsImportWorkflow workflow) : IDisposable
     {
-        public ClippingsSyncWorkflow Workflow { get; } = workflow;
+        public ClippingsImportWorkflow Workflow { get; } = workflow;
 
         public void Dispose()
         {

--- a/src/Relego.Tests/Cli/ImportCommandTests.cs
+++ b/src/Relego.Tests/Cli/ImportCommandTests.cs
@@ -3,16 +3,16 @@ using RichardSzalay.MockHttp;
 using Spectre.Console.Cli;
 using Relego.Cli.Commands;
 using Relego.Cli.Infrastructure;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 
 namespace Relego.Tests.Cli;
 
-public sealed class SyncCommandTests : IDisposable
+public sealed class ImportCommandTests : IDisposable
 {
     private readonly MockHttpMessageHandler _mockHttp = new();
     private readonly string _tempDir;
 
-    public SyncCommandTests()
+    public ImportCommandTests()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), $"relego-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
@@ -26,7 +26,7 @@ public sealed class SyncCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task Sync_WithValidFile_ReturnsZero()
+    public async Task Import_WithValidFile_ReturnsZero()
     {
         var filePath = CreateClippingsFile(SampleClippings);
 
@@ -35,43 +35,43 @@ public sealed class SyncCommandTests : IDisposable
                 {"newHighlights":5,"duplicateHighlights":2,"newBooks":3,"newAuthors":2}
                 """);
 
-        var exitCode = await RunSyncCommand(filePath);
+        var exitCode = await RunImportCommand(filePath);
 
         Assert.Equal(0, exitCode);
     }
 
     [Fact]
-    public async Task Sync_WithEmptyFile_ReturnsZero()
+    public async Task Import_WithEmptyFile_ReturnsZero()
     {
         var filePath = CreateClippingsFile("");
 
-        var exitCode = await RunSyncCommand(filePath);
+        var exitCode = await RunImportCommand(filePath);
 
         Assert.Equal(0, exitCode);
     }
 
     [Fact]
-    public async Task Sync_FileNotFound_ReturnsOne()
+    public async Task Import_FileNotFound_ReturnsOne()
     {
-        var exitCode = await RunSyncCommand("/nonexistent/path/My Clippings.txt");
+        var exitCode = await RunImportCommand("/nonexistent/path/My Clippings.txt");
 
         Assert.Equal(1, exitCode);
     }
 
     [Fact]
-    public async Task Sync_ServerUnreachable_ReturnsOne()
+    public async Task Import_ServerUnreachable_ReturnsOne()
     {
         var filePath = CreateClippingsFile(SampleClippings);
 
         _mockHttp.When(HttpMethod.Post, "http://localhost:5000/sync")
             .Throw(new HttpRequestException("Connection refused"));
 
-        var exitCode = await RunSyncCommand(filePath);
+        var exitCode = await RunImportCommand(filePath);
 
         Assert.Equal(1, exitCode);
     }
 
-    private async Task<int> RunSyncCommand(string filePath)
+    private async Task<int> RunImportCommand(string filePath)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -82,7 +82,7 @@ public sealed class SyncCommandTests : IDisposable
             httpClient.BaseAddress = new Uri("http://localhost:5000");
             return new RelegoHttpClient(httpClient);
         });
-        services.AddTransient<ClippingsSyncWorkflow>();
+        services.AddTransient<ClippingsImportWorkflow>();
 
         var registrar = new TypeRegistrar(services.BuildServiceProvider());
         var app = new CommandApp(registrar);
@@ -90,10 +90,10 @@ public sealed class SyncCommandTests : IDisposable
         app.Configure(config =>
         {
             config.SetApplicationName("relego");
-            config.AddCommand<SyncCommand>("sync");
+            config.AddCommand<ImportCommand>("import");
         });
 
-        return await app.RunAsync(["sync", filePath]);
+        return await app.RunAsync(["import", filePath]);
     }
 
     private string CreateClippingsFile(string content)

--- a/src/Relego.Tests/Tui/BookListScreenTests.cs
+++ b/src/Relego.Tests/Tui/BookListScreenTests.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using RichardSzalay.MockHttp;
 using Relego.Cli.Infrastructure;
-using Relego.Cli.Sync;
+using Relego.Cli.Import;
 using Relego.Cli.Tui;
 
 namespace Relego.Tests.Tui;
@@ -112,15 +112,15 @@ public sealed class BookListScreenTests : IDisposable
     }
 
     [Fact]
-    public async Task TryHandleShortcutKey_I_FocusesSyncField()
+    public async Task TryHandleShortcutKey_I_FocusesImportField()
     {
         var screen = await CreateScreenAsync();
-        var focusedSyncField = false;
+        var focusedImportField = false;
 
-        var handled = screen.TryHandleShortcutKey('i', _ => { }, null, null, () => focusedSyncField = true);
+        var handled = screen.TryHandleShortcutKey('i', _ => { }, null, null, () => focusedImportField = true);
 
         Assert.True(handled);
-        Assert.True(focusedSyncField);
+        Assert.True(focusedImportField);
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public sealed class BookListScreenTests : IDisposable
         ConfigureSupplementaryEndpoints(mockHttp);
 
         var releClient = CreateRelegoClient(mockHttp);
-        var workflow = new ClippingsSyncWorkflow(releClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var workflow = new ClippingsImportWorkflow(releClient, NullLogger<ClippingsImportWorkflow>.Instance);
         var screen = new BookListScreen(releClient, workflow);
         await screen.InitializeAsync(CancellationToken.None);
 
@@ -176,32 +176,32 @@ public sealed class BookListScreenTests : IDisposable
     }
 
     [Fact]
-    public async Task CancelSyncPrompt_LeavesScreenStable()
+    public async Task CancelImportPrompt_LeavesScreenStable()
     {
         var screen = await CreateScreenAsync();
 
         SetSyncPromptState(screen, syncPathInput: "/tmp/My Clippings.txt");
-        screen.CancelSyncPrompt();
+        screen.CancelImportPrompt();
 
-        Assert.False(screen.IsSyncPromptActive);
+        Assert.False(screen.IsImportPromptActive);
     }
 
     [Fact]
-    public async Task SubmitSyncAsync_WithBlankPath_SetsValidationFeedback()
+    public async Task SubmitImportAsync_WithBlankPath_SetsValidationFeedback()
     {
         var screen = await CreateScreenAsync();
 
         SetSyncPromptState(screen, syncPathInput: string.Empty);
-        var outcome = await screen.SubmitSyncAsync(string.Empty);
+        var outcome = await screen.SubmitImportAsync(string.Empty);
 
-        Assert.Equal(ClippingsSyncStatus.Cancelled, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.Cancelled, outcome.Status);
         Assert.Equal("Enter a path to My Clippings.txt or press Esc to cancel.", screen.FeedbackMessage);
         Assert.True(screen.FeedbackIsError);
-        Assert.True(screen.IsSyncPromptActive);
+        Assert.True(screen.IsImportPromptActive);
     }
 
     [Fact]
-    public async Task SubmitSyncAsync_OnSuccess_RefreshesBooksAndClosesPrompt()
+    public async Task SubmitImportAsync_OnSuccess_RefreshesBooksAndClosesPrompt()
     {
         using var mockHttp = new MockHttpMessageHandler(BackendDefinitionBehavior.Always);
 
@@ -247,24 +247,24 @@ public sealed class BookListScreenTests : IDisposable
         ConfigureSupplementaryEndpoints(mockHttp);
 
         var releClient = CreateRelegoClient(mockHttp);
-        var workflow = new ClippingsSyncWorkflow(releClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var workflow = new ClippingsImportWorkflow(releClient, NullLogger<ClippingsImportWorkflow>.Instance);
         var screen = new BookListScreen(releClient, workflow);
         await screen.InitializeAsync(CancellationToken.None);
 
         var filePath = CreateClippingsFile();
         SetSyncPromptState(screen, detectedPath: filePath, syncPathInput: filePath);
-        var outcome = await screen.SubmitSyncAsync(filePath);
+        var outcome = await screen.SubmitImportAsync(filePath);
 
-        Assert.Equal(ClippingsSyncStatus.Succeeded, outcome.Status);
+        Assert.Equal(ClippingsImportStatus.Succeeded, outcome.Status);
         Assert.Single(screen.Books);
-        Assert.False(screen.IsSyncPromptActive);
+        Assert.False(screen.IsImportPromptActive);
         Assert.False(screen.FeedbackIsError);
-        Assert.Contains("Sync complete.", screen.FeedbackMessage);
+        Assert.Contains("Import complete.", screen.FeedbackMessage);
         mockHttp.VerifyNoOutstandingExpectation();
     }
 
     [Fact]
-    public async Task SubmitSyncAsync_OnServerError_ShowsRetryableFeedback()
+    public async Task SubmitImportAsync_OnServerError_ShowsRetryableFeedback()
     {
         using var mockHttp = new MockHttpMessageHandler(BackendDefinitionBehavior.Always);
         ConfigureHighlightEndpoints(mockHttp);
@@ -274,18 +274,18 @@ public sealed class BookListScreenTests : IDisposable
             .Throw(new HttpRequestException("Connection refused"));
 
         var releClient = CreateRelegoClient(mockHttp);
-        var workflow = new ClippingsSyncWorkflow(releClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var workflow = new ClippingsImportWorkflow(releClient, NullLogger<ClippingsImportWorkflow>.Instance);
         var screen = new BookListScreen(releClient, workflow);
         await screen.InitializeAsync(CancellationToken.None);
 
         var filePath = CreateClippingsFile();
         SetSyncPromptState(screen, detectedPath: filePath, syncPathInput: filePath);
-        var outcome = await screen.SubmitSyncAsync(filePath);
+        var outcome = await screen.SubmitImportAsync(filePath);
 
-        Assert.Equal(ClippingsSyncStatus.ServerError, outcome.Status);
-        Assert.True(screen.IsSyncPromptActive);
+        Assert.Equal(ClippingsImportStatus.ServerError, outcome.Status);
+        Assert.True(screen.IsImportPromptActive);
         Assert.True(screen.FeedbackIsError);
-        Assert.Equal("Sync failed: Connection refused", screen.FeedbackMessage);
+        Assert.Equal("Import failed: Connection refused", screen.FeedbackMessage);
     }
 
     private async Task<BookListScreen> CreateScreenAsync(int total = 3, string? itemsJson = null)

--- a/src/Relego.Tests/Tui/BookListScreenTests.cs
+++ b/src/Relego.Tests/Tui/BookListScreenTests.cs
@@ -299,7 +299,7 @@ public sealed class BookListScreenTests : IDisposable
         ConfigureSupplementaryEndpoints(mockHttp);
 
         var releClient = CreateRelegoClient(mockHttp);
-        var workflow = new ClippingsSyncWorkflow(releClient, NullLogger<ClippingsSyncWorkflow>.Instance);
+        var workflow = new ClippingsImportWorkflow(releClient, NullLogger<ClippingsImportWorkflow>.Instance);
         var screen = new BookListScreen(releClient, workflow);
         await screen.InitializeAsync(CancellationToken.None);
         return screen;

--- a/src/landing/pages/index.astro
+++ b/src/landing/pages/index.astro
@@ -14,9 +14,9 @@ import heroImage from '../assets/hero-kindle.jpg';
 const steps = [
 	{
 		number: 1,
-		title: 'Sync your highlights',
+		title: 'Import your highlights',
 		description: 'Connect your Kindle and run a single command.',
-		content: 'Plug your Kindle via USB and run relego sync. The CLI detects the device, reads My Clippings.txt, parses every highlight and note, then stores them locally. No cloud upload, no account required. Your data stays on your machine.',
+		content: 'Plug your Kindle via USB and run relego import. The CLI detects the device, reads My Clippings.txt, parses every highlight and note, then stores them locally. No cloud upload, no account required. Your data stays on your machine.',
 	},
 	{
 		number: 2,

--- a/src/landing/playwright.config.ts
+++ b/src/landing/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
 	testDir: './tests',
 	retries: process.env.CI ? 2 : 0,
 	use: {
-		baseURL: 'http://localhost:4321/',
+		baseURL: 'http://localhost:4321/relego/',
 		screenshot: 'only-on-failure',
 	},
 	projects: [
@@ -17,7 +17,7 @@ export default defineConfig({
 	],
 	webServer: {
 		command: 'npm run dev -- --host 0.0.0.0 --port 4321',
-		url: 'http://localhost:4321/',
+		url: 'http://localhost:4321/relego/',
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,
 	},

--- a/src/landing/tests/accessibility.spec.ts
+++ b/src/landing/tests/accessibility.spec.ts
@@ -3,7 +3,7 @@ import AxeBuilder from '@axe-core/playwright';
 
 test.describe('Accessibility', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
+		await page.goto('/relego/');
 	});
 
 	test('full page has no critical or serious axe violations', async ({ page }) => {

--- a/src/landing/tests/content-sections.spec.ts
+++ b/src/landing/tests/content-sections.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Content Sections', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
+		await page.goto('/relego/');
 	});
 
 	test('sections appear in correct order', async ({ page }) => {

--- a/src/landing/tests/content-sections.spec.ts
+++ b/src/landing/tests/content-sections.spec.ts
@@ -36,7 +36,7 @@ test.describe('Content Sections', () => {
 		const section = page.locator('#getting-started');
 		const tabs = section.locator('[data-step-tab]');
 		await expect(tabs).toHaveCount(3);
-		await expect(tabs.nth(0).locator('h3')).toHaveText('Sync your highlights');
+		await expect(tabs.nth(0).locator('h3')).toHaveText('Import your highlights');
 		await expect(tabs.nth(1).locator('h3')).toHaveText('Let the server schedule');
 		await expect(tabs.nth(2).locator('h3')).toHaveText('Read on your Kindle');
 	});

--- a/src/landing/tests/faq.spec.ts
+++ b/src/landing/tests/faq.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('FAQ Section', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
+		await page.goto('/relego/');
 	});
 
 	test('renders 6 FAQ accordion items with visible questions', async ({ page }) => {

--- a/src/landing/tests/hero-readme-screenshot.spec.ts
+++ b/src/landing/tests/hero-readme-screenshot.spec.ts
@@ -9,7 +9,7 @@ test('capture dark hero section for README', async ({ page }) => {
 	await page.emulateMedia({ colorScheme: 'dark' });
 	await page.setViewportSize({ width: 1600, height: 1000 });
 
-	await page.goto('/');
+	await page.goto('/relego/');
 	await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 
 	// Ensure the hero background image has finished loading.

--- a/src/landing/tests/navigation.spec.ts
+++ b/src/landing/tests/navigation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Navigation', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
+		await page.goto('/relego/');
 	});
 
 	test('navbar renders with "relego." logotype text', async ({ page }) => {

--- a/src/landing/tests/theme.spec.ts
+++ b/src/landing/tests/theme.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Theme Toggle', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.emulateMedia({ colorScheme: 'light' });
-		await page.goto('/');
+		await page.goto('/relego/');
 	});
 
 	test('clicking theme toggle switches data-theme from light to dark', async ({ page }) => {


### PR DESCRIPTION
## Summary

Standardizes the canonical verb to `import` across CLI, TUI, and docs, replacing `sync` (no backward-compat alias).

## Changes

- **CLI command**: `relego sync` → `relego import`
- **Namespace/folder**: `Relego.Cli.Sync/` → `Relego.Cli.Import/`
- **Types renamed**: `ClippingsSyncWorkflow/Options/Status/Outcome` → `ClippingsImport*`
- **User-facing messages**: "Sync cancelled/complete/failed" → "Import …"
- **TUI placeholder**: "Press Enter to sync or edit the path" → "Press Enter to import or edit the path"
- **README**: section heading, all command examples updated
- **Tests**: renamed and updated to match
- **Version bump**: `Relego.Cli` 0.11.3 → 0.11.4

Closes #269