### PR TITLE
Rework TUI popup UX for consistent modals

### DIFF
--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.5</Version>
+    <Version>0.11.6</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -58,6 +58,30 @@ public sealed class BookListScreen(
     private Action? _refreshVisibleBooks;
     private ShortcutListView? _listView;
     private ToolbarMode _toolbarMode;
+    private bool _renameOpen;
+    private BookViewModel? _renameBook;
+    private FrameView? _renameFrame;
+    private TextField? _renameInputField;
+    private Label? _modalBackdrop;
+    private Action? _uiStateObserver;
+
+    private static readonly IReadOnlyList<(string Key, string Label)> RenamePopupKeyHints =
+    [
+        ("Enter", "Save"),
+        ("Esc", "Cancel")
+    ];
+
+    private static readonly IReadOnlyList<(string Key, string Label)> DefaultKeyHints =
+    [
+        ("↑↓", "Navigate"),
+        ("Enter", "View"),
+        ("I", "Import"),
+        ("N", "Rename"),
+        ("S", "Settings"),
+        ("/", "Search"),
+        ("R", "Refresh"),
+        ("Q", "Quit")
+    ];
 
     public IReadOnlyList<BookViewModel> Books => _books;
 
@@ -71,6 +95,10 @@ public sealed class BookListScreen(
 
     public bool IsRenamePromptActive => _toolbarMode == ToolbarMode.Rename;
 
+    public bool RenameOpen => _renameOpen;
+
+    public BookViewModel? RenameBook => _renameBook;
+
     public string SearchQuery => _searchQuery;
 
     public string ImportPathInput => _syncPathInput;
@@ -82,16 +110,12 @@ public sealed class BookListScreen(
     public string Title => string.Empty;
 
     public IReadOnlyList<(string Key, string Label)> KeyHints =>
-    [
-        ("↑↓", "Navigate"),
-        ("Enter", "View"),
-        ("I", "Import"),
-        ("N", "Rename"),
-        ("S", "Settings"),
-        ("/", "Search"),
-        ("R", "Refresh"),
-        ("Q", "Quit")
-    ];
+        _renameOpen ? RenamePopupKeyHints : DefaultKeyHints;
+
+    public void RegisterUiStateObserver(Action? onStateChanged)
+    {
+        _uiStateObserver = onStateChanged;
+    }
 
     private readonly record struct TableLayout(int TitleWidth, int AuthorWidth, int HighlightsWidth);
 
@@ -398,6 +422,39 @@ public sealed class BookListScreen(
         container.SubViewsLaidOut += (_, _) => UpdateTableLayout();
         listView.ViewportChanged += (_, _) => UpdateTableLayout();
 
+        _modalBackdrop = ModalChrome.CreateBackdrop();
+
+        const int RenamePopupWidth = 68;
+        const int RenamePopupHeight = 6;
+
+        _renameFrame = ModalChrome.CreateFrame(RenamePopupWidth, RenamePopupHeight, "Rename Book");
+
+        var renameLabel = new Label
+        {
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill(2),
+            Height = 1,
+            Text = "Enter new title:",
+            CanFocus = false
+        };
+        renameLabel.SetScheme(ModalChrome.CreateBodyTextScheme());
+
+        _renameInputField = new TextField
+        {
+            X = 1,
+            Y = 2,
+            Width = Dim.Fill(2),
+            Height = 1,
+            CanFocus = true,
+            Visible = false
+        };
+        _renameInputField.SetScheme(ModalChrome.CreateBodyTextScheme());
+        _renameInputField.KeyDown += async (_, key) => await HandleRenameKeyDownAsync(key).ConfigureAwait(false);
+
+        _renameFrame.Add(renameLabel, _renameInputField);
+        container.Add(_modalBackdrop, _renameFrame);
+
         container.Add(titleLabel, headerLabel, headerRuleLabel, listView);
         _listView = listView;
         _refreshVisibleBooks = RefreshVisibleBooks;
@@ -511,18 +568,77 @@ public sealed class BookListScreen(
 
     public void BeginRenamePrompt(BookViewModel book)
     {
-        _toolbarMode = ToolbarMode.Rename;
-        _isSearchActive = false;
+        OpenRenamePopup(book);
+    }
+
+    private void OpenRenamePopup(BookViewModel book)
+    {
+        _renameOpen = true;
+        _renameBook = book;
         _renameInput = book.Title;
 
-        if (_searchField is not null)
+        if (_renameInputField is not null)
         {
-            _searchField.Text = _renameInput;
-            _searchField.SetFocus();
-            _searchField.MoveEnd();
+            _renameInputField.Text = _renameInput;
+            _renameInputField.Visible = true;
+            _renameInputField.SetFocus();
+            _renameInputField.MoveEnd();
         }
 
-        UpdateToolbarChrome();
+        ModalChrome.SetBackdropVisible(_modalBackdrop, visible: true);
+        _renameFrame?.SetFocus();
+        NotifyUiStateChanged();
+    }
+
+    private void CloseRenamePopup()
+    {
+        _renameOpen = false;
+        _renameBook = null;
+        _renameInput = string.Empty;
+
+        if (_renameInputField is not null)
+        {
+            _renameInputField.Visible = false;
+            _renameInputField.Text = string.Empty;
+        }
+
+        if (_renameFrame is not null)
+        {
+            _renameFrame.Visible = false;
+        }
+
+        ModalChrome.SetBackdropVisible(_modalBackdrop, visible: false);
+
+        if (_listView is not null)
+        {
+            _listView.SetFocus();
+        }
+
+        NotifyUiStateChanged();
+    }
+
+    private async Task HandleRenameKeyDownAsync(Key key)
+    {
+        if (!_renameOpen || _renameBook is null)
+        {
+            return;
+        }
+
+        switch (key.KeyCode)
+        {
+            case KeyCode.Enter:
+                await SubmitRenameAsync(_renameInputField?.Text, CancellationToken.None).ConfigureAwait(false);
+                return;
+
+            case KeyCode.Esc:
+                CloseRenamePopup();
+                return;
+        }
+    }
+
+    private void NotifyUiStateChanged()
+    {
+        _uiStateObserver?.Invoke();
     }
 
     public void CancelRenamePrompt()
@@ -552,13 +668,14 @@ public sealed class BookListScreen(
         if (string.IsNullOrWhiteSpace(resolvedTitle))
         {
             SetFeedback("Enter a title or press Esc to cancel.", isError: true);
+            CloseRenamePopup();
             return;
         }
 
         var book = GetSelectedBook();
         if (book is null)
         {
-            CancelRenamePrompt();
+            CloseRenamePopup();
             return;
         }
 
@@ -571,27 +688,27 @@ public sealed class BookListScreen(
         catch (HttpRequestException)
         {
             SetFeedback("Cannot reach server.", isError: true);
-            CancelRenamePrompt();
+            CloseRenamePopup();
             return;
         }
 
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             SetFeedback($"Book {book.BookId} not found.", isError: true);
-            CancelRenamePrompt();
+            CloseRenamePopup();
             return;
         }
 
         if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
         {
             SetFeedback($"A book titled \"{resolvedTitle}\" by the same author already exists.", isError: true);
-            CancelRenamePrompt();
+            CloseRenamePopup();
             return;
         }
 
         response.EnsureSuccessStatusCode();
 
-        CancelRenamePrompt();
+        CloseRenamePopup();
         SetFeedback($"Book renamed to \"{resolvedTitle}\".", isError: false);
 
         // Reload so the list reflects the new title

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -18,6 +18,24 @@ public sealed class BookListScreen(
     Action? onConnectionFailure = null,
     Func<CancellationToken, Task>? refreshConnectionStatusAsync = null) : IScreen
 {
+    private static readonly IReadOnlyList<(string Key, string Label)> DefaultKeyHints =
+    [
+        ("↑↓", "Navigate"),
+        ("Enter", "View"),
+        ("I", "Import"),
+        ("N", "Rename book title"),
+        ("S", "Settings"),
+        ("/", "Search"),
+        ("R", "Refresh"),
+        ("Q", "Quit")
+    ];
+
+    private static readonly IReadOnlyList<(string Key, string Label)> RenamePromptKeyHints =
+    [
+        ("Enter", "Save"),
+        ("Esc", "Cancel")
+    ];
+
     private const int PageSize = 100;
     private const int DefaultTableWidth = 80;
     private const int HighlightsColumnWidth = 10;
@@ -26,11 +44,12 @@ public sealed class BookListScreen(
     private const int PreferredAuthorColumnWidth = 30;
     private const int TableHorizontalPadding = 2;
     private const string SectionTitle = "Books";
+    private const int RenamePopupWidth = 68;
+    private const int RenamePopupHeight = 7;
     private const string SearchPlaceholderIdle = "type / to search";
     private const string SearchPlaceholderFocused = "Press Esc to return to the list";
     private const string SyncPlaceholderDetected = "Press Enter to import or edit the path";
     private const string SyncPlaceholderManual = "Enter the path to My Clippings.txt";
-    private const string RenamePlaceholder = "Enter new title, press Enter to confirm or Esc to cancel";
 
     private readonly RelegoHttpClient _client = client;
     private readonly ClippingsImportWorkflow _syncWorkflow = syncWorkflow;
@@ -40,6 +59,7 @@ public sealed class BookListScreen(
     private List<BookViewModel> _filteredBooks = [];
     private int _selectedIndex;
     private bool _isSearchActive;
+    private bool _isRenamePromptActive;
     private string _searchQuery = string.Empty;
     private string _syncPathInput = string.Empty;
     private string _renameInput = string.Empty;
@@ -52,36 +72,17 @@ public sealed class BookListScreen(
     private Label? _errorLabel;
     private Label? _feedbackLabel;
     private bool _viewHasBooksList;
+    private bool _hasRenamePromptView;
     private string? _feedbackMessage;
     private bool _feedbackIsError;
+    private Label? _renameBackdrop;
+    private FrameView? _renameFrame;
+    private SearchTextField? _renameField;
     private Action<ScreenResult>? _navigate;
     private Action? _refreshVisibleBooks;
+    private Action? _uiStateObserver;
     private ShortcutListView? _listView;
     private ToolbarMode _toolbarMode;
-    private bool _renameOpen;
-    private BookViewModel? _renameBook;
-    private FrameView? _renameFrame;
-    private TextField? _renameInputField;
-    private Label? _modalBackdrop;
-    private Action? _uiStateObserver;
-
-    private static readonly IReadOnlyList<(string Key, string Label)> RenamePopupKeyHints =
-    [
-        ("Enter", "Save"),
-        ("Esc", "Cancel")
-    ];
-
-    private static readonly IReadOnlyList<(string Key, string Label)> DefaultKeyHints =
-    [
-        ("↑↓", "Navigate"),
-        ("Enter", "View"),
-        ("I", "Import"),
-        ("N", "Rename"),
-        ("S", "Settings"),
-        ("/", "Search"),
-        ("R", "Refresh"),
-        ("Q", "Quit")
-    ];
 
     public IReadOnlyList<BookViewModel> Books => _books;
 
@@ -93,11 +94,7 @@ public sealed class BookListScreen(
 
     public bool IsImportPromptActive => _toolbarMode == ToolbarMode.SyncPath;
 
-    public bool IsRenamePromptActive => _toolbarMode == ToolbarMode.Rename;
-
-    public bool RenameOpen => _renameOpen;
-
-    public BookViewModel? RenameBook => _renameBook;
+    public bool IsRenamePromptActive => _isRenamePromptActive;
 
     public string SearchQuery => _searchQuery;
 
@@ -109,24 +106,22 @@ public sealed class BookListScreen(
 
     public string Title => string.Empty;
 
-    public IReadOnlyList<(string Key, string Label)> KeyHints =>
-        _renameOpen ? RenamePopupKeyHints : DefaultKeyHints;
-
-    public void RegisterUiStateObserver(Action? onStateChanged)
-    {
-        _uiStateObserver = onStateChanged;
-    }
+    public IReadOnlyList<(string Key, string Label)> KeyHints => _isRenamePromptActive ? RenamePromptKeyHints : DefaultKeyHints;
 
     private readonly record struct TableLayout(int TitleWidth, int AuthorWidth, int HighlightsWidth);
 
     private enum ToolbarMode
     {
         Search,
-        SyncPath,
-        Rename
+        SyncPath
     }
 
     public int ToolbarHeight => 4;
+
+    public void RegisterUiStateObserver(Action? onStateChanged)
+    {
+        _uiStateObserver = onStateChanged;
+    }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Views are owned by the window hierarchy")]
     public View? CreateToolbarView(Action<ScreenResult> navigate)
@@ -419,43 +414,46 @@ public sealed class BookListScreen(
 
         UpdateTableLayout();
 
+        _renameBackdrop = ModalChrome.CreateBackdrop();
+
+        var palette = TuiTheme.Palette;
+        var fieldAttribute = new Terminal.Gui.Drawing.Attribute(palette.Text, palette.Background);
+
+        _renameField = new SearchTextField
+        {
+            X = 2,
+            Y = 2,
+            Width = Dim.Fill(4),
+            Height = 1,
+            CanFocus = true,
+            Text = _renameInput
+        };
+        _renameField.SetScheme(CreateSearchFieldScheme(fieldAttribute));
+        _renameField.TextChanged += (_, _) => _renameInput = _renameField.Text ?? string.Empty;
+        _renameField.HasFocusChanged += (_, _) => UpdateRenamePromptState();
+        _renameField.Accepting += async (_, _) => await SubmitRenameAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        _renameField.KeyDown += (_, key) => HandleRenamePromptKeyDown(key);
+
+        var renameHelpLabel = new Label
+        {
+            X = 2,
+            Y = 4,
+            Width = Dim.Fill(4),
+            Height = 1,
+            Text = "Press Enter to save or Esc to cancel.",
+            CanFocus = false
+        };
+        renameHelpLabel.SetScheme(ModalChrome.CreateMutedTextScheme());
+
+        _renameFrame = ModalChrome.CreateFrame(RenamePopupWidth, RenamePopupHeight);
+        _renameFrame.KeyDown += (_, key) => HandleRenamePromptKeyDown(key);
+        _renameFrame.Add(_renameField, renameHelpLabel);
+        _hasRenamePromptView = true;
+
         container.SubViewsLaidOut += (_, _) => UpdateTableLayout();
         listView.ViewportChanged += (_, _) => UpdateTableLayout();
 
-        _modalBackdrop = ModalChrome.CreateBackdrop();
-
-        const int RenamePopupWidth = 68;
-        const int RenamePopupHeight = 6;
-
-        _renameFrame = ModalChrome.CreateFrame(RenamePopupWidth, RenamePopupHeight, "Rename Book");
-
-        var renameLabel = new Label
-        {
-            X = 1,
-            Y = 1,
-            Width = Dim.Fill(2),
-            Height = 1,
-            Text = "Enter new title:",
-            CanFocus = false
-        };
-        renameLabel.SetScheme(ModalChrome.CreateBodyTextScheme());
-
-        _renameInputField = new TextField
-        {
-            X = 1,
-            Y = 2,
-            Width = Dim.Fill(2),
-            Height = 1,
-            CanFocus = true,
-            Visible = false
-        };
-        _renameInputField.SetScheme(ModalChrome.CreateBodyTextScheme());
-        _renameInputField.KeyDown += async (_, key) => await HandleRenameKeyDownAsync(key).ConfigureAwait(false);
-
-        _renameFrame.Add(renameLabel, _renameInputField);
-        container.Add(_modalBackdrop, _renameFrame);
-
-        container.Add(titleLabel, headerLabel, headerRuleLabel, listView);
+        container.Add(titleLabel, headerLabel, headerRuleLabel, listView, _renameBackdrop, _renameFrame);
         _listView = listView;
         _refreshVisibleBooks = RefreshVisibleBooks;
         SetupContainerKeyBindings(container, listView, navigate, RefreshVisibleBooks, BeginSearchInput, () => BeginImportPrompt());
@@ -467,6 +465,8 @@ public sealed class BookListScreen(
         _selectedIndex = savedIndex;
         if (_filteredBooks.Count > 0)
             listView.SelectedItem = Math.Min(savedIndex, _filteredBooks.Count - 1);
+
+        UpdateRenamePromptState();
 
         return container;
     }
@@ -568,97 +568,28 @@ public sealed class BookListScreen(
 
     public void BeginRenamePrompt(BookViewModel book)
     {
-        OpenRenamePopup(book);
-    }
-
-    private void OpenRenamePopup(BookViewModel book)
-    {
-        _renameOpen = true;
-        _renameBook = book;
+        _isRenamePromptActive = true;
         _renameInput = book.Title;
 
-        if (_renameInputField is not null)
+        if (_hasRenamePromptView)
         {
-            _renameInputField.Text = _renameInput;
-            _renameInputField.Visible = true;
-            _renameInputField.SetFocus();
-            _renameInputField.MoveEnd();
-        }
-
-        ModalChrome.SetBackdropVisible(_modalBackdrop, visible: true);
-        _renameFrame?.SetFocus();
-        NotifyUiStateChanged();
-    }
-
-    private void CloseRenamePopup()
-    {
-        _renameOpen = false;
-        _renameBook = null;
-        _renameInput = string.Empty;
-
-        if (_renameInputField is not null)
-        {
-            _renameInputField.Visible = false;
-            _renameInputField.Text = string.Empty;
-        }
-
-        if (_renameFrame is not null)
-        {
-            _renameFrame.Visible = false;
-        }
-
-        ModalChrome.SetBackdropVisible(_modalBackdrop, visible: false);
-
-        if (_listView is not null)
-        {
-            _listView.SetFocus();
+            ShowRenamePromptView();
         }
 
         NotifyUiStateChanged();
-    }
-
-    private async Task HandleRenameKeyDownAsync(Key key)
-    {
-        if (!_renameOpen || _renameBook is null)
-        {
-            return;
-        }
-
-        switch (key.KeyCode)
-        {
-            case KeyCode.Enter:
-                await SubmitRenameAsync(_renameInputField?.Text, CancellationToken.None).ConfigureAwait(false);
-                return;
-
-            case KeyCode.Esc:
-                CloseRenamePopup();
-                return;
-        }
-    }
-
-    private void NotifyUiStateChanged()
-    {
-        _uiStateObserver?.Invoke();
     }
 
     public void CancelRenamePrompt()
     {
-        _toolbarMode = ToolbarMode.Search;
+        _isRenamePromptActive = false;
         _renameInput = string.Empty;
 
-        if (_searchField is null)
+        if (_hasRenamePromptView)
         {
-            return;
+            HideRenamePromptView();
         }
 
-        _searchField.Text = _searchQuery;
-
-        if (_listView is not null)
-            _listView.SetFocus();
-        else
-            _searchField.SetFocus();
-
-        UpdateToolbarChrome();
+        NotifyUiStateChanged();
     }
 
     public async Task SubmitRenameAsync(string? newTitle = null, CancellationToken cancellationToken = default)
@@ -668,14 +599,13 @@ public sealed class BookListScreen(
         if (string.IsNullOrWhiteSpace(resolvedTitle))
         {
             SetFeedback("Enter a title or press Esc to cancel.", isError: true);
-            CloseRenamePopup();
             return;
         }
 
         var book = GetSelectedBook();
         if (book is null)
         {
-            CloseRenamePopup();
+            CancelRenamePrompt();
             return;
         }
 
@@ -688,27 +618,27 @@ public sealed class BookListScreen(
         catch (HttpRequestException)
         {
             SetFeedback("Cannot reach server.", isError: true);
-            CloseRenamePopup();
+            CancelRenamePrompt();
             return;
         }
 
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             SetFeedback($"Book {book.BookId} not found.", isError: true);
-            CloseRenamePopup();
+            CancelRenamePrompt();
             return;
         }
 
         if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
         {
             SetFeedback($"A book titled \"{resolvedTitle}\" by the same author already exists.", isError: true);
-            CloseRenamePopup();
+            CancelRenamePrompt();
             return;
         }
 
         response.EnsureSuccessStatusCode();
 
-        CloseRenamePopup();
+        CancelRenamePrompt();
         SetFeedback($"Book renamed to \"{resolvedTitle}\".", isError: false);
 
         // Reload so the list reflects the new title
@@ -839,6 +769,11 @@ public sealed class BookListScreen(
         Action? focusSearchField,
         Action? focusSyncField)
     {
+        if (_isRenamePromptActive)
+        {
+            return false;
+        }
+
         switch (char.ToLowerInvariant(shortcutKey))
         {
             case 'q':
@@ -1090,10 +1025,6 @@ public sealed class BookListScreen(
         {
             _syncPathInput = _searchField.Text ?? string.Empty;
         }
-        else if (_toolbarMode == ToolbarMode.Rename)
-        {
-            _renameInput = _searchField.Text ?? string.Empty;
-        }
         else
         {
             _searchQuery = _searchField.Text ?? string.Empty;
@@ -1117,17 +1048,6 @@ public sealed class BookListScreen(
             return;
         }
 
-        if (_toolbarMode == ToolbarMode.Rename)
-        {
-            if (key.KeyCode == KeyCode.Esc)
-            {
-                CancelRenamePrompt();
-                key.Handled = true;
-            }
-
-            return;
-        }
-
         if (key.KeyCode is KeyCode.Esc or KeyCode.CursorDown)
         {
             LeaveSearchInput(_refreshVisibleBooks);
@@ -1138,12 +1058,6 @@ public sealed class BookListScreen(
 
     private async Task HandleToolbarSubmitAsync()
     {
-        if (_toolbarMode == ToolbarMode.Rename)
-        {
-            await SubmitRenameAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
-            return;
-        }
-
         if (_toolbarMode != ToolbarMode.SyncPath)
         {
             return;
@@ -1152,10 +1066,24 @@ public sealed class BookListScreen(
         await SubmitImportAsync(cancellationToken: CancellationToken.None).ConfigureAwait(false);
     }
 
+    private void HandleRenamePromptKeyDown(Key key)
+    {
+        if (key.KeyCode == KeyCode.Esc)
+        {
+            CancelRenamePrompt();
+            key.Handled = true;
+            return;
+        }
+
+        if (key.KeyCode == KeyCode.Tab)
+        {
+            key.Handled = true;
+        }
+    }
+
     private string GetToolbarText() => _toolbarMode switch
     {
         ToolbarMode.SyncPath => _syncPathInput,
-        ToolbarMode.Rename => _renameInput,
         _ => _searchQuery
     };
 
@@ -1167,9 +1095,6 @@ public sealed class BookListScreen(
                 ? SyncPlaceholderDetected
                 : SyncPlaceholderManual;
         }
-
-        if (_toolbarMode == ToolbarMode.Rename)
-            return RenamePlaceholder;
 
         return hasFocus ? SearchPlaceholderFocused : SearchPlaceholderIdle;
     }
@@ -1191,12 +1116,72 @@ public sealed class BookListScreen(
         _searchFrame.Title = _toolbarMode switch
         {
             ToolbarMode.SyncPath => " Import ",
-            ToolbarMode.Rename => " Rename ",
             _ => string.Empty
         };
         _searchPlaceholder.Visible = string.IsNullOrEmpty(_searchField.Text);
         _searchPlaceholder.Text = GetToolbarPlaceholder(_searchField.HasFocus);
+        _searchField.CanFocus = !_isRenamePromptActive;
+        _searchFrame.CanFocus = !_isRenamePromptActive;
         _searchFrame.SetScheme(CreateSearchFrameScheme(_searchField.HasFocus));
+    }
+
+    private void UpdateRenamePromptState()
+    {
+        ModalChrome.SetBackdropVisible(_renameBackdrop, _isRenamePromptActive);
+
+        if (_renameFrame is not null)
+        {
+            var isFocused = _isRenamePromptActive && ((_renameField?.HasFocus ?? false) || _renameFrame.HasFocus);
+            _renameFrame.Visible = _isRenamePromptActive;
+            _renameFrame.SetScheme(ModalChrome.CreateFrameScheme(isFocused));
+        }
+
+        if (_listView is not null)
+        {
+            _listView.CanFocus = !_isRenamePromptActive;
+        }
+
+        UpdateToolbarChrome();
+
+        if (_isRenamePromptActive)
+        {
+            _renameFrame?.SetFocus();
+            _renameField?.SetFocus();
+            _renameField?.MoveEnd();
+        }
+        else if (_listView is not null)
+        {
+            _listView.SetFocus();
+        }
+        else
+        {
+            _searchField?.SetFocus();
+        }
+    }
+
+    private void ShowRenamePromptView()
+    {
+        if (_renameField is not null)
+        {
+            _renameField.Text = _renameInput;
+        }
+
+        UpdateRenamePromptState();
+    }
+
+    private void HideRenamePromptView()
+    {
+        if (_renameField is not null)
+        {
+            _renameField.Text = string.Empty;
+        }
+
+        UpdateRenamePromptState();
+    }
+
+    private void NotifyUiStateChanged()
+    {
+        _uiStateObserver?.Invoke();
     }
 
     private Label CreateToolbarFeedbackLabel()

--- a/src/Relego.Cli/Tui/HighlightDetailScreen.cs
+++ b/src/Relego.Cli/Tui/HighlightDetailScreen.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Globalization;
+using Terminal.Gui.Drawing;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
@@ -12,6 +13,45 @@ namespace Relego.Cli.Tui;
 
 public sealed class HighlightDetailScreen : IScreen
 {
+    private static readonly IReadOnlyList<(string Key, string Label)> DefaultKeyHints =
+    [
+        ("↑↓", "Navigate"),
+        ("Enter", "Open details and actions"),
+        ("R", "Refresh"),
+        ("Esc", "Go Back"),
+        ("Q", "Quit")
+    ];
+
+    private static readonly IReadOnlyList<(string Key, string Label)> DetailActionKeyHints =
+    [
+        ("↑↓", "Navigate"),
+        ("Enter", "Use action"),
+        ("Tab", "Switch panel"),
+        ("Esc", "Close")
+    ];
+
+    private static readonly IReadOnlyList<(string Key, string Label)> DetailTextKeyHints =
+    [
+        ("↑↓", "Scroll"),
+        ("Tab", "Switch panel"),
+        ("Esc", "Close")
+    ];
+
+    private static readonly IReadOnlyList<(string Key, string Label)> WeightEditorKeyHints =
+    [
+        ("↑↓", "Adjust"),
+        ("1-5", "Set"),
+        ("Enter", "Save"),
+        ("Esc", "Cancel")
+    ];
+
+    private static readonly IReadOnlyList<(string Key, string Label)> DeleteConfirmationKeyHints =
+    [
+        ("Y", "Confirm"),
+        ("N", "Cancel"),
+        ("Esc", "Cancel")
+    ];
+
     private const int DetailPageSize = 200;
     private const int DefaultTableWidth = 80;
     private const int TableHorizontalPadding = 2;
@@ -21,13 +61,16 @@ public sealed class HighlightDetailScreen : IScreen
     private const int WeightColumnWidth = 8;
     private const int DotColumnWidth = 1;
     private const int MinimumHighlightColumnWidth = 18;
-    private const int WeightEditorWidth = 52;
-    private const int WeightEditorHeight = 7;
+    private const int WeightEditorWidth = 60;
+    private const int WeightEditorHeight = 8;
     private const int DetailPopupWidth = 78;
     private const int DetailPopupHeight = 18;
     private const int DetailLeftPaneWidth = 44;
     private const int DetailRightPaneWidth = 30;
     private const int DetailPaneSeparator = 2;
+    private const int DeleteConfirmationWidth = 60;
+    private const int DeleteConfirmationHeight = 6;
+    private const int DetailTextFallbackWidth = DetailLeftPaneWidth - 2;
     private readonly RelegoHttpClient _client;
     private readonly List<HighlightViewModel> _highlights;
     private readonly int _bookId;
@@ -47,6 +90,7 @@ public sealed class HighlightDetailScreen : IScreen
     private Label? _headerLabel;
     private Label? _headerRuleLabel;
     private Label? _statusLabel;
+    private Label? _modalBackdrop;
     private FrameView? _weightEditorFrame;
     private Label? _weightScaleLabel;
     private Label? _weightHelpLabel;
@@ -57,10 +101,9 @@ public sealed class HighlightDetailScreen : IScreen
     private FrameView? _detailActionFrame;
     private ObservableCollection<string>? _detailActionRows;
     private ListView? _detailActionList;
-    private Label? _detailTabHintKeyLabel;
-    private Label? _detailTabHintDescriptionLabel;
     private int _detailScrollOffset;
     private bool _detailFocusOnActions = true;
+    private Action? _uiStateObserver;
     private Action<ScreenResult>? _navigate;
     private string? _previewText;
     private bool _viewCreated;
@@ -110,13 +153,18 @@ public sealed class HighlightDetailScreen : IScreen
     public string Title => string.Empty;
 
     public IReadOnlyList<(string Key, string Label)> KeyHints =>
-    [
-        ("↑↓", "Navigate"),
-        ("Enter", "Open details and actions"),
-        ("R", "Refresh"),
-        ("Esc", "Go Back"),
-        ("Q", "Quit")
-    ];
+        DeleteConfirmationOpen
+            ? DeleteConfirmationKeyHints
+            : WeightEditorOpen
+                ? WeightEditorKeyHints
+                : DetailOpen
+                    ? _detailFocusOnActions ? DetailActionKeyHints : DetailTextKeyHints
+                    : DefaultKeyHints;
+
+    public void RegisterUiStateObserver(Action? onStateChanged)
+    {
+        _uiStateObserver = onStateChanged;
+    }
 
     public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
@@ -135,6 +183,8 @@ public sealed class HighlightDetailScreen : IScreen
             Height = Dim.Fill(),
             CanFocus = true
         };
+
+        _modalBackdrop = ModalChrome.CreateBackdrop();
 
         _titleLabel = new Label
         {
@@ -241,10 +291,10 @@ public sealed class HighlightDetailScreen : IScreen
             Width = Dim.Fill(),
             Height = Dim.Fill(),
             ReadOnly = true,
-            WordWrap = true,
+            WordWrap = false,
             CanFocus = true
         };
-        _detailTextView.SetScheme(CreateDetailTextViewScheme());
+        _detailTextView.SetScheme(ModalChrome.CreateBodyTextScheme());
         _detailTextView.KeyDown += async (_, key) => await HandleDetailTextKeyDownAsync(key).ConfigureAwait(false);
 
         _detailTextFrame = new FrameView
@@ -254,6 +304,7 @@ public sealed class HighlightDetailScreen : IScreen
             Width = DetailLeftPaneWidth,
             Height = Dim.Fill(),
             Title = string.Empty,
+            BorderStyle = LineStyle.Rounded,
             CanFocus = true
         };
         _detailTextFrame.KeyDown += async (_, key) => await HandleDetailTextKeyDownAsync(key).ConfigureAwait(false);
@@ -280,30 +331,6 @@ public sealed class HighlightDetailScreen : IScreen
         _detailActionList.Accepting += async (_, _) => await HandleDetailActionEnterAsync().ConfigureAwait(false);
         _detailActionList.KeyDown += async (_, key) => await HandleDetailKeyDownAsync(key).ConfigureAwait(false);
 
-        _detailTabHintKeyLabel = new Label
-        {
-            X = 0,
-            Y = Pos.AnchorEnd(1),
-            Width = 5,
-            Height = 1,
-            Text = "<Tab>",
-            CanFocus = false
-        };
-        _detailTabHintKeyLabel.SetScheme(new Terminal.Gui.Drawing.Scheme(new Terminal.Gui.Drawing.Attribute(
-            TuiTheme.Palette.AccentText, TuiTheme.Palette.Background)));
-
-        _detailTabHintDescriptionLabel = new Label
-        {
-            X = Pos.Right(_detailTabHintKeyLabel),
-            Y = Pos.AnchorEnd(1),
-            Width = Dim.Fill(),
-            Height = 1,
-            Text = " Switch panel",
-            CanFocus = false
-        };
-        _detailTabHintDescriptionLabel.SetScheme(new Terminal.Gui.Drawing.Scheme(new Terminal.Gui.Drawing.Attribute(
-            TuiTheme.Palette.TextMuted, TuiTheme.Palette.Background)));
-
         _detailActionFrame = new FrameView
         {
             X = DetailLeftPaneWidth + DetailPaneSeparator,
@@ -311,21 +338,13 @@ public sealed class HighlightDetailScreen : IScreen
             Width = DetailRightPaneWidth,
             Height = Dim.Fill(),
             Title = string.Empty,
+            BorderStyle = LineStyle.Rounded,
             CanFocus = true
         };
         _detailActionFrame.KeyDown += async (_, key) => await HandleDetailKeyDownAsync(key).ConfigureAwait(false);
-        _detailActionFrame.Add(_detailActionList, _detailTabHintKeyLabel, _detailTabHintDescriptionLabel);
+        _detailActionFrame.Add(_detailActionList);
 
-        _detailFrame = new FrameView
-        {
-            X = Pos.Center(),
-            Y = Pos.Center(),
-            Width = DetailPopupWidth,
-            Height = DetailPopupHeight,
-            Title = "",
-            CanFocus = true,
-            Visible = false
-        };
+        _detailFrame = ModalChrome.CreateFrame(DetailPopupWidth, DetailPopupHeight);
         _detailFrame.Add(_detailTextFrame, _detailActionFrame);
 
         _weightScaleLabel = new Label
@@ -336,6 +355,7 @@ public sealed class HighlightDetailScreen : IScreen
             Height = 1,
             CanFocus = false
         };
+        _weightScaleLabel.SetScheme(ModalChrome.CreateBodyTextScheme());
 
         _weightHelpLabel = new Label
         {
@@ -346,31 +366,14 @@ public sealed class HighlightDetailScreen : IScreen
             Text = "Use ← → or 1-5, Enter to save, Esc to cancel.",
             CanFocus = false
         };
+        _weightHelpLabel.SetScheme(ModalChrome.CreateMutedTextScheme());
 
-        _weightEditorFrame = new FrameView
-        {
-            X = Pos.Center() - (WeightEditorWidth / 2),
-            Y = Pos.Center() - 3,
-            Width = WeightEditorWidth,
-            Height = WeightEditorHeight,
-            Title = "Set Weight",
-            CanFocus = true,
-            Visible = false
-        };
+        _weightEditorFrame = ModalChrome.CreateFrame(WeightEditorWidth, WeightEditorHeight, "Set Weight");
         _weightEditorFrame.Add(_weightScaleLabel, _weightHelpLabel);
         _weightEditorFrame.KeyDown += async (_, key) => await HandleWeightEditorKeyDownAsync(key).ConfigureAwait(false);
 
-        _deleteConfirmationFrame = new FrameView
-        {
-            X = Pos.Center() - 24,
-            Y = Pos.Center() - 2,
-            Width = 48,
-            Height = 5,
-            Title = "Confirm Delete",
-            CanFocus = true,
-            Visible = false
-        };
-        _deleteConfirmationFrame.Add(new Label
+        _deleteConfirmationFrame = ModalChrome.CreateFrame(DeleteConfirmationWidth, DeleteConfirmationHeight, "Confirm Delete");
+        var deleteMessage = new Label
         {
             X = 1,
             Y = 1,
@@ -378,7 +381,9 @@ public sealed class HighlightDetailScreen : IScreen
             Height = 2,
             Text = "Delete this highlight? Press Y to confirm or N/Esc to cancel.",
             CanFocus = false
-        });
+        };
+        deleteMessage.SetScheme(ModalChrome.CreateBodyTextScheme());
+        _deleteConfirmationFrame.Add(deleteMessage);
         _deleteConfirmationFrame.KeyDown += async (_, key) => await HandleDeleteConfirmationKeyDownAsync(key).ConfigureAwait(false);
 
         _statusLabel = new Label
@@ -406,6 +411,7 @@ public sealed class HighlightDetailScreen : IScreen
             _headerRuleLabel,
             _highlightList,
             _statusLabel,
+            _modalBackdrop,
             _detailFrame,
             _weightEditorFrame,
             _deleteConfirmationFrame);
@@ -556,8 +562,6 @@ public sealed class HighlightDetailScreen : IScreen
                 ConsoleKey.Escape => CloseDetail(),
                 ConsoleKey.Enter => await ExecuteSelectedActionAsync(cancellationToken).ConfigureAwait(false),
                 ConsoleKey.Tab => SwitchDetailFocus(focusActions: false),
-                ConsoleKey.Q => ScreenResult.ConfirmQuit(),
-                ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control) => ScreenResult.Quit(),
                 _ => ScreenResult.Stay()
             };
         }
@@ -568,8 +572,6 @@ public sealed class HighlightDetailScreen : IScreen
             ConsoleKey.DownArrow => ScrollDetailText(1),
             ConsoleKey.Escape => CloseDetail(),
             ConsoleKey.Tab => SwitchDetailFocus(focusActions: true),
-            ConsoleKey.Q => ScreenResult.ConfirmQuit(),
-            ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control) => ScreenResult.Quit(),
             _ => ScreenResult.Stay()
         };
     }
@@ -604,10 +606,6 @@ public sealed class HighlightDetailScreen : IScreen
             case ConsoleKey.D5:
             case ConsoleKey.NumPad5:
                 return SelectPendingWeight(5);
-            case ConsoleKey.Q:
-                return ScreenResult.ConfirmQuit();
-            case ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control):
-                return ScreenResult.Quit();
             default:
                 return ScreenResult.Stay();
         }
@@ -625,10 +623,6 @@ public sealed class HighlightDetailScreen : IScreen
             case ConsoleKey.Y:
                 await DeleteSelectedHighlightAsync(cancellationToken).ConfigureAwait(false);
                 return ScreenResult.Stay();
-            case ConsoleKey.Q:
-                return ScreenResult.ConfirmQuit();
-            case ConsoleKey.C when key.Modifiers.HasFlag(ConsoleModifiers.Control):
-                return ScreenResult.Quit();
             default:
                 return ScreenResult.Stay();
         }
@@ -702,8 +696,10 @@ public sealed class HighlightDetailScreen : IScreen
             DetailOpen = false;
             WeightEditorOpen = false;
             DeleteConfirmationOpen = false;
+            _detailScrollOffset = 0;
             _previewText = null;
             _statusMessage = $"Reloaded {_highlights.Count.ToString(CultureInfo.InvariantCulture)} highlight(s).";
+            NotifyUiStateChanged();
         }
         catch (HttpRequestException)
         {
@@ -731,6 +727,7 @@ public sealed class HighlightDetailScreen : IScreen
         _highlights[SelectedIndex] = currentHighlight with { Weight = PendingWeight };
         WeightEditorOpen = false;
         _statusMessage = $"Weight updated to {PendingWeight.ToString(CultureInfo.InvariantCulture)}.";
+        NotifyUiStateChanged();
     }
 
     private async Task ToggleHighlightExclusionAsync(CancellationToken cancellationToken)
@@ -793,6 +790,7 @@ public sealed class HighlightDetailScreen : IScreen
         if (currentHighlight is null)
         {
             DeleteConfirmationOpen = false;
+            NotifyUiStateChanged();
             return;
         }
 
@@ -801,6 +799,7 @@ public sealed class HighlightDetailScreen : IScreen
         {
             _statusMessage = $"Delete failed: {(int)response.StatusCode} {response.ReasonPhrase}";
             DeleteConfirmationOpen = false;
+            NotifyUiStateChanged();
             return;
         }
 
@@ -809,8 +808,10 @@ public sealed class HighlightDetailScreen : IScreen
         DeleteConfirmationOpen = false;
         DetailOpen = false;
         WeightEditorOpen = false;
+        _detailScrollOffset = 0;
         _previewText = null;
         _statusMessage = "Highlight deleted.";
+        NotifyUiStateChanged();
     }
 
     private ScreenResult MoveSelection(int delta)
@@ -846,6 +847,7 @@ public sealed class HighlightDetailScreen : IScreen
     private ScreenResult SwitchDetailFocus(bool focusActions)
     {
         _detailFocusOnActions = focusActions;
+        NotifyUiStateChanged();
         return ScreenResult.Stay();
     }
 
@@ -877,6 +879,7 @@ public sealed class HighlightDetailScreen : IScreen
         WeightEditorOpen = false;
         DeleteConfirmationOpen = false;
         _statusMessage = null;
+        NotifyUiStateChanged();
         return ScreenResult.Stay();
     }
 
@@ -892,6 +895,7 @@ public sealed class HighlightDetailScreen : IScreen
         DetailOpen = false;
         WeightEditorOpen = true;
         _statusMessage = null;
+        NotifyUiStateChanged();
         return ScreenResult.Stay();
     }
 
@@ -899,6 +903,7 @@ public sealed class HighlightDetailScreen : IScreen
     {
         WeightEditorOpen = false;
         _statusMessage = null;
+        NotifyUiStateChanged();
         return ScreenResult.Stay();
     }
 
@@ -907,6 +912,7 @@ public sealed class HighlightDetailScreen : IScreen
         DetailOpen = false;
         _detailScrollOffset = 0;
         _previewText = null;
+        NotifyUiStateChanged();
         return ScreenResult.Stay();
     }
 
@@ -1008,14 +1014,16 @@ public sealed class HighlightDetailScreen : IScreen
                 _detailFrame.Visible = DetailOpen;
             }
 
+            ModalChrome.SetBackdropVisible(_modalBackdrop, DetailOpen || WeightEditorOpen || DeleteConfirmationOpen);
+
             if (_detailTextFrame is not null)
             {
-                _detailTextFrame.SetScheme(CreateDetailPaneFrameScheme(DetailOpen && !_detailFocusOnActions));
+                _detailTextFrame.SetScheme(ModalChrome.CreateFrameScheme(DetailOpen && !_detailFocusOnActions));
             }
 
             if (_detailActionFrame is not null)
             {
-                _detailActionFrame.SetScheme(CreateDetailPaneFrameScheme(DetailOpen && _detailFocusOnActions));
+                _detailActionFrame.SetScheme(ModalChrome.CreateFrameScheme(DetailOpen && _detailFocusOnActions));
             }
 
             if (_detailActionList is not null && _detailActionRows is { Count: > 0 })
@@ -1026,9 +1034,14 @@ public sealed class HighlightDetailScreen : IScreen
 
             if (_detailTextView is not null)
             {
-                _detailTextView.SetScheme(CreateDetailTextViewScheme());
-                _detailTextView.Text = DetailOpen ? _previewText ?? string.Empty : string.Empty;
+                _detailTextView.SetScheme(ModalChrome.CreateBodyTextScheme());
+                _detailTextView.Text = DetailOpen ? BuildJustifiedPreviewText(_previewText ?? string.Empty, GetDetailTextWidth()) : string.Empty;
                 _detailTextView.ScrollTo(new System.Drawing.Point(0, _detailScrollOffset));
+            }
+
+            if (_weightEditorFrame is not null)
+            {
+                _weightEditorFrame.SetScheme(ModalChrome.CreateFrameScheme(WeightEditorOpen));
             }
 
             if (_weightEditorFrame is not null)
@@ -1048,6 +1061,7 @@ public sealed class HighlightDetailScreen : IScreen
 
             if (_deleteConfirmationFrame is not null)
             {
+                _deleteConfirmationFrame.SetScheme(ModalChrome.CreateFrameScheme(DeleteConfirmationOpen));
                 _deleteConfirmationFrame.Visible = DeleteConfirmationOpen;
             }
 
@@ -1148,6 +1162,96 @@ public sealed class HighlightDetailScreen : IScreen
     private string BuildWeightScale()
         => string.Join("  ", Enumerable.Range(MinimumWeight, MaximumWeight)
             .Select(weight => weight == PendingWeight ? $"[{weight}]" : $" {weight} "));
+
+    private int GetDetailTextWidth()
+        => Math.Max(24, _detailTextView?.Viewport.Width ?? DetailTextFallbackWidth);
+
+    private static string BuildJustifiedPreviewText(string text, int width)
+    {
+        if (width <= 1 || string.IsNullOrWhiteSpace(text))
+        {
+            return text;
+        }
+
+        var paragraphs = text.ReplaceLineEndings("\n").Split('\n');
+        var lines = new List<string>();
+
+        foreach (var paragraph in paragraphs)
+        {
+            if (string.IsNullOrWhiteSpace(paragraph))
+            {
+                lines.Add(string.Empty);
+                continue;
+            }
+
+            var words = paragraph.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var currentLine = new List<string>();
+            var currentLength = 0;
+
+            foreach (var word in words)
+            {
+                if (currentLine.Count == 0)
+                {
+                    currentLine.Add(word);
+                    currentLength = word.Length;
+                    continue;
+                }
+
+                if (currentLength + currentLine.Count + word.Length <= width)
+                {
+                    currentLine.Add(word);
+                    currentLength += word.Length;
+                    continue;
+                }
+
+                lines.Add(JustifyPreviewLine(currentLine, currentLength, width, isLastLine: false));
+                currentLine.Clear();
+                currentLine.Add(word);
+                currentLength = word.Length;
+            }
+
+            if (currentLine.Count > 0)
+            {
+                lines.Add(JustifyPreviewLine(currentLine, currentLength, width, isLastLine: true));
+            }
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private static string JustifyPreviewLine(IReadOnlyList<string> words, int wordsLength, int width, bool isLastLine)
+    {
+        if (words.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        if (words.Count == 1 || isLastLine)
+        {
+            return string.Join(' ', words);
+        }
+
+        var gapCount = words.Count - 1;
+        var spacesToDistribute = Math.Max(gapCount, width - wordsLength);
+        var baseSpaces = spacesToDistribute / gapCount;
+        var extraSpaces = spacesToDistribute % gapCount;
+        var builder = new System.Text.StringBuilder(width + gapCount);
+
+        for (var index = 0; index < words.Count; index++)
+        {
+            builder.Append(words[index]);
+
+            if (index == gapCount)
+            {
+                continue;
+            }
+
+            var spaces = baseSpaces + (index < extraSpaces ? 1 : 0);
+            builder.Append(' ', Math.Max(1, spaces));
+        }
+
+        return builder.ToString();
+    }
 
     private static string FormatHeader(TableLayout tableLayout)
         => $"{FitCell("WEIGHT", tableLayout.WeightWidth)}  {" ",DotColumnWidth}  {FitCell("HIGHLIGHT", tableLayout.HighlightWidth)}";
@@ -1305,46 +1409,6 @@ public sealed class HighlightDetailScreen : IScreen
             WeightColumnWidth);
     }
 
-    private static Terminal.Gui.Drawing.Scheme CreateDetailPaneFrameScheme(bool isFocused)
-    {
-        var palette = TuiTheme.Palette;
-        var borderColor = isFocused ? palette.BorderFocus : palette.Border;
-        var attribute = new Terminal.Gui.Drawing.Attribute(borderColor, palette.Background);
-
-        return new Terminal.Gui.Drawing.Scheme(attribute)
-        {
-            Normal = attribute,
-            Focus = attribute,
-            Active = attribute,
-            HotNormal = attribute,
-            HotFocus = attribute,
-            HotActive = attribute,
-            Disabled = attribute
-        };
-    }
-
-    private static Terminal.Gui.Drawing.Scheme CreateDetailTextViewScheme()
-    {
-        var palette = TuiTheme.Palette;
-        var text = new Terminal.Gui.Drawing.Attribute(palette.Text, palette.Background);
-        var muted = new Terminal.Gui.Drawing.Attribute(palette.TextMuted, palette.Background);
-
-        return new Terminal.Gui.Drawing.Scheme(text)
-        {
-            Normal = text,
-            Focus = text,
-            Active = text,
-            Code = text,
-            Editable = text,
-            Highlight = text,
-            HotActive = text,
-            HotFocus = text,
-            HotNormal = text,
-            ReadOnly = text,
-            Disabled = muted
-        };
-    }
-
     private static Terminal.Gui.Drawing.Scheme CreateDetailActionListScheme(bool isFocused)
     {
         var palette = TuiTheme.Palette;
@@ -1368,6 +1432,11 @@ public sealed class HighlightDetailScreen : IScreen
             HotActive = selected,
             Disabled = muted
         };
+    }
+
+    private void NotifyUiStateChanged()
+    {
+        _uiStateObserver?.Invoke();
     }
 
     private static string FitCell(string value, int width)

--- a/src/Relego.Cli/Tui/IScreen.cs
+++ b/src/Relego.Cli/Tui/IScreen.cs
@@ -15,6 +15,10 @@ public interface IScreen
     string Title { get; }
 
     IReadOnlyList<(string Key, string Label)> KeyHints { get; }
+
+    void RegisterUiStateObserver(Action? onStateChanged)
+    {
+    }
 }
 
 public enum ScreenAction

--- a/src/Relego.Cli/Tui/ModalChrome.cs
+++ b/src/Relego.Cli/Tui/ModalChrome.cs
@@ -1,0 +1,127 @@
+﻿using Terminal.Gui.Drawing;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+namespace Relego.Cli.Tui;
+
+internal static class ModalChrome
+{
+    private const char BackdropShade = '\u2591';
+
+    public static Label CreateBackdrop()
+    {
+        var backdrop = new Label
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            Visible = false,
+            CanFocus = false,
+            Text = string.Empty
+        };
+        backdrop.SetScheme(CreateBackdropScheme());
+        backdrop.ViewportChanged += (_, _) => RefreshBackdrop(backdrop);
+        return backdrop;
+    }
+
+    public static void SetBackdropVisible(Label? backdrop, bool visible)
+    {
+        if (backdrop is null)
+        {
+            return;
+        }
+
+        backdrop.Visible = visible;
+        if (visible)
+        {
+            RefreshBackdrop(backdrop);
+        }
+    }
+
+    public static FrameView CreateFrame(int width, int height, string? title = null)
+    {
+        var frame = new FrameView
+        {
+            X = Pos.Center(),
+            Y = Pos.Center(),
+            Width = width,
+            Height = height,
+            Title = title ?? string.Empty,
+            BorderStyle = LineStyle.Rounded,
+            CanFocus = true,
+            Visible = false
+        };
+        frame.SetScheme(CreateFrameScheme(isFocused: true));
+        return frame;
+    }
+
+    public static Scheme CreateFrameScheme(bool isFocused)
+    {
+        var palette = TuiTheme.Palette;
+        var borderColor = isFocused ? palette.BorderFocus : palette.Border;
+        var attribute = new Terminal.Gui.Drawing.Attribute(borderColor, palette.Background);
+
+        return new Scheme(attribute)
+        {
+            Normal = attribute,
+            Focus = attribute,
+            Active = attribute,
+            HotNormal = attribute,
+            HotFocus = attribute,
+            HotActive = attribute,
+            Disabled = attribute
+        };
+    }
+
+    public static Scheme CreateBodyTextScheme()
+    {
+        var palette = TuiTheme.Palette;
+        var attribute = new Terminal.Gui.Drawing.Attribute(palette.Text, palette.Background);
+        return CreateUniformScheme(attribute);
+    }
+
+    public static Scheme CreateMutedTextScheme()
+    {
+        var palette = TuiTheme.Palette;
+        var attribute = new Terminal.Gui.Drawing.Attribute(palette.TextMuted, palette.Background);
+        return CreateUniformScheme(attribute);
+    }
+
+    public static Scheme CreateHintKeyScheme()
+    {
+        var palette = TuiTheme.Palette;
+        var attribute = new Terminal.Gui.Drawing.Attribute(palette.AccentText, palette.Background);
+        return CreateUniformScheme(attribute);
+    }
+
+    private static Scheme CreateBackdropScheme()
+    {
+        var palette = TuiTheme.Palette;
+        var attribute = new Terminal.Gui.Drawing.Attribute(palette.Border, palette.Background);
+        return CreateUniformScheme(attribute);
+    }
+
+    private static Scheme CreateUniformScheme(Terminal.Gui.Drawing.Attribute attribute) => new(attribute)
+    {
+        Normal = attribute,
+        Focus = attribute,
+        Active = attribute,
+        HotNormal = attribute,
+        HotFocus = attribute,
+        HotActive = attribute,
+        Disabled = attribute,
+        ReadOnly = attribute,
+        Editable = attribute,
+        Highlight = attribute,
+        Code = attribute
+    };
+
+    private static void RefreshBackdrop(Label backdrop)
+    {
+        var width = Math.Max(1, backdrop.Viewport.Width);
+        var height = Math.Max(1, backdrop.Viewport.Height);
+        var row = new string(BackdropShade, width);
+        backdrop.Text = string.Join("\n", Enumerable.Repeat(row, height));
+    }
+}

--- a/src/Relego.Cli/Tui/TuiApp.cs
+++ b/src/Relego.Cli/Tui/TuiApp.cs
@@ -12,8 +12,8 @@ namespace Relego.Cli.Tui;
 public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow syncWorkflow, string serverUrl, string version)
 {
     private const int SplashTopPadding = 1;
-    private const int ExitConfirmationWidth = 56;
-    private const int ExitConfirmationHeight = 5;
+    private const int ExitConfirmationWidth = 60;
+    private const int ExitConfirmationHeight = 6;
 
     private static readonly IReadOnlyList<(string Key, string Label)> ExitConfirmationHints =
     [
@@ -41,6 +41,7 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow sync
     private View? _toolbarView;
     private View? _statusBar;
     private Window? _window;
+    private Label? _exitConfirmationBackdrop;
     private FrameView? _exitConfirmationFrame;
     private bool _isExitConfirmationOpen;
     private IReadOnlyList<(string Key, string Label)> _currentHints = [];
@@ -353,10 +354,17 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow sync
         _contentFrame.RemoveAll();
         _contentFrame.Title = screen.Title;
 
+        screen.RegisterUiStateObserver(() => _app?.Invoke(() => RefreshCurrentHints(screen)));
+
         var view = screen.CreateView(Navigate);
         _contentFrame.Add(view);
         view.SetFocus();
 
+        RefreshCurrentHints(screen);
+    }
+
+    private void RefreshCurrentHints(IScreen screen)
+    {
         _currentHints = screen.KeyHints;
         UpdateStatusBar(_isExitConfirmationOpen ? ExitConfirmationHints : _currentHints);
     }
@@ -369,31 +377,23 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow sync
             return;
         }
 
-        var palette = TuiTheme.Palette;
-        _exitConfirmationFrame = new FrameView
-        {
-            X = Pos.Center() - (ExitConfirmationWidth / 2),
-            Y = Pos.Center() - (ExitConfirmationHeight / 2),
-            Width = ExitConfirmationWidth,
-            Height = ExitConfirmationHeight,
-            Title = "Confirm Exit",
-            CanFocus = true,
-            Visible = false
-        };
-        _exitConfirmationFrame.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.BorderFocus, palette.Background)));
+        _exitConfirmationBackdrop = ModalChrome.CreateBackdrop();
+
+        _exitConfirmationFrame = ModalChrome.CreateFrame(ExitConfirmationWidth, ExitConfirmationHeight, "Confirm Exit");
 
         var message = new Label
         {
             X = 1,
             Y = 1,
             Width = Dim.Fill(2),
-            Height = 1,
+            Height = 2,
             Text = "Exit Relego? Press Y to confirm or N/Esc to cancel.",
             CanFocus = false
         };
-        message.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.Text, palette.Background)));
+        message.SetScheme(ModalChrome.CreateBodyTextScheme());
 
         _exitConfirmationFrame.Add(message);
+        _window.Add(_exitConfirmationBackdrop);
         _window.Add(_exitConfirmationFrame);
     }
 
@@ -411,6 +411,7 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow sync
         }
 
         _isExitConfirmationOpen = true;
+        ModalChrome.SetBackdropVisible(_exitConfirmationBackdrop, visible: true);
         _exitConfirmationFrame.Visible = true;
         _exitConfirmationFrame.SetFocus();
         UpdateStatusBar(ExitConfirmationHints);
@@ -424,6 +425,7 @@ public sealed class TuiApp(RelegoHttpClient client, ClippingsImportWorkflow sync
         }
 
         _isExitConfirmationOpen = false;
+        ModalChrome.SetBackdropVisible(_exitConfirmationBackdrop, visible: false);
         if (_exitConfirmationFrame is not null)
         {
             _exitConfirmationFrame.Visible = false;

--- a/src/Relego.Tests/Tui/BookListScreenTests.cs
+++ b/src/Relego.Tests/Tui/BookListScreenTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Net;
+using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
 using RichardSzalay.MockHttp;
 using Relego.Cli.Infrastructure;
@@ -121,6 +122,45 @@ public sealed class BookListScreenTests : IDisposable
 
         Assert.True(handled);
         Assert.True(focusedImportField);
+    }
+
+    [Fact]
+    public async Task TryHandleShortcutKey_N_OpensRenamePopupAndUpdatesHints()
+    {
+        var screen = await CreateScreenAsync();
+
+        var handled = screen.TryHandleShortcutKey('n', _ => { }, null, null, null);
+
+        Assert.True(handled);
+        Assert.True(screen.IsRenamePromptActive);
+        Assert.Equal([("Enter", "Save"), ("Esc", "Cancel")], screen.KeyHints);
+    }
+
+    [Fact]
+    public async Task RegisterUiStateObserver_NotifiesOnRenamePopupTransitions()
+    {
+        var screen = await CreateScreenAsync();
+        var notifications = 0;
+
+        screen.RegisterUiStateObserver(() => notifications++);
+        screen.BeginRenamePrompt(screen.GetSelectedBook()!);
+        screen.CancelRenamePrompt();
+
+        Assert.Equal(2, notifications);
+    }
+
+    [Fact]
+    public async Task TryHandleShortcutKey_Q_WhenRenamePopupOpen_DoesNotRequestQuit()
+    {
+        var screen = await CreateScreenAsync();
+        ScreenResult? result = null;
+
+        screen.BeginRenamePrompt(screen.GetSelectedBook()!);
+        var handled = screen.TryHandleShortcutKey('q', navigate => result = navigate, null, null, null);
+
+        Assert.False(handled);
+        Assert.Null(result);
+        Assert.True(screen.IsRenamePromptActive);
     }
 
     [Fact]
@@ -286,6 +326,114 @@ public sealed class BookListScreenTests : IDisposable
         Assert.True(screen.IsImportPromptActive);
         Assert.True(screen.FeedbackIsError);
         Assert.Equal("Import failed: Connection refused", screen.FeedbackMessage);
+    }
+
+    [Fact]
+    public async Task SubmitRenameAsync_WithBlankTitle_StaysOpenAndShowsValidationFeedback()
+    {
+        var screen = await CreateScreenAsync();
+
+        screen.BeginRenamePrompt(screen.GetSelectedBook()!);
+        await screen.SubmitRenameAsync("   ");
+
+        Assert.True(screen.IsRenamePromptActive);
+        Assert.True(screen.FeedbackIsError);
+        Assert.Equal("Enter a title or press Esc to cancel.", screen.FeedbackMessage);
+    }
+
+    [Fact]
+    public async Task SubmitRenameAsync_OnSuccess_ClosesPromptAndReloadsBooks()
+    {
+        using var mockHttp = new MockHttpMessageHandler(BackendDefinitionBehavior.Always);
+
+        mockHttp.Expect(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+            .Respond("application/json", """
+                {
+                  "total": 3,
+                  "page": 1,
+                  "pageSize": 100,
+                  "items": [
+                    {
+                      "id": 1,
+                      "bookId": 10,
+                      "authorId": 7,
+                      "text": "Psychohistory is built on large numbers.",
+                      "bookTitle": "Foundation",
+                      "authorName": "Isaac Asimov"
+                    },
+                    {
+                      "id": 2,
+                      "bookId": 10,
+                      "authorId": 7,
+                      "text": "Violence is the last refuge of the incompetent.",
+                      "bookTitle": "Foundation",
+                      "authorName": "Isaac Asimov"
+                    },
+                    {
+                      "id": 3,
+                      "bookId": 20,
+                      "authorId": 8,
+                      "text": "In a hole in the ground there lived a hobbit.",
+                      "bookTitle": "The Hobbit",
+                      "authorName": "J.R.R. Tolkien"
+                    }
+                  ]
+                }
+                """);
+
+        mockHttp.Expect(HttpMethod.Put, "http://localhost:5000/books/10/title")
+            .Respond(HttpStatusCode.NoContent);
+
+        mockHttp.Expect(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+            .Respond("application/json", """
+                {
+                  "total": 3,
+                  "page": 1,
+                  "pageSize": 100,
+                  "items": [
+                    {
+                      "id": 1,
+                      "bookId": 10,
+                      "authorId": 7,
+                      "text": "Psychohistory is built on large numbers.",
+                      "bookTitle": "Foundation and Empire",
+                      "authorName": "Isaac Asimov"
+                    },
+                    {
+                      "id": 2,
+                      "bookId": 10,
+                      "authorId": 7,
+                      "text": "Violence is the last refuge of the incompetent.",
+                      "bookTitle": "Foundation and Empire",
+                      "authorName": "Isaac Asimov"
+                    },
+                    {
+                      "id": 3,
+                      "bookId": 20,
+                      "authorId": 8,
+                      "text": "In a hole in the ground there lived a hobbit.",
+                      "bookTitle": "The Hobbit",
+                      "authorName": "J.R.R. Tolkien"
+                    }
+                  ]
+                }
+                """);
+
+        ConfigureSupplementaryEndpoints(mockHttp);
+
+        var releClient = CreateRelegoClient(mockHttp);
+        var workflow = new ClippingsImportWorkflow(releClient, NullLogger<ClippingsImportWorkflow>.Instance);
+        var screen = new BookListScreen(releClient, workflow);
+        await screen.InitializeAsync(CancellationToken.None);
+
+        screen.BeginRenamePrompt(screen.GetSelectedBook()!);
+        await screen.SubmitRenameAsync("Foundation and Empire");
+
+        Assert.False(screen.IsRenamePromptActive);
+        Assert.False(screen.FeedbackIsError);
+        Assert.Equal("Book renamed to \"Foundation and Empire\".", screen.FeedbackMessage);
+        Assert.Contains(screen.Books, book => book.Title == "Foundation and Empire");
+        mockHttp.VerifyNoOutstandingExpectation();
     }
 
     private async Task<BookListScreen> CreateScreenAsync(int total = 3, string? itemsJson = null)

--- a/src/Relego.Tests/Tui/HighlightDetailScreenTests.cs
+++ b/src/Relego.Tests/Tui/HighlightDetailScreenTests.cs
@@ -22,6 +22,41 @@ public sealed class HighlightDetailScreenTests
     }
 
     [Fact]
+    public async Task KeyHints_ChangeWithModalState()
+    {
+        using var mockHttp = new MockHttpMessageHandler();
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+        var screen = CreateScreen(new RelegoHttpClient(httpClient));
+
+        await screen.HandleKeyAsync(Key(ConsoleKey.Enter), CancellationToken.None);
+        Assert.Equal([("↑↓", "Navigate"), ("Enter", "Use action"), ("Tab", "Switch panel"), ("Esc", "Close")], screen.KeyHints);
+
+        await screen.HandleKeyAsync(Key(ConsoleKey.Tab, '\t'), CancellationToken.None);
+        Assert.Equal([("↑↓", "Scroll"), ("Tab", "Switch panel"), ("Esc", "Close")], screen.KeyHints);
+
+        await screen.HandleKeyAsync(Key(ConsoleKey.Tab, '\t'), CancellationToken.None);
+        await screen.HandleKeyAsync(Key(ConsoleKey.Enter), CancellationToken.None);
+        Assert.Equal([("↑↓", "Adjust"), ("1-5", "Set"), ("Enter", "Save"), ("Esc", "Cancel")], screen.KeyHints);
+    }
+
+    [Fact]
+    public async Task RegisterUiStateObserver_NotifiesOnModalTransitions()
+    {
+        using var mockHttp = new MockHttpMessageHandler();
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+        var screen = CreateScreen(new RelegoHttpClient(httpClient));
+        var notifications = 0;
+
+        screen.RegisterUiStateObserver(() => notifications++);
+
+        await screen.HandleKeyAsync(Key(ConsoleKey.Enter), CancellationToken.None);
+        await screen.HandleKeyAsync(Key(ConsoleKey.Tab, '\t'), CancellationToken.None);
+        await screen.HandleKeyAsync(Key(ConsoleKey.Escape), CancellationToken.None);
+
+        Assert.Equal(3, notifications);
+    }
+
+    [Fact]
     public async Task HandleKeyAsync_NavigatesWithinBounds()
     {
         using var mockHttp = new MockHttpMessageHandler();
@@ -152,6 +187,21 @@ public sealed class HighlightDetailScreenTests
         Assert.Equal(ScreenAction.None, result.Action);
         Assert.False(screen.WeightEditorOpen);
         Assert.Null(screen.Highlights[0].Weight);
+    }
+
+    [Fact]
+    public async Task HandleKeyAsync_QWhileModalOpen_DoesNotEscapeModal()
+    {
+        using var mockHttp = new MockHttpMessageHandler();
+        using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
+        var screen = CreateScreen(new RelegoHttpClient(httpClient));
+
+        await screen.HandleKeyAsync(Key(ConsoleKey.Enter), CancellationToken.None);
+
+        var result = await screen.HandleKeyAsync(Key(ConsoleKey.Q, 'q'), CancellationToken.None);
+
+        Assert.Equal(ScreenAction.None, result.Action);
+        Assert.True(screen.DetailOpen);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- introduce shared modal chrome and dynamic footer hints for TUI popups
- make highlight detail popups and exit confirmation stricter and visually consistent
- add a modal book-title rename flow on the main screen using the same popup rules

## Validation
- dotnet build src/Relego.Cli/Relego.Cli.csproj
- dotnet test src/Relego.Tests/Relego.Tests.csproj --filter "FullyQualifiedName~HighlightDetailScreenTests"
- dotnet test src/Relego.Tests/Relego.Tests.csproj --filter "FullyQualifiedName~BookListScreenTests"

Closes #271