### PR TITLE
Update Dockerfile to set ASPNETCORE_HTTP_PORTS environment variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "${input:serverEnvironment}",
-                "ASPNETCORE_URLS": "http://+:8080"
+                "ASPNETCORE_HTTP_PORTS": "8080"
             },
             "serverReadyAction": {
                 "action": "openExternally",

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -13,7 +13,7 @@ WORKDIR /app
 
 COPY --from=build /out/ ./
 
-ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_HTTP_PORTS=8080
 
 RUN mkdir -p /data \
     && ln -s /data /app/.data


### PR DESCRIPTION
Change the environment variable in the Dockerfile to set `ASPNETCORE_HTTP_PORTS` instead of `ASPNETCORE_URLS` for better clarity on port configuration.

Closes #258