### PR TITLE
Align VS Code launch configurations with appsettings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,10 @@
             "args": [],
             "cwd": "${workspaceFolder}/src/Relego.Cli",
             "console": "integratedTerminal",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "env": {
+                "DOTNET_ENVIRONMENT": "Development"
+            }
         },
         {
             "name": "Relego.Server",
@@ -23,8 +26,7 @@
             "console": "integratedTerminal",
             "stopAtEntry": false,
             "env": {
-                "ASPNETCORE_ENVIRONMENT": "${input:serverEnvironment}",
-                "ASPNETCORE_HTTP_PORTS": "8080"
+                "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "serverReadyAction": {
                 "action": "openExternally",
@@ -40,18 +42,6 @@
                 "Relego.Cli"
             ],
             "stopAll": true
-        }
-    ],
-    "inputs": [
-        {
-            "id": "serverEnvironment",
-            "type": "pickString",
-            "description": "Pick the environment for Relego.Server",
-            "options": [
-                "Development",
-                "Production"
-            ],
-            "default": "Development"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,32 +6,36 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build: Relego.Cli",
-            "program": "${workspaceFolder}/src/Relego.Cli/bin/Debug/net10.0/Relego.Cli.dll",
-            "args": [],
+            "program": "dotnet",
+            "args": [
+                "run",
+                "--no-build",
+                "--project",
+                "${workspaceFolder}/src/Relego.Cli/Relego.Cli.csproj",
+                "--launch-profile",
+                "default"
+            ],
             "cwd": "${workspaceFolder}/src/Relego.Cli",
             "console": "integratedTerminal",
-            "stopAtEntry": false,
-            "env": {
-                "DOTNET_ENVIRONMENT": "Development"
-            }
+            "stopAtEntry": false
         },
         {
             "name": "Relego.Server",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build: Relego.Server",
-            "program": "${workspaceFolder}/src/Relego.Server/bin/Debug/net10.0/Relego.Server.dll",
-            "args": [],
+            "program": "dotnet",
+            "args": [
+                "run",
+                "--no-build",
+                "--project",
+                "${workspaceFolder}/src/Relego.Server/Relego.Server.csproj",
+                "--launch-profile",
+                "${input:serverLaunchProfile}"
+            ],
             "cwd": "${workspaceFolder}/src/Relego.Server",
             "console": "integratedTerminal",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "serverReadyAction": {
-                "action": "openExternally",
-                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
-            }
+            "stopAtEntry": false
         }
     ],
     "compounds": [
@@ -42,6 +46,18 @@
                 "Relego.Cli"
             ],
             "stopAll": true
+        }
+    ],
+    "inputs": [
+        {
+            "id": "serverLaunchProfile",
+            "type": "pickString",
+            "description": "Pick the server launch profile",
+            "options": [
+                "http",
+                "https"
+            ],
+            "default": "http"
         }
     ]
 }

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -285,3 +285,32 @@ Errors are actionable — they tell the user exactly what to do.
 
 - `relego sync` auto-detects the Kindle mount path on macOS, Linux, and Windows. If not found, it prompts the user to enter the path interactively.
 - Server authentication is not required — the server is assumed to be on a trusted local network.
+
+---
+
+## Local development (VS Code)
+
+### Configuration philosophy
+
+All application settings live in `appsettings.*.json` — never in `.vscode/launch.json`. The launch configuration contains only the **minimum bootstrapping** needed by the .NET hosting framework:
+
+| File | Purpose |
+|------|---------|
+| `launch.json` | Sets `ASPNETCORE_ENVIRONMENT` / `DOTNET_ENVIRONMENT` to `Development` (selects which config files to load) |
+| `appsettings.json` | Base settings shared across all environments |
+| `appsettings.Development.json` | Dev-only overrides: URLs, ports, logging levels, local SMTP, etc. |
+| `Properties/launchSettings.json` | Used by `dotnet run` (not the debugger); keep in sync with appsettings for consistency |
+
+### Changing a setting
+
+Edit `appsettings.Development.json` in the relevant project — no need to touch `.vscode/`.
+
+**Examples:**
+
+- Change the server port → `src/Relego.Server/appsettings.Development.json` → `"Urls": "http://localhost:9090"`
+- Change SMTP settings → same file, `"Smtp"` section
+- Change CLI log level → `src/Relego.Cli/appsettings.Development.json` → `"Serilog"` section
+
+### Running in debug
+
+Press **F5** and select `Relego.Server` or `Relego.Cli`. Both configurations automatically load `appsettings.Development.json` thanks to the environment variable set in `launch.json`.

--- a/src/Relego.Cli/Properties/launchSettings.json
+++ b/src/Relego.Cli/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "default": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.7</Version>
+    <Version>0.11.8</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Server/Properties/launchSettings.json
+++ b/src/Relego.Server/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -13,8 +13,8 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:8080;http://localhost:8081",
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:8080;https://localhost:8081",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.14.2</Version>
+    <Version>0.14.3</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Server/appsettings.Development.json
+++ b/src/Relego.Server/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "Urls": "http://localhost:8080",
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/src/Relego.Server/appsettings.Development.json
+++ b/src/Relego.Server/appsettings.Development.json
@@ -1,5 +1,4 @@
 {
-  "Urls": "http://localhost:8080",
   "Logging": {
     "LogLevel": {
       "Default": "Debug",


### PR DESCRIPTION
Updated VS Code launch configurations to remove app config from `launch.json`, ensuring that only `appsettings` are used. The `ASPNETCORE_ENVIRONMENT` is hardcoded to `Development`, and the port configuration is moved to `appsettings.Development.json`. Added launch settings for both CLI and Server to maintain consistency with `dotnet run`. Documented the local development configuration philosophy in `DX.md` for clarity.

Fixes #262