### PR TITLE
Refactor SMTP configuration to use environment variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,16 +6,11 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build: Relego.Cli",
-            "program": "dotnet",
-            "args": [
-                "run",
-                "--no-build",
-                "--project",
-                "${workspaceFolder}/src/Relego.Cli/Relego.Cli.csproj",
-                "--launch-profile",
-                "default"
-            ],
+            "program": "${workspaceFolder}/src/Relego.Cli/bin/Debug/net10.0/Relego.Cli.dll",
+            "args": [],
             "cwd": "${workspaceFolder}/src/Relego.Cli",
+            "launchSettingsFilePath": "${workspaceFolder}/src/Relego.Cli/Properties/launchSettings.json",
+            "launchSettingsProfile": "default",
             "console": "integratedTerminal",
             "stopAtEntry": false
         },
@@ -24,18 +19,17 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build: Relego.Server",
-            "program": "dotnet",
-            "args": [
-                "run",
-                "--no-build",
-                "--project",
-                "${workspaceFolder}/src/Relego.Server/Relego.Server.csproj",
-                "--launch-profile",
-                "${input:serverLaunchProfile}"
-            ],
+            "program": "${workspaceFolder}/src/Relego.Server/bin/Debug/net10.0/Relego.Server.dll",
+            "args": [],
             "cwd": "${workspaceFolder}/src/Relego.Server",
+            "launchSettingsFilePath": "${workspaceFolder}/src/Relego.Server/Properties/launchSettings.json",
+            "launchSettingsProfile": "${input:serverLaunchProfile}",
             "console": "integratedTerminal",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            }
         }
     ],
     "compounds": [

--- a/src/Relego.Server/Program.cs
+++ b/src/Relego.Server/Program.cs
@@ -23,14 +23,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 SerilogConfiguration.ConfigureLogging(builder);
 
-builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
-{
-    ["Smtp:Host"] = Environment.GetEnvironmentVariable("SMTP_HOST"),
-    ["Smtp:Port"] = Environment.GetEnvironmentVariable("SMTP_PORT"),
-    ["Smtp:FromAddress"] = Environment.GetEnvironmentVariable("SMTP_FROM_ADDRESS"),
-    ["Smtp:Username"] = Environment.GetEnvironmentVariable("SMTP_USER"),
-    ["Smtp:Password"] = Environment.GetEnvironmentVariable("SMTP_PASSWORD"),
-});
+var smtpEnvironmentOverrides = GetLegacySmtpEnvironmentOverrides();
+if (smtpEnvironmentOverrides.Count > 0)
+    builder.Configuration.AddInMemoryCollection(smtpEnvironmentOverrides);
 
 builder.Services.Configure<SmtpSettings>(builder.Configuration.GetSection("Smtp"));
 
@@ -163,6 +158,19 @@ Log.Information("Relego server started. Database: {DbPath}", dbPath);
 
 await app.RunAsync();
 
+static Dictionary<string, string?> GetLegacySmtpEnvironmentOverrides()
+{
+    var overrides = new Dictionary<string, string?>();
+
+    AddOverride(overrides, "Smtp:Host", "SMTP_HOST");
+    AddOverride(overrides, "Smtp:Port", "SMTP_PORT");
+    AddOverride(overrides, "Smtp:FromAddress", "SMTP_FROM_ADDRESS");
+    AddOverride(overrides, "Smtp:Username", "SMTP_USER");
+    AddOverride(overrides, "Smtp:Password", "SMTP_PASSWORD");
+
+    return overrides;
+}
+
 static void IncludeXmlCommentsIfPresent(Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions options, Assembly assembly)
 {
     var xmlFile = $"{assembly.GetName().Name}.xml";
@@ -170,4 +178,14 @@ static void IncludeXmlCommentsIfPresent(Swashbuckle.AspNetCore.SwaggerGen.Swagge
 
     if (File.Exists(xmlPath))
         options.IncludeXmlComments(xmlPath);
+}
+
+static void AddOverride(Dictionary<string, string?> overrides, string configurationKey, string environmentVariableName)
+{
+    var value = Environment.GetEnvironmentVariable(environmentVariableName);
+    if (!string.IsNullOrWhiteSpace(value))
+    {
+        overrides[configurationKey] = value;
+        return;
+    }
 }

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.14.3</Version>
+    <Version>0.14.4</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Update the SMTP configuration to retrieve settings from environment variables, enhancing flexibility and security in managing sensitive information.

Fixes #262