### PR TITLE
Fix standalone CLI startup when appsettings.json is absent

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -13,6 +13,6 @@ WORKDIR /app
 
 COPY --from=build /out/ ./
 
-ENV RELEGO_SERVER=http://localhost:8080
+ENV SERVER_URL=http://localhost:8080
 
 ENTRYPOINT ["dotnet", "Relego.Cli.dll"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -13,6 +13,4 @@ WORKDIR /app
 
 COPY --from=build /out/ ./
 
-ENV SERVER_URL=http://localhost:8080
-
 ENTRYPOINT ["dotnet", "Relego.Cli.dll"]

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The installer detects your OS and architecture automatically and prints the path
 
 </details>
 
-The native client automatically connects to `http://localhost:8080`. That default is stored as `Server:Url`; override it at runtime with `SERVER_URL` before starting the TUI:
+The native client automatically connects to `http://localhost:8080`. If you ran the server on a different host machine or port, override `SERVER_URL` before starting the TUI:
 
 ```powershell
 # PowerShell

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Import Kindle highlights using the TUI. It automatically detects the path to you
     -it `
     -v "D:\documents:/kindle:ro" `
     --network relego `
-    -e RELEGO_SERVER="http://relego-server:8080" `
+    -e SERVER_URL="http://relego-server:8080" `
     ghcr.io/krusty93/relego.cli:latest
   ```
 
@@ -106,7 +106,7 @@ Import Kindle highlights using the TUI. It automatically detects the path to you
   >  -it `
   >  -v "$(Get-Location):/kindle:ro" `
   >  --network relego `
-  >  -e RELEGO_SERVER="http://relego-server:8080" `
+  >  -e SERVER_URL="http://relego-server:8080" `
   >  ghcr.io/krusty93/relego.cli:latest
   >```
 
@@ -117,7 +117,7 @@ Import Kindle highlights using the TUI. It automatically detects the path to you
     -it \
     -v "/Volumes/Kindle/documents:/kindle:ro" \
     --network relego \
-    -e RELEGO_SERVER="http://relego-server:8080" \
+    -e SERVER_URL="http://relego-server:8080" \
     ghcr.io/krusty93/relego.cli:latest
   ```
 
@@ -128,7 +128,7 @@ Import Kindle highlights using the TUI. It automatically detects the path to you
     -it \
     -v "/media/$USER/Kindle/documents:/kindle:ro" \
     --network relego \
-    -e RELEGO_SERVER="http://relego-server:8080" \
+    -e SERVER_URL="http://relego-server:8080" \
     ghcr.io/krusty93/relego.cli:latest
   ```
 
@@ -167,17 +167,17 @@ The installer detects your OS and architecture automatically and prints the path
 
 </details>
 
-The native client automatically connects to `http://localhost:8080`. If you ran the server on a different host machine or port, override `RELEGO_SERVER` before starting the TUI:
+The native client automatically connects to `http://localhost:8080`. That default is stored as `Server:Url`; override it at runtime with `SERVER_URL` before starting the TUI:
 
 ```powershell
 # PowerShell
-$env:RELEGO_SERVER = "http://192.168.1.10:8080"
+$env:SERVER_URL = "http://192.168.1.10:8080"
 relego
 ```
 
 ```sh
 # macOS / Linux
-export RELEGO_SERVER=http://192.168.1.10:8080
+export SERVER_URL=http://192.168.1.10:8080
 relego
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ Kindle / My Clippings.txt                              │
 
 - Distributed as a self-contained binary (macOS/Linux/Windows) or runnable via Docker
 - Optional Docker image for no-install usage: `ghcr.io/krusty93/relego.cli`
-- Connects to the server via `RELEGO_SERVER` environment variable (no authentication — local network trusted)
+- Reads the server URL from client configuration (`Server:Url`) with runtime override via `SERVER_URL` (no authentication — local network trusted)
 - Responsibilities:
   - Parse and sync highlights from `My Clippings.txt` to the server
   - Manage user settings via CLI commands (schedule, count, weights, exclusions)

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -44,7 +44,7 @@ That's it. The server is running and will start sending recaps on the default sc
 
 **Option A — Docker (no install required):**
 ```sh
-docker run --rm -e RELEGO_SERVER=http://192.168.1.10:8080 ghcr.io/krusty93/relego.cli:latest <command>
+docker run --rm -e SERVER_URL=http://192.168.1.10:8080 ghcr.io/krusty93/relego.cli:latest <command>
 ```
 
 **Option B — Download binary:**
@@ -69,7 +69,7 @@ winget install Krusty93.Relego
 
 ## Configuration
 
-All configuration is passed as environment variables to the server container. The client reads `RELEGO_SERVER` from the environment to locate the server.
+All configuration is passed as environment variables to the server container. The client keeps its default server address in `Server:Url` and allows a runtime override via `SERVER_URL`.
 
 ```sh
 docker run -d \
@@ -81,14 +81,14 @@ docker run -d \
   ghcr.io/krusty93/relego.server:latest
 ```
 
-The client automatically connects to `http://localhost:8080`. If your server runs on a different host or port, set `RELEGO_SERVER` on the client side:
+The client automatically connects to `http://localhost:8080`. If your server runs on a different host or port, set `SERVER_URL` on the client side:
 
 ```sh
 # ~/.zshrc or ~/.bashrc (macOS/Linux)
-export RELEGO_SERVER=http://192.168.1.10:8080
+export SERVER_URL=http://192.168.1.10:8080
 
 # Windows (PowerShell profile)
-$env:RELEGO_SERVER = "http://192.168.1.10:8080"
+$env:SERVER_URL = "http://192.168.1.10:8080"
 ```
 
 No other configuration is required to get started.
@@ -99,7 +99,7 @@ No other configuration is required to get started.
 
 ```
 Step 1 — Deploy server (see above)
-Step 2 — Set RELEGO_SERVER in your shell profile
+Step 2 — Set SERVER_URL in your shell profile if the server is not on localhost:8080
 Step 3 — Connect Kindle via USB
 Step 4 — Sync highlights
 ```
@@ -227,7 +227,7 @@ Errors are actionable — they tell the user exactly what to do.
 ```
 ✗ Cannot connect to server at http://192.168.1.10:8080
   Is the server running? Check with: docker ps | grep relego-server
-  Is RELEGO_SERVER set correctly? Current value: http://192.168.1.10:8080
+  Is SERVER_URL set correctly? Current value: http://192.168.1.10:8080
 ```
 
 ### File not found

--- a/docs/adr/006-docker-only-distribution.md
+++ b/docs/adr/006-docker-only-distribution.md
@@ -18,7 +18,8 @@ Distribute the server exclusively as a **Docker image** published to GitHub Cont
 Configuration is passed entirely via environment variables:
 - `KINDLE_EMAIL` — the user's Send-to-Kindle email address
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD` — outbound email credentials
-- `RELEGO_SERVER` — server address (used by the client; also set here for reference)
+
+The client keeps its default server address in `Server:Url` and allows a `SERVER_URL` environment override.
 
 Data is persisted in a named Docker volume (`relego-data`).
 

--- a/src/Relego.Cli/Commands/ServerCommand.cs
+++ b/src/Relego.Cli/Commands/ServerCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Relego.Cli.Infrastructure;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -15,11 +16,12 @@ public abstract class ServerCommand<TSettings> : AsyncCommand<TSettings>
 
     protected int HandleServerError(HttpRequestException ex)
     {
-        var serverUrl = Environment.GetEnvironmentVariable("RELEGO_SERVER");
+        var serverUrl = Environment.GetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName)
+            ?? ServerUrlValidator.DefaultServerUrl;
         Logger.LogError(ex, "Failed to reach server at {ServerUrl}", serverUrl);
-        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{serverUrl}[/]");
-        AnsiConsole.MarkupLine($"[grey]{ex.Message}[/]");
-        AnsiConsole.MarkupLine("[grey]Check that the server is running and RELEGO_SERVER is correct.[/]");
+        AnsiConsole.MarkupLine($"[red]Error:[/] Cannot reach server at [yellow]{Markup.Escape(serverUrl)}[/]");
+        AnsiConsole.MarkupLine($"[grey]{Markup.Escape(ex.Message)}[/]");
+        AnsiConsole.MarkupLine($"[grey]Check that the server is running and {ServerUrlValidator.EnvironmentVariableName} is correct.[/]");
         return 1;
     }
 }

--- a/src/Relego.Cli/Infrastructure/ServerUrlValidator.cs
+++ b/src/Relego.Cli/Infrastructure/ServerUrlValidator.cs
@@ -5,11 +5,32 @@
 /// </summary>
 public static class ServerUrlValidator
 {
+    public const string DefaultServerUrl = "http://localhost:8080";
+
     public enum ValidationResult
     {
         Valid,
         Missing,
         Malformed,
+    }
+
+    /// <summary>
+    /// Returns the configured server URL, or the documented localhost default when no value is configured.
+    /// </summary>
+    public static string GetConfiguredOrDefault(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? DefaultServerUrl
+            : value.Trim();
+    }
+
+    /// <summary>
+    /// Resolves the configured server URL to a usable value and validates it.
+    /// </summary>
+    public static ValidationResult Resolve(string? value, out Uri? uri, out string resolvedValue)
+    {
+        resolvedValue = GetConfiguredOrDefault(value);
+        return Validate(resolvedValue, out uri);
     }
 
     /// <summary>

--- a/src/Relego.Cli/Infrastructure/ServerUrlValidator.cs
+++ b/src/Relego.Cli/Infrastructure/ServerUrlValidator.cs
@@ -5,7 +5,9 @@
 /// </summary>
 public static class ServerUrlValidator
 {
+    public const string ConfigKey = "Server:Url";
     public const string DefaultServerUrl = "http://localhost:8080";
+    public const string EnvironmentVariableName = "SERVER_URL";
 
     public enum ValidationResult
     {
@@ -15,21 +17,33 @@ public static class ServerUrlValidator
     }
 
     /// <summary>
-    /// Returns the configured server URL, or the documented localhost default when no value is configured.
+    /// Returns the configured server URL, preferring the environment override and falling back to the documented localhost default.
     /// </summary>
-    public static string GetConfiguredOrDefault(string? value)
+    public static string GetConfiguredOrDefault(string? configuredValue, string? environmentValue = null)
     {
-        return string.IsNullOrWhiteSpace(value)
+        if (!string.IsNullOrWhiteSpace(environmentValue))
+            return environmentValue.Trim();
+
+        return string.IsNullOrWhiteSpace(configuredValue)
             ? DefaultServerUrl
-            : value.Trim();
+            : configuredValue.Trim();
     }
 
     /// <summary>
     /// Resolves the configured server URL to a usable value and validates it.
     /// </summary>
-    public static ValidationResult Resolve(string? value, out Uri? uri, out string resolvedValue)
+    public static ValidationResult Resolve(string? configuredValue, string? environmentValue, out Uri? uri, out string resolvedValue)
     {
-        resolvedValue = GetConfiguredOrDefault(value);
+        resolvedValue = GetConfiguredOrDefault(configuredValue, environmentValue);
+        return Validate(resolvedValue, out uri);
+    }
+
+    /// <summary>
+    /// Resolves the configured server URL to a usable value and validates it.
+    /// </summary>
+    public static ValidationResult Resolve(string? configuredValue, out Uri? uri, out string resolvedValue)
+    {
+        resolvedValue = GetConfiguredOrDefault(configuredValue);
         return Validate(resolvedValue, out uri);
     }
 

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -16,24 +16,6 @@ using Relego.Cli.Tui;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-var validationResult = ServerUrlValidator.Resolve(
-    builder.Configuration[ServerUrlValidator.ConfigKey],
-    Environment.GetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName),
-    out Uri? serverUri,
-    out string resolvedServerUrl);
-if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
-{
-    AnsiConsole.MarkupLine($"[red]Error:[/] {ServerUrlValidator.EnvironmentVariableName} or {ServerUrlValidator.ConfigKey} must be a valid HTTP URL: [yellow]{Markup.Escape(resolvedServerUrl)}[/]");
-    return 1;
-}
-
-var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
-builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
-{
-    [ServerUrlValidator.ConfigKey] = normalizedServerUrl
-});
-Environment.SetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName, normalizedServerUrl);
-
 bool isTuiMode = TuiModeDetector.Detect(args, Console.IsInputRedirected) == StartupMode.Tui;
 
 Log.Logger = isTuiMode
@@ -49,6 +31,25 @@ builder.Services.AddLogging(loggingBuilder =>
     loggingBuilder.ClearProviders();
     loggingBuilder.AddSerilog(Log.Logger, dispose: true);
 });
+
+var validationResult = ServerUrlValidator.Resolve(
+    builder.Configuration[ServerUrlValidator.ConfigKey],
+    Environment.GetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName),
+    out Uri? serverUri,
+    out string resolvedServerUrl);
+
+if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
+{
+    AnsiConsole.MarkupLine($"[red]Error:[/] {ServerUrlValidator.EnvironmentVariableName} or {ServerUrlValidator.ConfigKey} must be a valid HTTP URL: [yellow]{Markup.Escape(resolvedServerUrl)}[/]");
+    return 1;
+}
+
+var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
+builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+{
+    [ServerUrlValidator.ConfigKey] = normalizedServerUrl
+});
+Environment.SetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName, normalizedServerUrl);
 
 Assembly assembly = typeof(ImportCommand).Assembly;
 string applicationName = "relego";

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -16,6 +16,20 @@ using Relego.Cli.Tui;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+var validationResult = ServerUrlValidator.Resolve(builder.Configuration["relego_server"], out Uri? serverUri, out string resolvedServerUrl);
+if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
+{
+    AnsiConsole.MarkupLine($"[red]Error:[/] RELEGO_SERVER value is not a valid HTTP URL: [yellow]{resolvedServerUrl}[/]");
+    return 1;
+}
+
+var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
+builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+{
+    ["relego_server"] = normalizedServerUrl
+});
+Environment.SetEnvironmentVariable("RELEGO_SERVER", normalizedServerUrl);
+
 bool isTuiMode = TuiModeDetector.Detect(args, Console.IsInputRedirected) == StartupMode.Tui;
 
 Log.Logger = isTuiMode
@@ -31,16 +45,6 @@ builder.Services.AddLogging(loggingBuilder =>
     loggingBuilder.ClearProviders();
     loggingBuilder.AddSerilog(Log.Logger, dispose: true);
 });
-
-string? serverUrl = builder.Configuration["relego_server"];
-var validationResult = ServerUrlValidator.Validate(serverUrl, out Uri? serverUri);
-if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
-{
-    AnsiConsole.MarkupLine($"[red]Error:[/] RELEGO_SERVER value is not a valid HTTP URL: [yellow]{serverUrl}[/]");
-    return 1;
-}
-
-var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
 
 Assembly assembly = typeof(ImportCommand).Assembly;
 string applicationName = "relego";

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -16,19 +16,23 @@ using Relego.Cli.Tui;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-var validationResult = ServerUrlValidator.Resolve(builder.Configuration["relego_server"], out Uri? serverUri, out string resolvedServerUrl);
+var validationResult = ServerUrlValidator.Resolve(
+    builder.Configuration[ServerUrlValidator.ConfigKey],
+    Environment.GetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName),
+    out Uri? serverUri,
+    out string resolvedServerUrl);
 if (validationResult == ServerUrlValidator.ValidationResult.Malformed)
 {
-    AnsiConsole.MarkupLine($"[red]Error:[/] RELEGO_SERVER value is not a valid HTTP URL: [yellow]{resolvedServerUrl}[/]");
+    AnsiConsole.MarkupLine($"[red]Error:[/] {ServerUrlValidator.EnvironmentVariableName} or {ServerUrlValidator.ConfigKey} must be a valid HTTP URL: [yellow]{Markup.Escape(resolvedServerUrl)}[/]");
     return 1;
 }
 
 var normalizedServerUrl = serverUri!.ToString().TrimEnd('/');
 builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
 {
-    ["relego_server"] = normalizedServerUrl
+    [ServerUrlValidator.ConfigKey] = normalizedServerUrl
 });
-Environment.SetEnvironmentVariable("RELEGO_SERVER", normalizedServerUrl);
+Environment.SetEnvironmentVariable(ServerUrlValidator.EnvironmentVariableName, normalizedServerUrl);
 
 bool isTuiMode = TuiModeDetector.Detect(args, Console.IsInputRedirected) == StartupMode.Tui;
 
@@ -56,7 +60,7 @@ string version = (assembly.GetCustomAttribute<AssemblyInformationalVersionAttrib
 builder.Services.AddHttpClient<RelegoHttpClient>((sp, client) =>
 {
     var config = sp.GetRequiredService<IConfiguration>();
-    var serverUrl = config["relego_server"]
+    var serverUrl = config[ServerUrlValidator.ConfigKey]
         ?? throw new InvalidOperationException("Missing Relego server URL configuration.");
     client.BaseAddress = new Uri(serverUrl);
     client.Timeout = TimeSpan.FromSeconds(30);

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.11.8</Version>
+    <Version>0.11.9</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/appsettings.json
+++ b/src/Relego.Cli/appsettings.json
@@ -1,5 +1,7 @@
 {
-  "relego_server": "http://localhost:8080",
+  "Server": {
+    "Url": "http://localhost:8080"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Warning",

--- a/src/Relego.Tests/Cli/ServerUrlValidationTests.cs
+++ b/src/Relego.Tests/Cli/ServerUrlValidationTests.cs
@@ -5,6 +5,36 @@ namespace Relego.Tests.Cli;
 public sealed class ServerUrlValidationTests
 {
     [Fact]
+    public void GetConfiguredOrDefault_MissingValue_ReturnsLocalhostDefault()
+    {
+        var value = ServerUrlValidator.GetConfiguredOrDefault(null);
+
+        Assert.Equal(ServerUrlValidator.DefaultServerUrl, value);
+    }
+
+    [Fact]
+    public void Resolve_MissingValue_ReturnsValidDefaultUri()
+    {
+        var result = ServerUrlValidator.Resolve(null, out var uri, out var resolvedValue);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Valid, result);
+        Assert.NotNull(uri);
+        Assert.Equal(ServerUrlValidator.DefaultServerUrl, resolvedValue);
+        Assert.Equal(ServerUrlValidator.DefaultServerUrl, uri.ToString().TrimEnd('/'));
+    }
+
+    [Fact]
+    public void Resolve_ConfiguredValue_TrimsAndPreservesUrl()
+    {
+        var result = ServerUrlValidator.Resolve("  https://relego.example.com/base/  ", out var uri, out var resolvedValue);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Valid, result);
+        Assert.NotNull(uri);
+        Assert.Equal("https://relego.example.com/base/", resolvedValue);
+        Assert.Equal("https://relego.example.com/base", uri.ToString().TrimEnd('/'));
+    }
+
+    [Fact]
     public void Validate_NullValue_ReturnsMissing()
     {
         var result = ServerUrlValidator.Validate(null, out var uri);

--- a/src/Relego.Tests/Cli/ServerUrlValidationTests.cs
+++ b/src/Relego.Tests/Cli/ServerUrlValidationTests.cs
@@ -1,4 +1,4 @@
-using Relego.Cli.Infrastructure;
+﻿using Relego.Cli.Infrastructure;
 
 namespace Relego.Tests.Cli;
 
@@ -13,6 +13,14 @@ public sealed class ServerUrlValidationTests
     }
 
     [Fact]
+    public void GetConfiguredOrDefault_EnvironmentValue_ReturnsEnvironmentOverride()
+    {
+        var value = ServerUrlValidator.GetConfiguredOrDefault("http://localhost:8080", "  https://relego.example.com/api  ");
+
+        Assert.Equal("https://relego.example.com/api", value);
+    }
+
+    [Fact]
     public void Resolve_MissingValue_ReturnsValidDefaultUri()
     {
         var result = ServerUrlValidator.Resolve(null, out var uri, out var resolvedValue);
@@ -21,6 +29,17 @@ public sealed class ServerUrlValidationTests
         Assert.NotNull(uri);
         Assert.Equal(ServerUrlValidator.DefaultServerUrl, resolvedValue);
         Assert.Equal(ServerUrlValidator.DefaultServerUrl, uri.ToString().TrimEnd('/'));
+    }
+
+    [Fact]
+    public void Resolve_EnvironmentOverride_WinsOverConfiguredValue()
+    {
+        var result = ServerUrlValidator.Resolve("http://localhost:8080", "  https://relego.example.com/base/  ", out var uri, out var resolvedValue);
+
+        Assert.Equal(ServerUrlValidator.ValidationResult.Valid, result);
+        Assert.NotNull(uri);
+        Assert.Equal("https://relego.example.com/base/", resolvedValue);
+        Assert.Equal("https://relego.example.com/base", uri.ToString().TrimEnd('/'));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- resolve `relego_server` to the documented `http://localhost:8080` default when no config file is present
- propagate the resolved URL through startup so standalone binaries and server error messages stay consistent
- add regression coverage for default server URL resolution

## Validation
- `dotnet publish src/Relego.Cli/Relego.Cli.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o artifacts/repro-cli`
- ran the published executable from a clean directory containing only `relego.exe`; `status` now returns an actionable connection error instead of `System.NullReferenceException`
- `runTests`: CLI test suite (64 passed)

Closes #259