### PR TITLE
Fix environment variable name in docker-compose.yml for relego-cli service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     restart: "no"
     tty: true
     environment:
-      RELEGO_SERVER: http://relego-server:8080
+      SERVER_URL: http://relego-server:8080
     networks:
       - relego
     profiles: [client]


### PR DESCRIPTION
Update the environment variable name for the relego-cli service in the docker-compose.yml file to ensure proper configuration.