### PR TITLE
Add Winget files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,9 @@ _pkginfo.txt
 *.appxbundle
 *.appxupload
 
+# Winget
+.winget
+
 # Visual Studio cache files
 # files ending in .cache can be ignored
 *.[Cc]ache


### PR DESCRIPTION
Include `.winget` files in the `.gitignore` to prevent them from being tracked by Git.