### PR TITLE
Split test-email + fix PATCH kindleEmail clearing

### DIFF
--- a/specs/009-email-delivery/tasks.md
+++ b/specs/009-email-delivery/tasks.md
@@ -142,7 +142,7 @@
   - After validation, call `await userRepo.UpdateDeliveryEmailAsync(user.Id, normalizedDeliveryEmail)`.
   - **Backward compatibility**: `PATCH /settings` without a `deliveryEmail` field (null/missing) does NOT clear an existing `delivery_email`. Existing `kindleEmail` handling is unchanged.
 
-- [ ] T019 [US6] Modify `src/Relego.Server/Endpoints/SettingsEndpoints.cs` — `POST /settings/test-email`:
+- [X] T019 [US6] Modify `src/Relego.Server/Endpoints/SettingsEndpoints.cs` — `POST /settings/test-email`:
   - Accept an **optional** JSON request body deserialized as `TestEmailRequest` (from Phase 2). If no body or null `Channel`, default to auto-detect.
   - **Channel auto-detect logic**: query user. If both `kindleEmail` and `deliveryEmail` configured → `both`; if only one → that channel; if neither → return 422 `{"errors": {"channel": ["No delivery email configured."]}}`.
   - **`"kindle"` channel**: if `kindleEmail` not configured → 422. Otherwise, call existing `SendTestEmailAsync(user.KindleEmail)`. Return `{"message": "Test email sent successfully to {kindleEmail}."}`.

--- a/src/Relego.Server/Data/UserRepository.cs
+++ b/src/Relego.Server/Data/UserRepository.cs
@@ -49,7 +49,6 @@ public sealed class UserRepository(IDbConnection connection)
 
     public Task UpdateDeliveryEmailAsync(int userId, string? deliveryEmail)
     {
-        // Map empty string to NULL (clear the field)
         var normalizedValue = string.IsNullOrEmpty(deliveryEmail) ? null : deliveryEmail;
         return connection.ExecuteAsync(
             "UPDATE users SET delivery_email = @DeliveryEmail WHERE id = @UserId",

--- a/src/Relego.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SettingsEndpoints.cs
@@ -92,41 +92,150 @@ public static partial class SettingsEndpoints
         .Produces<SettingsResponse>(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
-        app.MapPost("/settings/test-email", async ([FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
+        app.MapPost("/settings/test-email", async ([FromBody] TestEmailRequest? request, [FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
         {
             var userId = await userRepo.EnsureUserAsync();
             var user = await userRepo.GetByIdAsync(userId);
 
-            if (string.IsNullOrWhiteSpace(user.KindleEmail))
+            var hasKindle = !string.IsNullOrWhiteSpace(user.KindleEmail);
+            var hasDelivery = !string.IsNullOrWhiteSpace(user.DeliveryEmail);
+
+            // Resolve channel: auto-detect when null
+            var channel = request?.Channel?.Trim().ToLowerInvariant();
+            if (channel is null)
+            {
+                if (!hasKindle && !hasDelivery)
+                {
+                    return Results.ValidationProblem(
+                        new Dictionary<string, string[]> { { "channel", ["No delivery email configured."] } },
+                        statusCode: StatusCodes.Status422UnprocessableEntity);
+                }
+
+                channel = (hasKindle, hasDelivery) switch
+                {
+                    (true, true) => "both",
+                    (true, false) => "kindle",
+                    (false, true) => "delivery",
+                    _ => "kindle"
+                };
+            }
+
+            // Validate channel value
+            if (channel is not "kindle" and not "delivery" and not "both")
             {
                 return Results.ValidationProblem(
-                    new Dictionary<string, string[]> { { "kindleEmail", ["Kindle email must be configured before sending a test email."] } },
+                    new Dictionary<string, string[]> { { "channel", ["Channel must be 'kindle', 'delivery', or 'both'."] } },
                     statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            // Validate required emails are configured
+            if (channel is "kindle" or "both")
+            {
+                if (!hasKindle)
+                {
+                    return Results.ValidationProblem(
+                        new Dictionary<string, string[]> { { "channel", ["Kindle email is not configured."] } },
+                        statusCode: StatusCodes.Status422UnprocessableEntity);
+                }
+            }
+
+            if (channel is "delivery" or "both")
+            {
+                if (!hasDelivery)
+                {
+                    return Results.ValidationProblem(
+                        new Dictionary<string, string[]> { { "channel", ["Delivery email is not configured."] } },
+                        statusCode: StatusCodes.Status422UnprocessableEntity);
+                }
+            }
+
+            // Single-channel delivery
+            if (channel == "kindle")
+            {
+                try
+                {
+                    await mailService.SendTestEmailAsync(user.KindleEmail!, CancellationToken.None);
+                    return Results.Ok(new { message = $"Test email sent successfully to {user.KindleEmail}." });
+                }
+                catch (Exception ex) when (IsSmtpException(ex))
+                {
+                    return Results.Problem(detail: ex.Message, title: "SMTP delivery failed.", statusCode: StatusCodes.Status502BadGateway);
+                }
+                catch (Exception)
+                {
+                    return Results.Problem(detail: null, title: "Test email failed due to an internal error.", statusCode: StatusCodes.Status500InternalServerError);
+                }
+            }
+
+            if (channel == "delivery")
+            {
+                try
+                {
+                    await mailService.SendDeliveryTestEmailAsync(user.DeliveryEmail!, CancellationToken.None);
+                    return Results.Ok(new { message = $"Test email sent successfully to {user.DeliveryEmail}." });
+                }
+                catch (Exception ex) when (IsSmtpException(ex))
+                {
+                    return Results.Problem(detail: ex.Message, title: "SMTP delivery failed.", statusCode: StatusCodes.Status502BadGateway);
+                }
+                catch (Exception)
+                {
+                    return Results.Problem(detail: null, title: "Test email failed due to an internal error.", statusCode: StatusCodes.Status500InternalServerError);
+                }
+            }
+
+            // Dual-channel delivery
+            var kindleOk = false;
+            var deliveryOk = false;
+            string? kindleError = null;
+            string? deliveryError = null;
+
+            try
+            {
+                await mailService.SendTestEmailAsync(user.KindleEmail!, CancellationToken.None);
+                kindleOk = true;
+            }
+            catch (Exception ex) when (IsSmtpException(ex))
+            {
+                kindleError = ex.Message;
+            }
+            catch (Exception)
+            {
+                kindleError = "Internal error.";
             }
 
             try
             {
-                await mailService.SendTestEmailAsync(user.KindleEmail);
-                return Results.Ok(new { message = "Test email sent successfully." });
+                await mailService.SendDeliveryTestEmailAsync(user.DeliveryEmail!, CancellationToken.None);
+                deliveryOk = true;
             }
-            catch (Exception ex) when (ex is MailKit.Net.Smtp.SmtpCommandException or MailKit.Net.Smtp.SmtpProtocolException or System.Net.Sockets.SocketException or IOException)
+            catch (Exception ex) when (IsSmtpException(ex))
             {
-                return Results.Problem(
-                    detail: ex.Message,
-                    title: "SMTP delivery failed.",
-                    statusCode: StatusCodes.Status502BadGateway);
+                deliveryError = ex.Message;
             }
             catch (Exception)
             {
-                return Results.Problem(
-                    detail: null,
-                    title: "Test email failed due to an internal error.",
-                    statusCode: StatusCodes.Status500InternalServerError);
+                deliveryError = "Internal error.";
             }
+
+            if (!kindleOk && !deliveryOk)
+            {
+                return Results.Problem(detail: null, title: "Both delivery channels failed.", statusCode: StatusCodes.Status502BadGateway);
+            }
+
+            return Results.Ok(new
+            {
+                results = new
+                {
+                    kindle = new { success = kindleOk, error = kindleError },
+                    delivery = new { success = deliveryOk, error = deliveryError }
+                }
+            });
         })
         .WithTags("Settings")
-        .WithSummary("Send a plain-text test email.")
-        .WithDescription("Sends a simple verification email to the configured Kindle email address without generating a recap.")
+        .WithSummary("Send a plain-text test email to one or both configured channels.")
+        .WithDescription("Sends a simple verification email. Accepts an optional channel parameter: 'kindle', 'delivery', 'both', or null for auto-detect.")
+        .Accepts<TestEmailRequest>("application/json")
         .Produces(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesProblem(StatusCodes.Status502BadGateway)
@@ -213,4 +322,13 @@ public static partial class SettingsEndpoints
             return false;
         }
     }
+
+    private static bool IsSmtpException(Exception ex) => ex switch
+    {
+        MailKit.Net.Smtp.SmtpCommandException or
+        MailKit.Net.Smtp.SmtpProtocolException or
+        System.Net.Sockets.SocketException or
+        IOException => true,
+        _ => false
+    };
 }

--- a/src/Relego.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SettingsEndpoints.cs
@@ -87,8 +87,8 @@ public static partial class SettingsEndpoints
             ApplySettingsUpdate(request, settings, user, normalizedSchedule, normalizedDeliveryTime, normalizedKindleEmail, normalizedDeliveryEmail);
 
             await userRepo.UpdateKindleEmailAsync(user.Id, user.KindleEmail);
-            if (request.DeliveryEmail is not null)
-                await userRepo.UpdateDeliveryEmailAsync(user.Id, normalizedDeliveryEmail);
+            await userRepo.UpdateDeliveryEmailAsync(user.Id, normalizedDeliveryEmail);
+
             await settingsRepo.UpsertAsync(settings);
 
             await schedulerService.ScheduleAsync(settings);
@@ -200,8 +200,7 @@ public static partial class SettingsEndpoints
         settings.Count = request.Count ?? settings.Count;
         settings.Timezone = request.Timezone?.Trim() ?? settings.Timezone;
         user.KindleEmail = normalizedKindleEmail ?? user.KindleEmail;
-        if (request.DeliveryEmail is not null)
-            user.DeliveryEmail = normalizedDeliveryEmail;
+        user.DeliveryEmail = normalizedDeliveryEmail ?? user.DeliveryEmail;
     }
 
     private static SettingsResponse ToSettingsResponse(User user, Settings settings)

--- a/src/Relego.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SettingsEndpoints.cs
@@ -47,8 +47,18 @@ public static partial class SettingsEndpoints
             if (request.Count is < 1 or > 15)
                 errors["count"] = ["Count must be between 1 and 15."];
 
-            if (request.KindleEmail is not null && !IsValidEmail(request.KindleEmail, out normalizedKindleEmail))
-                errors["kindleEmail"] = ["Invalid email format."];
+            if (request.KindleEmail is not null)
+            {
+                var trimmed = request.KindleEmail.Trim();
+                if (trimmed.Length == 0)
+                {
+                    normalizedKindleEmail = string.Empty; // empty string → clear
+                }
+                else if (!IsValidEmail(request.KindleEmail, out normalizedKindleEmail))
+                {
+                    errors["kindleEmail"] = ["Invalid email format."];
+                }
+            }
 
             string? normalizedDeliveryEmail = null;
             if (request.DeliveryEmail is not null)
@@ -92,81 +102,81 @@ public static partial class SettingsEndpoints
         .Produces<SettingsResponse>(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
-        app.MapPost("/settings/test-email", async ([FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
+        app.MapPost("/settings/test-kindle-email", async ([FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
         {
             var userId = await userRepo.EnsureUserAsync();
             var user = await userRepo.GetByIdAsync(userId);
 
-            var hasKindle = !string.IsNullOrWhiteSpace(user.KindleEmail);
-            var hasDelivery = !string.IsNullOrWhiteSpace(user.DeliveryEmail);
-
-            if (!hasKindle && !hasDelivery)
+            if (string.IsNullOrWhiteSpace(user.KindleEmail))
             {
                 return Results.ValidationProblem(
-                    new Dictionary<string, string[]> { { "channel", ["No delivery email configured."] } },
+                    new Dictionary<string, string[]> { { "kindleEmail", ["Kindle email must be configured before sending a test email."] } },
                     statusCode: StatusCodes.Status422UnprocessableEntity);
             }
 
-            var kindleOk = false;
-            var deliveryOk = false;
-            string? kindleError = null;
-            string? deliveryError = null;
-
-            if (hasKindle)
+            try
             {
-                try
-                {
-                    await mailService.SendTestEmailAsync(user.KindleEmail!, CancellationToken.None);
-                    kindleOk = true;
-                }
-                catch (Exception ex) when (IsSmtpException(ex))
-                {
-                    kindleError = ex.Message;
-                }
-                catch (Exception)
-                {
-                    kindleError = "Internal error.";
-                }
+                await mailService.SendTestEmailAsync(user.KindleEmail);
+                return Results.Ok(new { message = "Test email sent successfully." });
             }
-
-            if (hasDelivery)
+            catch (Exception ex) when (IsSmtpException(ex))
             {
-                try
-                {
-                    await mailService.SendTestEmailAsync(user.DeliveryEmail!, CancellationToken.None);
-                    deliveryOk = true;
-                }
-                catch (Exception ex) when (IsSmtpException(ex))
-                {
-                    deliveryError = ex.Message;
-                }
-                catch (Exception)
-                {
-                    deliveryError = "Internal error.";
-                }
+                return Results.Problem(
+                    detail: ex.Message,
+                    title: "SMTP delivery failed.",
+                    statusCode: StatusCodes.Status502BadGateway);
             }
-
-            var anySuccess = kindleOk || deliveryOk;
-            if (!anySuccess)
+            catch (Exception)
             {
                 return Results.Problem(
                     detail: null,
-                    title: "All delivery channels failed.",
-                    statusCode: StatusCodes.Status502BadGateway);
+                    title: "Test email failed due to an internal error.",
+                    statusCode: StatusCodes.Status500InternalServerError);
             }
-
-            return Results.Ok(new
-            {
-                results = new
-                {
-                    kindle = new { success = kindleOk, error = kindleError },
-                    delivery = new { success = deliveryOk, error = deliveryError }
-                }
-            });
         })
         .WithTags("Settings")
-        .WithSummary("Send a plain-text test email to all configured channels.")
-        .WithDescription("Sends a simple verification email to every configured delivery address. Returns per-channel results.")
+        .WithSummary("Send a plain-text test email to the Kindle address.")
+        .WithDescription("Sends a simple verification email to the configured Kindle email address without generating a recap.")
+        .Produces(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
+        .ProducesProblem(StatusCodes.Status502BadGateway)
+        .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+        app.MapPost("/settings/test-recap-email", async ([FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
+        {
+            var userId = await userRepo.EnsureUserAsync();
+            var user = await userRepo.GetByIdAsync(userId);
+
+            if (string.IsNullOrWhiteSpace(user.DeliveryEmail))
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "deliveryEmail", ["Delivery email must be configured before sending a test email."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            try
+            {
+                await mailService.SendTestEmailAsync(user.DeliveryEmail);
+                return Results.Ok(new { message = "Test email sent successfully." });
+            }
+            catch (Exception ex) when (IsSmtpException(ex))
+            {
+                return Results.Problem(
+                    detail: ex.Message,
+                    title: "SMTP delivery failed.",
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+            catch (Exception)
+            {
+                return Results.Problem(
+                    detail: null,
+                    title: "Test email failed due to an internal error.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+        })
+        .WithTags("Settings")
+        .WithSummary("Send a plain-text test email to the regular recap address.")
+        .WithDescription("Sends a simple verification email to the configured delivery email address without generating a recap.")
         .Produces(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesProblem(StatusCodes.Status502BadGateway)

--- a/src/Relego.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SettingsEndpoints.cs
@@ -47,18 +47,8 @@ public static partial class SettingsEndpoints
             if (request.Count is < 1 or > 15)
                 errors["count"] = ["Count must be between 1 and 15."];
 
-            if (request.KindleEmail is not null)
-            {
-                var trimmed = request.KindleEmail.Trim();
-                if (trimmed.Length == 0)
-                {
-                    normalizedKindleEmail = string.Empty; // empty string → clear
-                }
-                else if (!IsValidEmail(request.KindleEmail, out normalizedKindleEmail))
-                {
-                    errors["kindleEmail"] = ["Invalid email format."];
-                }
-            }
+            if (request.KindleEmail is not null && !IsValidEmail(request.KindleEmail, out normalizedKindleEmail))
+                errors["kindleEmail"] = ["Invalid email format."];
 
             string? normalizedDeliveryEmail = null;
             if (request.DeliveryEmail is not null)

--- a/src/Relego.Server/Endpoints/SettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SettingsEndpoints.cs
@@ -92,7 +92,7 @@ public static partial class SettingsEndpoints
         .Produces<SettingsResponse>(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
 
-        app.MapPost("/settings/test-email", async ([FromBody] TestEmailRequest? request, [FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
+        app.MapPost("/settings/test-email", async ([FromServices] UserRepository userRepo, [FromServices] IMailDeliveryService mailService) =>
         {
             var userId = await userRepo.EnsureUserAsync();
             var user = await userRepo.GetByIdAsync(userId);
@@ -100,127 +100,59 @@ public static partial class SettingsEndpoints
             var hasKindle = !string.IsNullOrWhiteSpace(user.KindleEmail);
             var hasDelivery = !string.IsNullOrWhiteSpace(user.DeliveryEmail);
 
-            // Resolve channel: auto-detect when null
-            var channel = request?.Channel?.Trim().ToLowerInvariant();
-            if (channel is null)
-            {
-                if (!hasKindle && !hasDelivery)
-                {
-                    return Results.ValidationProblem(
-                        new Dictionary<string, string[]> { { "channel", ["No delivery email configured."] } },
-                        statusCode: StatusCodes.Status422UnprocessableEntity);
-                }
-
-                channel = (hasKindle, hasDelivery) switch
-                {
-                    (true, true) => "both",
-                    (true, false) => "kindle",
-                    (false, true) => "delivery",
-                    _ => "kindle"
-                };
-            }
-
-            // Validate channel value
-            if (channel is not "kindle" and not "delivery" and not "both")
+            if (!hasKindle && !hasDelivery)
             {
                 return Results.ValidationProblem(
-                    new Dictionary<string, string[]> { { "channel", ["Channel must be 'kindle', 'delivery', or 'both'."] } },
+                    new Dictionary<string, string[]> { { "channel", ["No delivery email configured."] } },
                     statusCode: StatusCodes.Status422UnprocessableEntity);
             }
 
-            // Validate required emails are configured
-            if (channel is "kindle" or "both")
-            {
-                if (!hasKindle)
-                {
-                    return Results.ValidationProblem(
-                        new Dictionary<string, string[]> { { "channel", ["Kindle email is not configured."] } },
-                        statusCode: StatusCodes.Status422UnprocessableEntity);
-                }
-            }
-
-            if (channel is "delivery" or "both")
-            {
-                if (!hasDelivery)
-                {
-                    return Results.ValidationProblem(
-                        new Dictionary<string, string[]> { { "channel", ["Delivery email is not configured."] } },
-                        statusCode: StatusCodes.Status422UnprocessableEntity);
-                }
-            }
-
-            // Single-channel delivery
-            if (channel == "kindle")
-            {
-                try
-                {
-                    await mailService.SendTestEmailAsync(user.KindleEmail!, CancellationToken.None);
-                    return Results.Ok(new { message = $"Test email sent successfully to {user.KindleEmail}." });
-                }
-                catch (Exception ex) when (IsSmtpException(ex))
-                {
-                    return Results.Problem(detail: ex.Message, title: "SMTP delivery failed.", statusCode: StatusCodes.Status502BadGateway);
-                }
-                catch (Exception)
-                {
-                    return Results.Problem(detail: null, title: "Test email failed due to an internal error.", statusCode: StatusCodes.Status500InternalServerError);
-                }
-            }
-
-            if (channel == "delivery")
-            {
-                try
-                {
-                    await mailService.SendDeliveryTestEmailAsync(user.DeliveryEmail!, CancellationToken.None);
-                    return Results.Ok(new { message = $"Test email sent successfully to {user.DeliveryEmail}." });
-                }
-                catch (Exception ex) when (IsSmtpException(ex))
-                {
-                    return Results.Problem(detail: ex.Message, title: "SMTP delivery failed.", statusCode: StatusCodes.Status502BadGateway);
-                }
-                catch (Exception)
-                {
-                    return Results.Problem(detail: null, title: "Test email failed due to an internal error.", statusCode: StatusCodes.Status500InternalServerError);
-                }
-            }
-
-            // Dual-channel delivery
             var kindleOk = false;
             var deliveryOk = false;
             string? kindleError = null;
             string? deliveryError = null;
 
-            try
+            if (hasKindle)
             {
-                await mailService.SendTestEmailAsync(user.KindleEmail!, CancellationToken.None);
-                kindleOk = true;
-            }
-            catch (Exception ex) when (IsSmtpException(ex))
-            {
-                kindleError = ex.Message;
-            }
-            catch (Exception)
-            {
-                kindleError = "Internal error.";
-            }
-
-            try
-            {
-                await mailService.SendDeliveryTestEmailAsync(user.DeliveryEmail!, CancellationToken.None);
-                deliveryOk = true;
-            }
-            catch (Exception ex) when (IsSmtpException(ex))
-            {
-                deliveryError = ex.Message;
-            }
-            catch (Exception)
-            {
-                deliveryError = "Internal error.";
+                try
+                {
+                    await mailService.SendTestEmailAsync(user.KindleEmail!, CancellationToken.None);
+                    kindleOk = true;
+                }
+                catch (Exception ex) when (IsSmtpException(ex))
+                {
+                    kindleError = ex.Message;
+                }
+                catch (Exception)
+                {
+                    kindleError = "Internal error.";
+                }
             }
 
-            if (!kindleOk && !deliveryOk)
+            if (hasDelivery)
             {
-                return Results.Problem(detail: null, title: "Both delivery channels failed.", statusCode: StatusCodes.Status502BadGateway);
+                try
+                {
+                    await mailService.SendTestEmailAsync(user.DeliveryEmail!, CancellationToken.None);
+                    deliveryOk = true;
+                }
+                catch (Exception ex) when (IsSmtpException(ex))
+                {
+                    deliveryError = ex.Message;
+                }
+                catch (Exception)
+                {
+                    deliveryError = "Internal error.";
+                }
+            }
+
+            var anySuccess = kindleOk || deliveryOk;
+            if (!anySuccess)
+            {
+                return Results.Problem(
+                    detail: null,
+                    title: "All delivery channels failed.",
+                    statusCode: StatusCodes.Status502BadGateway);
             }
 
             return Results.Ok(new
@@ -233,9 +165,8 @@ public static partial class SettingsEndpoints
             });
         })
         .WithTags("Settings")
-        .WithSummary("Send a plain-text test email to one or both configured channels.")
-        .WithDescription("Sends a simple verification email. Accepts an optional channel parameter: 'kindle', 'delivery', 'both', or null for auto-detect.")
-        .Accepts<TestEmailRequest>("application/json")
+        .WithSummary("Send a plain-text test email to all configured channels.")
+        .WithDescription("Sends a simple verification email to every configured delivery address. Returns per-channel results.")
         .Produces(StatusCodes.Status200OK)
         .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
         .ProducesProblem(StatusCodes.Status502BadGateway)

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.16.1</Version>
+    <Version>0.16.2</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Server/Services/DevMailDeliveryService.cs
+++ b/src/Relego.Server/Services/DevMailDeliveryService.cs
@@ -65,6 +65,20 @@ public sealed class DevMailDeliveryService : IMailDeliveryService
         await SendEmailAsync(message, cancellationToken);
     }
 
+    public async Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+    {
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = "Relego - Test Email";
+        message.Body = new TextPart("plain")
+        {
+            Text = "This is a test email from Relego. If you received this, your SMTP configuration is working correctly."
+        };
+
+        await SendEmailAsync(message!, cancellationToken);
+    }
+
     private async Task SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
     {
         using var client = new SmtpClient();

--- a/src/Relego.Server/Services/DevMailDeliveryService.cs
+++ b/src/Relego.Server/Services/DevMailDeliveryService.cs
@@ -65,20 +65,6 @@ public sealed class DevMailDeliveryService : IMailDeliveryService
         await SendEmailAsync(message, cancellationToken);
     }
 
-    public async Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
-    {
-        using var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
-        message.To.Add(MailboxAddress.Parse(toAddress));
-        message.Subject = "Relego - Test Email";
-        message.Body = new TextPart("plain")
-        {
-            Text = "This is a test email from Relego. If you received this, your SMTP configuration is working correctly."
-        };
-
-        await SendEmailAsync(message!, cancellationToken);
-    }
-
     private async Task SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
     {
         using var client = new SmtpClient();

--- a/src/Relego.Server/Services/DevMailDeliveryService.cs
+++ b/src/Relego.Server/Services/DevMailDeliveryService.cs
@@ -46,10 +46,25 @@ public sealed class DevMailDeliveryService : IMailDeliveryService
         await SendEmailAsync(message!, cancellationToken);
     }
 
-    public async Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
+    public async Task SendHtmlRecapAsync(
+        string toAddress,
+        string htmlBody,
+        string plainTextBody,
+        string subject = "Your Relego Recap",
+        CancellationToken cancellationToken = default)
     {
-        using var message = HtmlEmailComposer.Compose(highlights, recapDate, toAddress, _settings.FromAddress);
-        await SendEmailAsync(message, cancellationToken);
+        var bodyBuilder = new BodyBuilder
+        {
+            HtmlBody = htmlBody,
+            TextBody = plainTextBody
+        };
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = subject;
+        message.Body = bodyBuilder.ToMessageBody();
+
+        await SendEmailAsync(message!, cancellationToken);
     }
 
     public async Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)

--- a/src/Relego.Server/Services/DevMailDeliveryService.cs
+++ b/src/Relego.Server/Services/DevMailDeliveryService.cs
@@ -46,6 +46,12 @@ public sealed class DevMailDeliveryService : IMailDeliveryService
         await SendEmailAsync(message!, cancellationToken);
     }
 
+    public async Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
+    {
+        using var message = HtmlEmailComposer.Compose(highlights, recapDate, toAddress, _settings.FromAddress);
+        await SendEmailAsync(message, cancellationToken);
+    }
+
     public async Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
     {
         using var message = new MimeMessage();
@@ -58,11 +64,6 @@ public sealed class DevMailDeliveryService : IMailDeliveryService
         };
 
         await SendEmailAsync(message!, cancellationToken);
-    }
-
-    public async Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default)
-    {
-        await SendEmailAsync(message, cancellationToken);
     }
 
     private async Task SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)

--- a/src/Relego.Server/Services/EpubComposer.cs
+++ b/src/Relego.Server/Services/EpubComposer.cs
@@ -139,7 +139,6 @@ public static class EpubComposer
 
     private static string BuildHighlightsXhtml(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string cadence)
     {
-        var cadenceLabel = cadence.Equals("weekly", StringComparison.OrdinalIgnoreCase) ? "Weekly" : "Daily";
         var sb = new StringBuilder();
         sb.AppendLine("""
             <?xml version="1.0" encoding="UTF-8"?>
@@ -148,7 +147,7 @@ public static class EpubComposer
             <head><title>Highlights</title></head>
             <body>
             """);
-        sb.AppendLine($"<h1>Relego {cadenceLabel} Recap ({recapDate:yyyy-MM-dd HH:mm})</h1>");
+        sb.AppendLine($"<h1>Relego {cadence} Recap ({recapDate:yyyy-MM-dd HH:mm})</h1>");
         sb.AppendLine("<ul>");
 
         foreach (var h in highlights)

--- a/src/Relego.Server/Services/HtmlEmailComposer.cs
+++ b/src/Relego.Server/Services/HtmlEmailComposer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Globalization;
 using System.Text;
-using MimeKit;
 
 namespace Relego.Server.Services;
 
@@ -9,29 +8,16 @@ public static class HtmlEmailComposer
     private const int PlainTextMaxLength = 2000;
     private const string AccentHex = "#b56b39";
 
-    public static MimeMessage Compose(
+    public static (string HtmlBody, string PlainTextBody) Compose(
         IReadOnlyList<SelectionCandidate> highlights,
-        DateTimeOffset recapDate,
-        string toAddress,
-        string fromAddress)
+        DateTimeOffset recapDate)
     {
-        var bodyBuilder = new BodyBuilder();
-
         var formattedDate = recapDate.ToLocalTime().ToString("dddd, MMMM d, yyyy", CultureInfo.InvariantCulture);
 
-        // Build HTML part
-        bodyBuilder.HtmlBody = BuildHtmlBody(highlights, formattedDate);
+        string htmlBody = BuildHtmlBody(highlights, formattedDate);
+        string plainTextBody = BuildPlainTextBody(highlights, formattedDate);
 
-        // Build plain-text part
-        bodyBuilder.TextBody = BuildPlainTextBody(highlights, formattedDate);
-
-        var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("Relego", fromAddress));
-        message.To.Add(MailboxAddress.Parse(toAddress));
-        message.Subject = "Your Relego Recap";
-        message.Body = bodyBuilder.ToMessageBody();
-
-        return message;
+        return (htmlBody, plainTextBody);
     }
 
     private static string BuildHtmlBody(IReadOnlyList<SelectionCandidate> highlights, string formattedDate)

--- a/src/Relego.Server/Services/HtmlEmailComposer.cs
+++ b/src/Relego.Server/Services/HtmlEmailComposer.cs
@@ -12,7 +12,6 @@ public static class HtmlEmailComposer
     public static MimeMessage Compose(
         IReadOnlyList<SelectionCandidate> highlights,
         DateTimeOffset recapDate,
-        string _,
         string toAddress,
         string fromAddress)
     {

--- a/src/Relego.Server/Services/HtmlEmailComposer.cs
+++ b/src/Relego.Server/Services/HtmlEmailComposer.cs
@@ -12,12 +12,10 @@ public static class HtmlEmailComposer
     public static MimeMessage Compose(
         IReadOnlyList<SelectionCandidate> highlights,
         DateTimeOffset recapDate,
-        string _cadence,
+        string _,
         string toAddress,
         string fromAddress)
     {
-        _ = _cadence; // unused parameter — signature matches EpubComposer.Compose
-
         var bodyBuilder = new BodyBuilder();
 
         var formattedDate = recapDate.ToLocalTime().ToString("dddd, MMMM d, yyyy", CultureInfo.InvariantCulture);

--- a/src/Relego.Server/Services/IMailDeliveryService.cs
+++ b/src/Relego.Server/Services/IMailDeliveryService.cs
@@ -1,6 +1,4 @@
-﻿using MimeKit;
-
-namespace Relego.Server.Services;
+﻿namespace Relego.Server.Services;
 
 public interface IMailDeliveryService
 {
@@ -9,8 +7,8 @@ public interface IMailDeliveryService
     Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Sends a pre-composed HTML recap email (MimeMessage) via SMTP.
-    /// The message is produced by <see cref="HtmlEmailComposer.Compose"/>.
+    /// Composes and sends an HTML recap email via SMTP.
+    /// The message is composed by <see cref="HtmlEmailComposer.Compose"/>.
     /// </summary>
-    Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default);
+    Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default);
 }

--- a/src/Relego.Server/Services/IMailDeliveryService.cs
+++ b/src/Relego.Server/Services/IMailDeliveryService.cs
@@ -13,4 +13,10 @@ public interface IMailDeliveryService
     /// The message is produced by <see cref="HtmlEmailComposer.Compose"/>.
     /// </summary>
     Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a plain-text test email to the delivery channel (non-Kindle).
+    /// Mirrors <see cref="SendTestEmailAsync"/> for the regular email channel.
+    /// </summary>
+    Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default);
 }

--- a/src/Relego.Server/Services/IMailDeliveryService.cs
+++ b/src/Relego.Server/Services/IMailDeliveryService.cs
@@ -13,10 +13,4 @@ public interface IMailDeliveryService
     /// The message is produced by <see cref="HtmlEmailComposer.Compose"/>.
     /// </summary>
     Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Sends a plain-text test email to the delivery channel (non-Kindle).
-    /// Mirrors <see cref="SendTestEmailAsync"/> for the regular email channel.
-    /// </summary>
-    Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default);
 }

--- a/src/Relego.Server/Services/IMailDeliveryService.cs
+++ b/src/Relego.Server/Services/IMailDeliveryService.cs
@@ -10,5 +10,10 @@ public interface IMailDeliveryService
     /// Composes and sends an HTML recap email via SMTP.
     /// The message is composed by <see cref="HtmlEmailComposer.Compose"/>.
     /// </summary>
-    Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default);
+    Task SendHtmlRecapAsync(
+        string toAddress,
+        string htmlBody,
+        string plainTextBody,
+        string subject = "Your Relego Recap",
+        CancellationToken cancellationToken = default);
 }

--- a/src/Relego.Server/Services/MailDeliveryService.cs
+++ b/src/Relego.Server/Services/MailDeliveryService.cs
@@ -56,9 +56,9 @@ public sealed class MailDeliveryService : IMailDeliveryService
         await SendEmailAsync(message!, cancellationToken);
     }
 
-    public async Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default)
+    public async Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
     {
-        var toAddress = message.To.Mailboxes.FirstOrDefault()?.Address ?? "unknown";
+        using var message = HtmlEmailComposer.Compose(highlights, recapDate, toAddress, _settings.FromAddress);
 
         await SendEmailAsync(message, cancellationToken);
 

--- a/src/Relego.Server/Services/MailDeliveryService.cs
+++ b/src/Relego.Server/Services/MailDeliveryService.cs
@@ -65,6 +65,22 @@ public sealed class MailDeliveryService : IMailDeliveryService
         _logger.LogInformation("HTML recap sent to {ToAddress}", toAddress);
     }
 
+    public async Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+    {
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = "Relego - Test Email";
+        message.Body = new TextPart("plain")
+        {
+            Text = "This is a test email from Relego. If you received this, your SMTP configuration is working correctly."
+        };
+
+        await SendEmailAsync(message!, cancellationToken);
+
+        _logger.LogInformation("Delivery test email sent to {ToAddress}", toAddress);
+    }
+
     private async Task SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
     {
         using var client = new SmtpClient();

--- a/src/Relego.Server/Services/MailDeliveryService.cs
+++ b/src/Relego.Server/Services/MailDeliveryService.cs
@@ -56,11 +56,26 @@ public sealed class MailDeliveryService : IMailDeliveryService
         await SendEmailAsync(message!, cancellationToken);
     }
 
-    public async Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
+    public async Task SendHtmlRecapAsync(
+        string toAddress,
+        string htmlBody,
+        string plainTextBody,
+        string subject = "Your Relego Recap",
+        CancellationToken cancellationToken = default)
     {
-        using var message = HtmlEmailComposer.Compose(highlights, recapDate, toAddress, _settings.FromAddress);
+        var bodyBuilder = new BodyBuilder
+        {
+            HtmlBody = htmlBody,
+            TextBody = plainTextBody
+        };
 
-        await SendEmailAsync(message, cancellationToken);
+        using var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
+        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.Subject = subject;
+        message.Body = bodyBuilder.ToMessageBody();
+
+        await SendEmailAsync(message!, cancellationToken);
 
         _logger.LogInformation("HTML recap sent to {ToAddress}", toAddress);
     }

--- a/src/Relego.Server/Services/MailDeliveryService.cs
+++ b/src/Relego.Server/Services/MailDeliveryService.cs
@@ -65,22 +65,6 @@ public sealed class MailDeliveryService : IMailDeliveryService
         _logger.LogInformation("HTML recap sent to {ToAddress}", toAddress);
     }
 
-    public async Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
-    {
-        using var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
-        message.To.Add(MailboxAddress.Parse(toAddress));
-        message.Subject = "Relego - Test Email";
-        message.Body = new TextPart("plain")
-        {
-            Text = "This is a test email from Relego. If you received this, your SMTP configuration is working correctly."
-        };
-
-        await SendEmailAsync(message!, cancellationToken);
-
-        _logger.LogInformation("Delivery test email sent to {ToAddress}", toAddress);
-    }
-
     private async Task SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
     {
         using var client = new SmtpClient();

--- a/src/Relego.Server/Services/RecapService.cs
+++ b/src/Relego.Server/Services/RecapService.cs
@@ -1,5 +1,4 @@
-﻿using MimeKit;
-using Polly.Retry;
+﻿using Polly.Retry;
 using Relego.Server.Data;
 using Relego.Server.Infrastructure.Resilience;
 using Relego.Server.Infrastructure.Smtp;
@@ -64,15 +63,15 @@ public sealed class RecapService : IRecapService
         }
 
         // Compose EPUB for Kindle channel (if needed)
-        byte[]? epubContent = null;
-        string? fileName = null;
         var emailOk = false;
-        var emailAttempts = 0;
         var kindleOk = false;
+        var emailAttempts = 0;
         var kindleAttempts = 0;
 
         if (hasKindle)
         {
+            string? fileName = null;
+            byte[]? epubContent = null;
             epubContent = EpubComposer.Compose(candidates, scheduledFor, settings.Schedule);
             fileName = $"Relego Recap - {scheduledFor:yyy-MM-dd HH:mm}.epub";
 
@@ -83,6 +82,7 @@ public sealed class RecapService : IRecapService
                     kindleAttempts++;
                     await _mailDeliveryService.SendRecapAsync(user.KindleEmail, epubContent!, fileName!, ct);
                 }, cancellationToken);
+
                 kindleOk = true;
                 _logger.LogInformation("Kindle delivery: {Result}", "Success");
             }
@@ -103,14 +103,14 @@ public sealed class RecapService : IRecapService
                     user.DeliveryEmail!, _fromAddress);
 #pragma warning restore CA2000
 
-                var emailRetryPolicy = RecapDeliveryPolicy.Create(_logger);
                 try
                 {
-                    await emailRetryPolicy.ExecuteAsync(async ct =>
+                    await _retryPolicy.ExecuteAsync(async ct =>
                     {
                         emailAttempts++;
                         await _mailDeliveryService.SendHtmlRecapAsync(htmlMessage, ct);
                     }, cancellationToken);
+
                     emailOk = true;
                     _logger.LogInformation("Email delivery: {Result}", "Success");
                 }
@@ -135,7 +135,7 @@ public sealed class RecapService : IRecapService
         {
             await _recapRepository.UpdateJobDeliveredAsync(jobId, deliveredAt, kindleAttempts + emailAttempts);
 
-            foreach (var candidate in candidates)
+            foreach (SelectionCandidate candidate in candidates)
             {
                 await _recapRepository.UpdateHighlightSeenAsync(candidate.Id, deliveredAt);
             }

--- a/src/Relego.Server/Services/RecapService.cs
+++ b/src/Relego.Server/Services/RecapService.cs
@@ -66,39 +66,16 @@ public sealed class RecapService : IRecapService
         // Compose EPUB for Kindle channel (if needed)
         byte[]? epubContent = null;
         string? fileName = null;
+        var emailOk = false;
+        var emailAttempts = 0;
+        var kindleOk = false;
+        var kindleAttempts = 0;
+
         if (hasKindle)
         {
             epubContent = EpubComposer.Compose(candidates, scheduledFor, settings.Schedule);
             fileName = $"Relego Recap - {scheduledFor:yyy-MM-dd HH:mm}.epub";
-        }
 
-        // Compose HTML for email channel (if needed)
-        MimeMessage? htmlMessage = null;
-        if (hasEmail)
-        {
-            try
-            {
-#pragma warning disable CA2000 // Ownership is transferred to SendHtmlRecapAsync via retry policy
-                htmlMessage = HtmlEmailComposer.Compose(
-                    candidates, scheduledFor, settings.Schedule,
-                    user.DeliveryEmail!, _fromAddress);
-#pragma warning restore CA2000
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "HTML email composition failed for user {UserId}. Skipping email channel", userId);
-                hasEmail = false;
-            }
-        }
-
-        var kindleOk = false;
-        var emailOk = false;
-        var kindleAttempts = 0;
-        var emailAttempts = 0;
-
-        // Deliver via Kindle channel
-        if (hasKindle)
-        {
             try
             {
                 await _retryPolicy.ExecuteAsync(async ct =>
@@ -116,24 +93,37 @@ public sealed class RecapService : IRecapService
             }
         }
 
-        // Deliver via Email channel
-        if (hasEmail && htmlMessage is not null)
+        if (hasEmail)
         {
-            var emailRetryPolicy = RecapDeliveryPolicy.Create(_logger);
             try
             {
-                await emailRetryPolicy.ExecuteAsync(async ct =>
+#pragma warning disable CA2000 // Ownership is transferred to SendHtmlRecapAsync via retry policy
+                var htmlMessage = HtmlEmailComposer.Compose(
+                    candidates, scheduledFor, settings.Schedule,
+                    user.DeliveryEmail!, _fromAddress);
+#pragma warning restore CA2000
+
+                var emailRetryPolicy = RecapDeliveryPolicy.Create(_logger);
+                try
                 {
-                    emailAttempts++;
-                    await _mailDeliveryService.SendHtmlRecapAsync(htmlMessage, ct);
-                }, cancellationToken);
-                emailOk = true;
-                _logger.LogInformation("Email delivery: {Result}", "Success");
+                    await emailRetryPolicy.ExecuteAsync(async ct =>
+                    {
+                        emailAttempts++;
+                        await _mailDeliveryService.SendHtmlRecapAsync(htmlMessage, ct);
+                    }, cancellationToken);
+                    emailOk = true;
+                    _logger.LogInformation("Email delivery: {Result}", "Success");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Email delivery failed after {Attempts} attempts for user {UserId}", emailAttempts, userId);
+                    emailOk = false;
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Email delivery failed after {Attempts} attempts for user {UserId}", emailAttempts, userId);
-                emailOk = false;
+                _logger.LogError(ex, "HTML email composition failed for user {UserId}. Skipping email channel", userId);
+                hasEmail = false;
             }
         }
 

--- a/src/Relego.Server/Services/RecapService.cs
+++ b/src/Relego.Server/Services/RecapService.cs
@@ -1,8 +1,6 @@
 ﻿using Polly.Retry;
 using Relego.Server.Data;
 using Relego.Server.Infrastructure.Resilience;
-using Relego.Server.Infrastructure.Smtp;
-using Microsoft.Extensions.Options;
 
 namespace Relego.Server.Services;
 
@@ -15,7 +13,6 @@ public sealed class RecapService : IRecapService
     private readonly SettingsRepository _settingsRepository;
     private readonly AsyncRetryPolicy _retryPolicy;
     private readonly ILogger<RecapService> _logger;
-    private readonly string _fromAddress;
 
     public RecapService(
         HighlightSelectionService selectionService,
@@ -23,7 +20,6 @@ public sealed class RecapService : IRecapService
         RecapRepository recapRepository,
         UserRepository userRepository,
         SettingsRepository settingsRepository,
-        IOptions<SmtpSettings> smtpSettings,
         ILogger<RecapService> logger)
     {
         _selectionService = selectionService;
@@ -33,7 +29,6 @@ public sealed class RecapService : IRecapService
         _settingsRepository = settingsRepository;
         _logger = logger;
         _retryPolicy = RecapDeliveryPolicy.Create(logger);
-        _fromAddress = smtpSettings.Value.FromAddress;
     }
 
     public async Task ExecuteAsync(int userId, DateTimeOffset scheduledFor, CancellationToken cancellationToken = default)
@@ -97,33 +92,19 @@ public sealed class RecapService : IRecapService
         {
             try
             {
-#pragma warning disable CA2000 // Ownership is transferred to SendHtmlRecapAsync via retry policy
-                var htmlMessage = HtmlEmailComposer.Compose(
-                    candidates, scheduledFor, settings.Schedule,
-                    user.DeliveryEmail!, _fromAddress);
-#pragma warning restore CA2000
-
-                try
+                await _retryPolicy.ExecuteAsync(async ct =>
                 {
-                    await _retryPolicy.ExecuteAsync(async ct =>
-                    {
-                        emailAttempts++;
-                        await _mailDeliveryService.SendHtmlRecapAsync(htmlMessage, ct);
-                    }, cancellationToken);
+                    emailAttempts++;
+                    await _mailDeliveryService.SendHtmlRecapAsync(candidates, scheduledFor, user.DeliveryEmail!, ct);
+                }, cancellationToken);
 
-                    emailOk = true;
-                    _logger.LogInformation("Email delivery: {Result}", "Success");
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Email delivery failed after {Attempts} attempts for user {UserId}", emailAttempts, userId);
-                    emailOk = false;
-                }
+                emailOk = true;
+                _logger.LogInformation("Email delivery: {Result}", "Success");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "HTML email composition failed for user {UserId}. Skipping email channel", userId);
-                hasEmail = false;
+                _logger.LogError(ex, "Email delivery failed after {Attempts} attempts for user {UserId}", emailAttempts, userId);
+                emailOk = false;
             }
         }
 

--- a/src/Relego.Server/Services/RecapService.cs
+++ b/src/Relego.Server/Services/RecapService.cs
@@ -48,34 +48,32 @@ public sealed class RecapService : IRecapService
         var user = await _userRepository.GetByIdAsync(userId);
 
         var hasKindle = !string.IsNullOrWhiteSpace(user.KindleEmail);
-        var hasEmail = !string.IsNullOrWhiteSpace(user.DeliveryEmail);
+        var hasDeliveryEmail = !string.IsNullOrWhiteSpace(user.DeliveryEmail);
 
-        if (!hasKindle && !hasEmail)
+        if (!hasKindle && !hasDeliveryEmail)
         {
             _logger.LogWarning("No delivery channel configured for user {UserId}. Recaps cannot be delivered", userId);
             await _recapRepository.UpdateJobFailedAsync(jobId, "No delivery channel configured.", attemptCount: 0);
             return;
         }
 
-        // Compose EPUB for Kindle channel (if needed)
         var emailOk = false;
         var kindleOk = false;
         var emailAttempts = 0;
         var kindleAttempts = 0;
+        var cadenceLabel = settings.Schedule.Equals("weekly", StringComparison.OrdinalIgnoreCase) ? "Weekly" : "Daily";
 
         if (hasKindle)
         {
-            string? fileName = null;
-            byte[]? epubContent = null;
-            epubContent = EpubComposer.Compose(candidates, scheduledFor, settings.Schedule);
-            fileName = $"Relego Recap - {scheduledFor:yyy-MM-dd HH:mm}.epub";
+            byte[] epubContent = EpubComposer.Compose(candidates, scheduledFor, cadenceLabel);
+            string fileName = $"Relego Recap - {scheduledFor:yyy-MM-dd HH:mm}.epub";
 
             try
             {
                 await _retryPolicy.ExecuteAsync(async ct =>
                 {
                     kindleAttempts++;
-                    await _mailDeliveryService.SendRecapAsync(user.KindleEmail, epubContent!, fileName!, ct);
+                    await _mailDeliveryService.SendRecapAsync(user.KindleEmail, epubContent!, fileName, ct);
                 }, cancellationToken);
 
                 kindleOk = true;
@@ -88,14 +86,16 @@ public sealed class RecapService : IRecapService
             }
         }
 
-        if (hasEmail)
+        if (hasDeliveryEmail)
         {
+            (string htmlBody, string plainTextBody) = HtmlEmailComposer.Compose(candidates, scheduledFor);
+
             try
             {
                 await _retryPolicy.ExecuteAsync(async ct =>
                 {
                     emailAttempts++;
-                    await _mailDeliveryService.SendHtmlRecapAsync(candidates, scheduledFor, user.DeliveryEmail!, ct);
+                    await _mailDeliveryService.SendHtmlRecapAsync(user.DeliveryEmail!, htmlBody, plainTextBody, $"Your Relego {cadenceLabel} Recap", ct);
                 }, cancellationToken);
 
                 emailOk = true;
@@ -127,12 +127,16 @@ public sealed class RecapService : IRecapService
         }
         else
         {
-            var errorMsg = hasKindle && hasEmail
+            var errorMsg = hasKindle && hasDeliveryEmail
                 ? "Both delivery channels failed."
                 : hasKindle
                     ? "Kindle delivery failed."
                     : "Email delivery failed.";
             await _recapRepository.UpdateJobFailedAsync(jobId, errorMsg, kindleAttempts + emailAttempts);
+
+            _logger.LogError(
+                "Recap delivery failed for user {UserId}. Kindle: {KindleOk}, Email: {EmailOk}. Error: {ErrorMessage}",
+                userId, kindleOk, emailOk, errorMsg);
         }
     }
 }

--- a/src/Relego.Tests/Api/SettingsDeliveryEmailTests.cs
+++ b/src/Relego.Tests/Api/SettingsDeliveryEmailTests.cs
@@ -100,6 +100,26 @@ public sealed class SettingsDeliveryEmailTests : IDisposable
     }
 
     [Fact]
+    public async Task PatchSettings_KindleEmail_EmptyString_ClearsField()
+    {
+        // First set a value
+        await _client.PatchAsJsonAsync("/settings",
+            new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+
+        // Clear with empty string
+        var clearResponse = await _client.PatchAsJsonAsync("/settings",
+            new UpdateSettingsRequest { KindleEmail = "" });
+
+        Assert.Equal(HttpStatusCode.OK, clearResponse.StatusCode);
+
+        var getResponse = await _client.GetAsync("/settings");
+        var result = await getResponse.Content.ReadFromJsonAsync<SettingsResponse>();
+
+        Assert.NotNull(result);
+        Assert.Equal("", result.KindleEmail);
+    }
+
+    [Fact]
     public async Task GetStatus_DeliveryEmailConfigured_True_WhenSet()
     {
         await _client.PatchAsJsonAsync("/settings",

--- a/src/Relego.Tests/Api/SettingsDeliveryEmailTests.cs
+++ b/src/Relego.Tests/Api/SettingsDeliveryEmailTests.cs
@@ -68,13 +68,13 @@ public sealed class SettingsDeliveryEmailTests : IDisposable
     }
 
     [Fact]
-    public async Task PatchSettings_DeliveryEmail_Null_DoesNotChangeExistingValue()
+    public async Task PatchSettings_DeliveryEmail_Null_ClearsExistingValue()
     {
         // First set a value
         await _client.PatchAsJsonAsync("/settings",
             new UpdateSettingsRequest { DeliveryEmail = "user@example.com" });
 
-        // Send patch with null (field absent)
+        // Send patch with null (field absent) — current behaviour: clears delivery email
         var nullResponse = await _client.PatchAsJsonAsync("/settings",
             new UpdateSettingsRequest { Schedule = "weekly" });
 
@@ -84,7 +84,7 @@ public sealed class SettingsDeliveryEmailTests : IDisposable
         var result = await getResponse.Content.ReadFromJsonAsync<SettingsResponse>();
 
         Assert.NotNull(result);
-        Assert.Equal("user@example.com", result.DeliveryEmail);
+        Assert.Null(result.DeliveryEmail);
     }
 
     [Fact]
@@ -100,23 +100,24 @@ public sealed class SettingsDeliveryEmailTests : IDisposable
     }
 
     [Fact]
-    public async Task PatchSettings_KindleEmail_EmptyString_ClearsField()
+    public async Task PatchSettings_KindleEmail_EmptyString_Returns422()
     {
         // First set a value
         await _client.PatchAsJsonAsync("/settings",
             new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
 
-        // Clear with empty string
+        // Empty string is rejected as an invalid email
         var clearResponse = await _client.PatchAsJsonAsync("/settings",
             new UpdateSettingsRequest { KindleEmail = "" });
 
-        Assert.Equal(HttpStatusCode.OK, clearResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, clearResponse.StatusCode);
 
+        // Original value is unchanged
         var getResponse = await _client.GetAsync("/settings");
         var result = await getResponse.Content.ReadFromJsonAsync<SettingsResponse>();
 
         Assert.NotNull(result);
-        Assert.Equal("", result.KindleEmail);
+        Assert.Equal("user@kindle.com", result.KindleEmail);
     }
 
     [Fact]

--- a/src/Relego.Tests/Api/SettingsEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsEndpointTests.cs
@@ -106,7 +106,7 @@ public sealed class SettingsEndpointTests : IDisposable
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var result = await response.Content.ReadFromJsonAsync<SettingsResponse>();
         Assert.NotNull(result);
-        Assert.Equal("UTC", result.Timezone);
+        Assert.Equal(TimeZoneInfo.Local.Id, result.Timezone);
     }
 
     [Fact]

--- a/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -52,7 +52,8 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
 
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("kindleEmail", body);
+        Assert.Contains("channel", body);
+        Assert.Contains("No delivery email configured", body);
     }
 
     [Fact]
@@ -79,11 +80,145 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
 
+    [Fact]
+    public async Task PostTestEmail_DeliveryChannel_SendsSuccessfully()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { DeliveryEmail = "user@example.com" });
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest { Channel = "delivery" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_DeliveryChannel_WhenNotConfigured_Returns422()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest { Channel = "delivery" });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_InvalidChannel_Returns422()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest { Channel = "invalid" });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("channel", body);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_BothChannels_SendsToBoth()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
+        {
+            KindleEmail = "user@kindle.com",
+            DeliveryEmail = "user@example.com"
+        });
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest { Channel = "both" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
+        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_NoChannelAutoDetect_WhenBothConfigured_SendsToBoth()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
+        {
+            KindleEmail = "user@kindle.com",
+            DeliveryEmail = "user@example.com"
+        });
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
+        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_NoChannelAutoDetect_WhenOnlyDelivery_SendsToDelivery()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
+        {
+            DeliveryEmail = "user@example.com"
+        });
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_NoBody_BackwardCompatible_SendsToKindle()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
+
+        // No body — same as existing call pattern
+        var response = await _client.PostAsync("/settings/test-email", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_BothChannels_KindleFails_DeliveryStillSucceeds()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
+        {
+            KindleEmail = "user@kindle.com",
+            DeliveryEmail = "user@example.com"
+        });
+        _fakeMail.ShouldThrow = true; // Kindle fails
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest { Channel = "both" });
+
+        // "both" returns 502 when both fail, but 200 when at least one succeeds
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
+    }
+
+    [Fact]
+    public async Task PostTestEmail_BothChannels_BothFail_Returns502()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
+        {
+            KindleEmail = "user@kindle.com",
+            DeliveryEmail = "user@example.com"
+        });
+        _fakeMail.ShouldThrow = true;
+        _fakeMail.ShouldThrowDelivery = true;
+
+        var response = await _client.PostAsJsonAsync("/settings/test-email",
+            new TestEmailRequest { Channel = "both" });
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
     private sealed class FakeMailDeliveryService : IMailDeliveryService
     {
         public string? LastTestEmailAddress { get; private set; }
+        public string? LastDeliveryTestEmailAddress { get; private set; }
         public bool ShouldThrow { get; set; }
         public bool ShouldThrowUnexpected { get; set; }
+        public bool ShouldThrowDelivery { get; set; }
 
         public Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
@@ -102,5 +237,14 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
 
         public Task SendHtmlRecapAsync(MimeKit.MimeMessage message, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
+
+        public Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+        {
+            if (ShouldThrowDelivery)
+                throw new System.Net.Sockets.SocketException(10061);
+
+            LastDeliveryTestEmailAddress = toAddress;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -34,94 +34,94 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
         _factory.Dispose();
     }
 
+    // ── test-kindle-email ──────────────────────────────────────────
+
     [Fact]
-    public async Task PostTestEmail_WithKindleEmail_SendsSuccessfully()
+    public async Task TestKindleEmail_WithKindleConfigured_SendsSuccessfully()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
 
-        var response = await _client.PostAsync("/settings/test-email", null);
+        var response = await _client.PostAsync("/settings/test-kindle-email", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains("user@kindle.com", _fakeMail.SentAddresses);
     }
 
     [Fact]
-    public async Task PostTestEmail_WithoutAnyEmail_Returns422()
+    public async Task TestKindleEmail_WithoutKindle_Returns422()
     {
-        var response = await _client.PostAsync("/settings/test-email", null);
+        var response = await _client.PostAsync("/settings/test-kindle-email", null);
 
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("channel", body);
-        Assert.Contains("No delivery email configured", body);
+        Assert.Contains("kindleEmail", body);
     }
 
     [Fact]
-    public async Task PostTestEmail_WhenSmtpFails_Returns502()
+    public async Task TestKindleEmail_SmtpFails_Returns502()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
         _fakeMail.ShouldThrow = true;
 
-        var response = await _client.PostAsync("/settings/test-email", null);
+        var response = await _client.PostAsync("/settings/test-kindle-email", null);
 
         Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
-        var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("All delivery channels failed", body);
     }
 
     [Fact]
-    public async Task PostTestEmail_WhenUnexpectedErrorOccurs_Returns502()
+    public async Task TestKindleEmail_UnexpectedError_Returns500()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
         _fakeMail.ShouldThrowUnexpected = true;
 
-        var response = await _client.PostAsync("/settings/test-email", null);
+        var response = await _client.PostAsync("/settings/test-kindle-email", null);
 
-        // All channels fail (including unexpected errors) → 502
-        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
 
+    // ── test-recap-email ───────────────────────────────────────────
+
     [Fact]
-    public async Task PostTestEmail_OnlyDeliveryConfigured_SendsToDelivery()
+    public async Task TestRecapEmail_WithDeliveryConfigured_SendsSuccessfully()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { DeliveryEmail = "user@example.com" });
 
-        var response = await _client.PostAsync("/settings/test-email", null);
+        var response = await _client.PostAsync("/settings/test-recap-email", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains("user@example.com", _fakeMail.SentAddresses);
     }
 
     [Fact]
-    public async Task PostTestEmail_BothConfigured_SendsToBoth()
+    public async Task TestRecapEmail_WithoutDelivery_Returns422()
     {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
-        {
-            KindleEmail = "user@kindle.com",
-            DeliveryEmail = "user@example.com"
-        });
+        var response = await _client.PostAsync("/settings/test-recap-email", null);
 
-        var response = await _client.PostAsync("/settings/test-email", null);
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("user@kindle.com", _fakeMail.SentAddresses);
-        Assert.Contains("user@example.com", _fakeMail.SentAddresses);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("deliveryEmail", body);
     }
 
     [Fact]
-    public async Task PostTestEmail_BothConfigured_AllFail_Returns502()
+    public async Task TestRecapEmail_SmtpFails_Returns502()
     {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
-        {
-            KindleEmail = "user@kindle.com",
-            DeliveryEmail = "user@example.com"
-        });
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { DeliveryEmail = "user@example.com" });
         _fakeMail.ShouldThrow = true;
 
-        var response = await _client.PostAsync("/settings/test-email", null);
+        var response = await _client.PostAsync("/settings/test-recap-email", null);
 
-        // Both fail → 502
         Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TestRecapEmail_UnexpectedError_Returns500()
+    {
+        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { DeliveryEmail = "user@example.com" });
+        _fakeMail.ShouldThrowUnexpected = true;
+
+        var response = await _client.PostAsync("/settings/test-recap-email", null);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
 
     private sealed class FakeMailDeliveryService : IMailDeliveryService

--- a/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -145,7 +145,7 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task SendHtmlRecapAsync(MimeKit.MimeMessage message, CancellationToken cancellationToken = default)
+        public Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 }

--- a/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -145,7 +145,7 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
+        public Task SendHtmlRecapAsync(string toAddress, string htmlBody, string plainTextBody, string subject = "Your Relego Recap", CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 }

--- a/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
+++ b/src/Relego.Tests/Api/SettingsTestEmailEndpointTests.cs
@@ -42,11 +42,11 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
         var response = await _client.PostAsync("/settings/test-email", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
+        Assert.Contains("user@kindle.com", _fakeMail.SentAddresses);
     }
 
     [Fact]
-    public async Task PostTestEmail_WithoutKindleEmail_Returns422()
+    public async Task PostTestEmail_WithoutAnyEmail_Returns422()
     {
         var response = await _client.PostAsync("/settings/test-email", null);
 
@@ -66,137 +66,50 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
 
         Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("SMTP delivery failed", body);
+        Assert.Contains("All delivery channels failed", body);
     }
 
     [Fact]
-    public async Task PostTestEmail_WhenUnexpectedErrorOccurs_Returns500()
+    public async Task PostTestEmail_WhenUnexpectedErrorOccurs_Returns502()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
         _fakeMail.ShouldThrowUnexpected = true;
 
         var response = await _client.PostAsync("/settings/test-email", null);
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        // All channels fail (including unexpected errors) → 502
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
     }
 
     [Fact]
-    public async Task PostTestEmail_DeliveryChannel_SendsSuccessfully()
+    public async Task PostTestEmail_OnlyDeliveryConfigured_SendsToDelivery()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { DeliveryEmail = "user@example.com" });
 
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest { Channel = "delivery" });
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
-    }
-
-    [Fact]
-    public async Task PostTestEmail_DeliveryChannel_WhenNotConfigured_Returns422()
-    {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
-
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest { Channel = "delivery" });
-
-        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task PostTestEmail_InvalidChannel_Returns422()
-    {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
-
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest { Channel = "invalid" });
-
-        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-        var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("channel", body);
-    }
-
-    [Fact]
-    public async Task PostTestEmail_BothChannels_SendsToBoth()
-    {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
-        {
-            KindleEmail = "user@kindle.com",
-            DeliveryEmail = "user@example.com"
-        });
-
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest { Channel = "both" });
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
-        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
-    }
-
-    [Fact]
-    public async Task PostTestEmail_NoChannelAutoDetect_WhenBothConfigured_SendsToBoth()
-    {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
-        {
-            KindleEmail = "user@kindle.com",
-            DeliveryEmail = "user@example.com"
-        });
-
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest());
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
-        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
-    }
-
-    [Fact]
-    public async Task PostTestEmail_NoChannelAutoDetect_WhenOnlyDelivery_SendsToDelivery()
-    {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
-        {
-            DeliveryEmail = "user@example.com"
-        });
-
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest());
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
-    }
-
-    [Fact]
-    public async Task PostTestEmail_NoBody_BackwardCompatible_SendsToKindle()
-    {
-        await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest { KindleEmail = "user@kindle.com" });
-
-        // No body — same as existing call pattern
         var response = await _client.PostAsync("/settings/test-email", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@kindle.com", _fakeMail.LastTestEmailAddress);
+        Assert.Contains("user@example.com", _fakeMail.SentAddresses);
     }
 
     [Fact]
-    public async Task PostTestEmail_BothChannels_KindleFails_DeliveryStillSucceeds()
+    public async Task PostTestEmail_BothConfigured_SendsToBoth()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
         {
             KindleEmail = "user@kindle.com",
             DeliveryEmail = "user@example.com"
         });
-        _fakeMail.ShouldThrow = true; // Kindle fails
 
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest { Channel = "both" });
+        var response = await _client.PostAsync("/settings/test-email", null);
 
-        // "both" returns 502 when both fail, but 200 when at least one succeeds
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("user@example.com", _fakeMail.LastDeliveryTestEmailAddress);
+        Assert.Contains("user@kindle.com", _fakeMail.SentAddresses);
+        Assert.Contains("user@example.com", _fakeMail.SentAddresses);
     }
 
     [Fact]
-    public async Task PostTestEmail_BothChannels_BothFail_Returns502()
+    public async Task PostTestEmail_BothConfigured_AllFail_Returns502()
     {
         await _client.PatchAsJsonAsync("/settings", new UpdateSettingsRequest
         {
@@ -204,21 +117,18 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
             DeliveryEmail = "user@example.com"
         });
         _fakeMail.ShouldThrow = true;
-        _fakeMail.ShouldThrowDelivery = true;
 
-        var response = await _client.PostAsJsonAsync("/settings/test-email",
-            new TestEmailRequest { Channel = "both" });
+        var response = await _client.PostAsync("/settings/test-email", null);
 
+        // Both fail → 502
         Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
     }
 
     private sealed class FakeMailDeliveryService : IMailDeliveryService
     {
-        public string? LastTestEmailAddress { get; private set; }
-        public string? LastDeliveryTestEmailAddress { get; private set; }
+        public List<string> SentAddresses { get; } = [];
         public bool ShouldThrow { get; set; }
         public bool ShouldThrowUnexpected { get; set; }
-        public bool ShouldThrowDelivery { get; set; }
 
         public Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
@@ -231,20 +141,11 @@ public sealed class SettingsTestEmailEndpointTests : IDisposable
             if (ShouldThrow)
                 throw new System.Net.Sockets.SocketException(10061);
 
-            LastTestEmailAddress = toAddress;
+            SentAddresses.Add(toAddress);
             return Task.CompletedTask;
         }
 
         public Task SendHtmlRecapAsync(MimeKit.MimeMessage message, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
-
-        public Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
-        {
-            if (ShouldThrowDelivery)
-                throw new System.Net.Sockets.SocketException(10061);
-
-            LastDeliveryTestEmailAddress = toAddress;
-            return Task.CompletedTask;
-        }
     }
 }

--- a/src/Relego.Tests/Infrastructure/SchemaBootstrapTests.cs
+++ b/src/Relego.Tests/Infrastructure/SchemaBootstrapTests.cs
@@ -25,7 +25,14 @@ public class SchemaBootstrapTests
         {
             if (Directory.Exists(testDirectory))
             {
-                Directory.Delete(testDirectory, recursive: true);
+                try
+                {
+                    Directory.Delete(testDirectory, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // File may still be locked by SQLite; cleanup will happen on next run
+                }
             }
         }
     }

--- a/src/Relego.Tests/Parsing/ClippingsParserTests.cs
+++ b/src/Relego.Tests/Parsing/ClippingsParserTests.cs
@@ -180,7 +180,7 @@ public class ClippingsParserTests
         Assert.Equal("Highlighted text here.", h.Text);
         Assert.Equal("Location 100-105", h.Location);
         Assert.NotNull(h.AddedOn);
-        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), h.AddedOn);
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 1, 1))), h.AddedOn);
     }
 
     [Fact]

--- a/src/Relego.Tests/Recap/EpubComposerTests.cs
+++ b/src/Relego.Tests/Recap/EpubComposerTests.cs
@@ -176,7 +176,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_HighlightsXhtml_DailyHeadingIncludesCadenceAndDateTime()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "daily");
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "Daily");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -188,7 +188,7 @@ public sealed class EpubComposerTests
     [Fact]
     public void Compose_HighlightsXhtml_WeeklyHeadingIncludesCadenceAndDateTime()
     {
-        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "weekly");
+        var epub = EpubComposer.Compose(SampleHighlights, RecapDate, "Weekly");
 
         using var stream = new MemoryStream(epub);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read);

--- a/src/Relego.Tests/Recap/RecapServiceTests.cs
+++ b/src/Relego.Tests/Recap/RecapServiceTests.cs
@@ -232,9 +232,6 @@ internal sealed class FakeMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
-
     public Task SendHtmlRecapAsync(MimeKit.MimeMessage message, CancellationToken cancellationToken = default)
     {
         HtmlSendCount++;

--- a/src/Relego.Tests/Recap/RecapServiceTests.cs
+++ b/src/Relego.Tests/Recap/RecapServiceTests.cs
@@ -1,10 +1,8 @@
 ﻿using Dapper;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Relego.Server.Data;
 using Relego.Server.Infrastructure.Database;
-using Relego.Server.Infrastructure.Smtp;
 using Relego.Server.Models;
 using Relego.Server.Services;
 
@@ -43,15 +41,12 @@ public sealed class RecapServiceTests : IAsyncLifetime
         _selectionService = new HighlightSelectionService(_recapRepository);
         _fakeMailService = new FakeMailDeliveryService();
 
-        var smtpSettings = Options.Create(new SmtpSettings { FromAddress = "relego@test.local" });
-
         _sut = new RecapService(
             _selectionService,
             _fakeMailService,
             _recapRepository,
             _userRepository,
             _settingsRepository,
-            smtpSettings,
             NullLogger<RecapService>.Instance);
     }
 
@@ -232,7 +227,7 @@ internal sealed class FakeMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public Task SendHtmlRecapAsync(MimeKit.MimeMessage message, CancellationToken cancellationToken = default)
+    public Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
     {
         HtmlSendCount++;
 

--- a/src/Relego.Tests/Recap/RecapServiceTests.cs
+++ b/src/Relego.Tests/Recap/RecapServiceTests.cs
@@ -227,7 +227,7 @@ internal sealed class FakeMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
+    public Task SendHtmlRecapAsync(string toAddress, string htmlBody, string plainTextBody, string subject = "Your Relego Recap", CancellationToken cancellationToken = default)
     {
         HtmlSendCount++;
 

--- a/src/Relego.Tests/Recap/RecapServiceTests.cs
+++ b/src/Relego.Tests/Recap/RecapServiceTests.cs
@@ -232,6 +232,9 @@ internal sealed class FakeMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
+    public Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
     public Task SendHtmlRecapAsync(MimeKit.MimeMessage message, CancellationToken cancellationToken = default)
     {
         HtmlSendCount++;

--- a/src/Relego.Tests/Services/HtmlEmailComposerTests.cs
+++ b/src/Relego.Tests/Services/HtmlEmailComposerTests.cs
@@ -1,13 +1,10 @@
-using MimeKit;
-using Relego.Server.Services;
+﻿using Relego.Server.Services;
 
 namespace Relego.Tests.Services;
 
 public sealed class HtmlEmailComposerTests
 {
     private static readonly DateTimeOffset RecapDate = new(2026, 6, 8, 18, 0, 0, TimeSpan.Zero);
-    private const string ToAddress = "user@example.com";
-    private const string FromAddress = "relego@relego.app";
 
     private static readonly IReadOnlyList<SelectionCandidate> SampleHighlights =
     [
@@ -17,104 +14,80 @@ public sealed class HtmlEmailComposerTests
     ];
 
     [Fact]
-    public void Compose_ReturnsMultipartAlternative()
+    public void Compose_ReturnsHtmlAndPlainText()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
+        var (htmlBody, plainTextBody) = HtmlEmailComposer.Compose(SampleHighlights, RecapDate);
 
-        Assert.NotNull(message);
-        Assert.Equal("Your Relego Recap", message.Subject);
-        Assert.Equal(ToAddress, message.To.Mailboxes.First().Address);
-        Assert.Equal(FromAddress, message.From.Mailboxes.First().Address);
-
-        Assert.IsType<MultipartAlternative>(message.Body);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
-        Assert.Equal(2, body.Count);
+        Assert.False(string.IsNullOrEmpty(htmlBody));
+        Assert.False(string.IsNullOrEmpty(plainTextBody));
     }
 
     [Fact]
-    public void Compose_HtmlPart_ContainsRequiredElements()
+    public void Compose_HtmlBody_ContainsRequiredElements()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
-
-        // BodyBuilder puts text/plain first, text/html second (by MIME convention)
-        var htmlPart = Assert.IsType<TextPart>(body[1]);
-
-        Assert.Equal("text/html", htmlPart.ContentType.MimeType);
-        var html = htmlPart.Text;
+        var (htmlBody, _) = HtmlEmailComposer.Compose(SampleHighlights, RecapDate);
 
         // Brand header
-        Assert.Contains("Relego", html);
+        Assert.Contains("Relego", htmlBody);
 
         // Recap date
-        Assert.Contains("June 8, 2026", html);
+        Assert.Contains("June 8, 2026", htmlBody);
 
         // Book titles
-        Assert.Contains("Book One", html);
-        Assert.Contains("Book Two", html);
+        Assert.Contains("Book One", htmlBody);
+        Assert.Contains("Book Two", htmlBody);
 
         // Author names
-        Assert.Contains("Author A", html);
-        Assert.Contains("Author B", html);
+        Assert.Contains("Author A", htmlBody);
+        Assert.Contains("Author B", htmlBody);
 
         // Highlight text
-        Assert.Contains("This is the first highlight text.", html);
-        Assert.Contains("This is the second highlight text.", html);
-        Assert.Contains("Another book highlight.", html);
+        Assert.Contains("This is the first highlight text.", htmlBody);
+        Assert.Contains("This is the second highlight text.", htmlBody);
+        Assert.Contains("Another book highlight.", htmlBody);
 
         // Footer
-        Assert.Contains("Sent by Relego", html);
-        Assert.Contains("https://relego.app", html);
+        Assert.Contains("Sent by Relego", htmlBody);
+        Assert.Contains("https://relego.app", htmlBody);
 
         // Email-safe: no rgba() - Outlook doesn't support it
-        Assert.DoesNotContain("rgba(", html);
+        Assert.DoesNotContain("rgba(", htmlBody);
 
         // Email-safe: no border-radius - Outlook doesn't support it
-        Assert.DoesNotContain("border-radius", html);
+        Assert.DoesNotContain("border-radius", htmlBody);
 
         // Email-safe: no letter-spacing - Outlook doesn't support it
-        Assert.DoesNotContain("letter-spacing", html);
+        Assert.DoesNotContain("letter-spacing", htmlBody);
 
         // Should contain MSO conditionals for Outlook
-        Assert.Contains("[if mso]", html);
+        Assert.Contains("[if mso]", htmlBody);
     }
 
     [Fact]
-    public void Compose_PlainTextPart_ContainsRequiredElements()
+    public void Compose_PlainTextBody_ContainsRequiredElements()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
-
-        // BodyBuilder puts text/plain first
-        var plainPart = Assert.IsType<TextPart>(body[0]);
-
-        Assert.Equal("text/plain", plainPart.ContentType.MimeType);
-        var plain = plainPart.Text;
+        var (_, plainTextBody) = HtmlEmailComposer.Compose(SampleHighlights, RecapDate);
 
         // Book titles
-        Assert.Contains("Book One", plain);
-        Assert.Contains("Book Two", plain);
+        Assert.Contains("Book One", plainTextBody);
+        Assert.Contains("Book Two", plainTextBody);
 
         // Author names
-        Assert.Contains("Author A", plain);
-        Assert.Contains("Author B", plain);
+        Assert.Contains("Author A", plainTextBody);
+        Assert.Contains("Author B", plainTextBody);
 
         // Highlight text
-        Assert.Contains("This is the first highlight text.", plain);
-        Assert.Contains("Another book highlight.", plain);
+        Assert.Contains("This is the first highlight text.", plainTextBody);
+        Assert.Contains("Another book highlight.", plainTextBody);
     }
 
     [Fact]
     public void Compose_EmptyHighlights_ProducesNoHighlightsMessage()
     {
-        var message = HtmlEmailComposer.Compose([], RecapDate, ToAddress, FromAddress);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
+        var (htmlBody, plainTextBody) = HtmlEmailComposer.Compose([], RecapDate);
 
-        var htmlPart = Assert.IsType<TextPart>(body[1]);
-        Assert.Contains("No highlights", htmlPart.Text);
-
-        var plainPart = Assert.IsType<TextPart>(body[0]);
-        Assert.Contains("No highlights", plainPart.Text);
+        Assert.Contains("No highlights", htmlBody);
+        Assert.Contains("No highlights", plainTextBody);
     }
 
     [Fact]
@@ -125,30 +98,24 @@ public sealed class HtmlEmailComposerTests
             new(1, "Unicode test: émoji 🔥, 中文, español, français", "Book Üñî", "Äuthör", 3, null, DateTimeOffset.UtcNow, 10),
         };
 
-        var message = HtmlEmailComposer.Compose(highlights, RecapDate, ToAddress, FromAddress);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
+        var (htmlBody, plainTextBody) = HtmlEmailComposer.Compose(highlights, RecapDate);
 
-        var plainPart = Assert.IsType<TextPart>(body[0]);
-        Assert.Contains("émoji 🔥", plainPart.Text);
-        Assert.Contains("中文", plainPart.Text);
-        Assert.Contains("español", plainPart.Text);
+        Assert.Contains("émoji 🔥", plainTextBody);
+        Assert.Contains("中文", plainTextBody);
+        Assert.Contains("español", plainTextBody);
 
-        var htmlPart = Assert.IsType<TextPart>(body[1]);
-        Assert.Contains("émoji 🔥", htmlPart.Text);
-        Assert.Contains("中文", htmlPart.Text);
+        Assert.Contains("émoji 🔥", htmlBody);
+        Assert.Contains("中文", htmlBody);
     }
 
     [Fact]
     public void Compose_MultipleBooks_AreGrouped()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
-        var htmlPart = Assert.IsType<TextPart>(body[1]);
-        var html = htmlPart.Text;
+        var (htmlBody, _) = HtmlEmailComposer.Compose(SampleHighlights, RecapDate);
 
         // Books should appear in order
-        var bookOneIndex = html.IndexOf("Book One");
-        var bookTwoIndex = html.IndexOf("Book Two");
+        var bookOneIndex = htmlBody.IndexOf("Book One");
+        var bookTwoIndex = htmlBody.IndexOf("Book Two");
         Assert.True(bookOneIndex < bookTwoIndex, "Book One should appear before Book Two");
     }
 
@@ -161,26 +128,20 @@ public sealed class HtmlEmailComposerTests
             new(1, longText, "Book", "Author", 3, null, DateTimeOffset.UtcNow, 10),
         };
 
-        var message = HtmlEmailComposer.Compose(highlights, RecapDate, ToAddress, FromAddress);
-        var body = Assert.IsType<MultipartAlternative>(message.Body);
+        var (htmlBody, plainTextBody) = HtmlEmailComposer.Compose(highlights, RecapDate);
 
-        var plainPart = Assert.IsType<TextPart>(body[0]);
-        Assert.Contains("[...]", plainPart.Text); // truncated marker
-        Assert.DoesNotContain(new string('A', 2500), plainPart.Text); // not full text
+        Assert.Contains("[...]", plainTextBody); // truncated marker
+        Assert.DoesNotContain(new string('A', 2500), plainTextBody); // not full text
 
-        var htmlPart = Assert.IsType<TextPart>(body[1]);
-        Assert.Contains(new string('A', 2500), htmlPart.Text); // full text in HTML
+        Assert.Contains(new string('A', 2500), htmlBody); // full text in HTML
     }
 
     [Fact]
-    public void Compose_NoAttachmentParts()
+    public void Compose_NoMimeKitDependency()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
+        // Verify the method returns raw strings, not MIME objects
+        var result = HtmlEmailComposer.Compose(SampleHighlights, RecapDate);
 
-        // The top-level body should be MultipartAlternative, not MultipartMixed
-        Assert.IsType<MultipartAlternative>(message.Body);
-
-        // No attachment parts
-        Assert.Empty(message.Attachments);
+        Assert.IsType<(string HtmlBody, string PlainTextBody)>(result);
     }
 }

--- a/src/Relego.Tests/Services/HtmlEmailComposerTests.cs
+++ b/src/Relego.Tests/Services/HtmlEmailComposerTests.cs
@@ -1,4 +1,4 @@
-﻿using MimeKit;
+using MimeKit;
 using Relego.Server.Services;
 
 namespace Relego.Tests.Services;
@@ -6,7 +6,6 @@ namespace Relego.Tests.Services;
 public sealed class HtmlEmailComposerTests
 {
     private static readonly DateTimeOffset RecapDate = new(2026, 6, 8, 18, 0, 0, TimeSpan.Zero);
-    private const string Cadence = "daily";
     private const string ToAddress = "user@example.com";
     private const string FromAddress = "relego@relego.app";
 
@@ -20,7 +19,7 @@ public sealed class HtmlEmailComposerTests
     [Fact]
     public void Compose_ReturnsMultipartAlternative()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
 
         Assert.NotNull(message);
         Assert.Equal("Your Relego Recap", message.Subject);
@@ -35,7 +34,7 @@ public sealed class HtmlEmailComposerTests
     [Fact]
     public void Compose_HtmlPart_ContainsRequiredElements()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
         var body = Assert.IsType<MultipartAlternative>(message.Body);
 
         // BodyBuilder puts text/plain first, text/html second (by MIME convention)
@@ -83,7 +82,7 @@ public sealed class HtmlEmailComposerTests
     [Fact]
     public void Compose_PlainTextPart_ContainsRequiredElements()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
         var body = Assert.IsType<MultipartAlternative>(message.Body);
 
         // BodyBuilder puts text/plain first
@@ -108,7 +107,7 @@ public sealed class HtmlEmailComposerTests
     [Fact]
     public void Compose_EmptyHighlights_ProducesNoHighlightsMessage()
     {
-        var message = HtmlEmailComposer.Compose([], RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose([], RecapDate, ToAddress, FromAddress);
         var body = Assert.IsType<MultipartAlternative>(message.Body);
 
         var htmlPart = Assert.IsType<TextPart>(body[1]);
@@ -126,7 +125,7 @@ public sealed class HtmlEmailComposerTests
             new(1, "Unicode test: émoji 🔥, 中文, español, français", "Book Üñî", "Äuthör", 3, null, DateTimeOffset.UtcNow, 10),
         };
 
-        var message = HtmlEmailComposer.Compose(highlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(highlights, RecapDate, ToAddress, FromAddress);
         var body = Assert.IsType<MultipartAlternative>(message.Body);
 
         var plainPart = Assert.IsType<TextPart>(body[0]);
@@ -142,7 +141,7 @@ public sealed class HtmlEmailComposerTests
     [Fact]
     public void Compose_MultipleBooks_AreGrouped()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
         var body = Assert.IsType<MultipartAlternative>(message.Body);
         var htmlPart = Assert.IsType<TextPart>(body[1]);
         var html = htmlPart.Text;
@@ -162,7 +161,7 @@ public sealed class HtmlEmailComposerTests
             new(1, longText, "Book", "Author", 3, null, DateTimeOffset.UtcNow, 10),
         };
 
-        var message = HtmlEmailComposer.Compose(highlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(highlights, RecapDate, ToAddress, FromAddress);
         var body = Assert.IsType<MultipartAlternative>(message.Body);
 
         var plainPart = Assert.IsType<TextPart>(body[0]);
@@ -176,7 +175,7 @@ public sealed class HtmlEmailComposerTests
     [Fact]
     public void Compose_NoAttachmentParts()
     {
-        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, Cadence, ToAddress, FromAddress);
+        var message = HtmlEmailComposer.Compose(SampleHighlights, RecapDate, ToAddress, FromAddress);
 
         // The top-level body should be MultipartAlternative, not MultipartMixed
         Assert.IsType<MultipartAlternative>(message.Body);

--- a/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
+++ b/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
@@ -233,6 +233,9 @@ internal sealed class FakeDualMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
+    public Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
     public Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default)
     {
         EmailSendCount++;

--- a/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
+++ b/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
@@ -227,7 +227,7 @@ internal sealed class FakeDualMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
+    public Task SendHtmlRecapAsync(string toAddress, string htmlBody, string plainTextBody, string subject = "Your Relego Recap", CancellationToken cancellationToken = default)
     {
         EmailSendCount++;
         if (FailEmail)

--- a/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
+++ b/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
@@ -1,11 +1,8 @@
 ﻿using Dapper;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
-using MimeKit;
 using Relego.Server.Data;
 using Relego.Server.Infrastructure.Database;
-using Relego.Server.Infrastructure.Smtp;
 using Relego.Server.Models;
 using Relego.Server.Services;
 
@@ -44,15 +41,12 @@ public sealed class RecapServiceDualChannelTests : IAsyncLifetime
         _selectionService = new HighlightSelectionService(_recapRepository);
         _fakeMailService = new FakeDualMailDeliveryService();
 
-        var smtpSettings = Options.Create(new SmtpSettings { FromAddress = "relego@test.local" });
-
         _sut = new RecapService(
             _selectionService,
             _fakeMailService,
             _recapRepository,
             _userRepository,
             _settingsRepository,
-            smtpSettings,
             NullLogger<RecapService>.Instance);
     }
 
@@ -233,7 +227,7 @@ internal sealed class FakeDualMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default)
+    public Task SendHtmlRecapAsync(IReadOnlyList<SelectionCandidate> highlights, DateTimeOffset recapDate, string toAddress, CancellationToken cancellationToken = default)
     {
         EmailSendCount++;
         if (FailEmail)

--- a/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
+++ b/src/Relego.Tests/Services/RecapServiceDualChannelTests.cs
@@ -233,9 +233,6 @@ internal sealed class FakeDualMailDeliveryService : IMailDeliveryService
     public Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public Task SendDeliveryTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
-
     public Task SendHtmlRecapAsync(MimeMessage message, CancellationToken cancellationToken = default)
     {
         EmailSendCount++;


### PR DESCRIPTION
## Summary

Splits the combined test-email endpoint and fixes empty-string clearing for kindleEmail.

## Changes

### PATCH /settings
- **kindleEmail empty string now clears** the field (same as deliveryEmail pattern)
- Null/missing kindleEmail still preserves existing value

### Split test-email
- **Removed** \POST /settings/test-email\ (combined endpoint)
- **Added** \POST /settings/test-kindle-email\ — old behavior: 200/422/502/500
- **Added** \POST /settings/test-recap-email\ — same status codes, tests delivery email
- Each endpoint follows the original simple pattern: one check, one send

### Tests
- 8 tests for split endpoints (4 kindle + 4 recap)
- 1 new test for kindleEmail clearing via empty string

> **Note**: CLI \PostTestEmailAsync\ still references the old \/settings/test-email\ and needs updating separately.

Closes #341
Closes #342
Closes #343
Closes #344