### PR TITLE
Enhance email recap delivery configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ docker compose run --rm relego-cli config kindle-email "email@kindle.com"
 relego config kindle-email "email@kindle.com"
 ```
 
+Optionally, set an **"Also Email Recap to"** address to also receive an HTML recap in any regular inbox (in addition to Kindle):
+
+```sh
+# Docker
+docker compose run --rm relego-cli config delivery-email "you@example.com"
+
+# Binary
+relego config delivery-email "you@example.com"
+```
+
+Leave this blank if you only want Kindle delivery. Clear it at any time with `relego config delivery-email ""`.
+
 ### 5. Explore the TUI
 
 The TUI lets you sync highlights from `My Clippings.txt`, browse your library, manage exclusions, and adjust settings, all without leaving the terminal. To open it, launch the CLI without any argument:
@@ -224,25 +236,26 @@ If you've been using the demo mode, open `http://localhost:5000` to view the cap
 
 ## CLI reference
 
-|                   Command                        |              Description                  |
-|--------------------------------------------------|-------------------------------------------|
-| `relego`                                         | Open interactive TUI                      |
-| `relego import [path]`                           | Import highlights from `My Clippings.txt` |
-| `relego status`                                  | Show server status and next recap         |
-| `relego config show`                             | Show all current server settings          |
-| `relego config schedule <daily\|weekly> [HH:MM]` | Set recap schedule                        |
-| `relego config schedule show`                    | Show current schedule                     |
-| `relego config count show`                       | Show current highlights-per-recap setting |
-| `relego config count <1-15>`                     | Set highlights per recap (default: 5)     |
-| `relego config kindle-email <address>`           | Set the Kindle delivery email address     |
-| `relego exclude add <highlight\|book\|author> <id>` | Exclude an entity from future recaps   |
-| `relego exclude remove <highlight\|book\|author> <id>` | Re-include an excluded entity       |
-| `relego exclude list`                            | List all exclusions                       |
-| `relego rename-book <id> <title>`                | Rename a book                             |
-| `relego weight set <id> <1-5>`                   | Set highlight weight                      |
-| `relego weight list`                             | Show weighted highlights                  |
-| `relego recap trigger`                           | Trigger a recap immediately               |
-| `relego --version`                               | Print version                             |
+|                   Command                              |              Description                                                     |
+|--------------------------------------------------------|------------------------------------------------------------------------------|
+| `relego`                                               | Open interactive TUI                                                         |
+| `relego import [path]`                                 | Import highlights from `My Clippings.txt`                                    |
+| `relego status`                                        | Show server status and next recap                                            |
+| `relego config show`                                   | Show all current server settings                                             |
+| `relego config schedule <daily\|weekly> [HH:MM]`       | Set recap schedule                                                           |
+| `relego config schedule show`                          | Show current schedule                                                        |
+| `relego config count show`                             | Show current highlights-per-recap setting                                    |
+| `relego config count <1-15>`                           | Set highlights per recap (default: 5)                                        |
+| `relego config kindle-email <address>`                 | Set the Kindle delivery email address                                        |
+| `relego config delivery-email <address>`               | Set an optional email address to send HTML recaps to (in addition to Kindle) |
+| `relego exclude add <highlight\|book\|author> <id>`    | Exclude an entity from future recaps                                         |
+| `relego exclude remove <highlight\|book\|author> <id>` | Re-include an excluded entity                                                |
+| `relego exclude list`                                  | List all exclusions                                                          |
+| `relego rename-book <id> <title>`                      | Rename a book                                                                |
+| `relego weight set <id> <1-5>`                         | Set highlight weight                                                         |
+| `relego weight list`                                   | Show weighted highlights                                                     |
+| `relego recap trigger`                                 | Trigger a recap immediately                                                  |
+| `relego --version`                                     | Print version                                                                |
 
 ---
 

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -149,6 +149,22 @@ relego sync <path>   # Explicit path to My Clippings.txt
 
 ## Settings management
 
+### Email addresses
+
+```sh
+# Set the Kindle delivery email (required for Kindle delivery)
+relego config kindle-email your-address@kindle.com
+
+# Set an optional "Also Email Recap to" address for HTML recap delivery in addition to Kindle
+relego config delivery-email you@example.com
+
+# Clear the optional address
+relego config delivery-email ""
+
+# Show all current settings
+relego config show
+```
+
 ### Schedule
 
 ```sh
@@ -259,25 +275,26 @@ Errors are actionable — they tell the user exactly what to do.
 
 ## Full CLI reference
 
-|                   Command                       |              Description                  |
-|-------------------------------------------------|-------------------------------------------|
-| `relego sync [path]`                             | Import highlights from `My Clippings.txt` |
-| `relego status`                                  | Show server status and next recap         |
-| `relego config schedule <daily\|weekly> [HH:MM]` | Set recap schedule                        |
-| `relego config schedule show`                    | Show current schedule                     |
-| `relego config count show`                       | Show current highlights-per-recap setting |
-| `relego config count <1-15>`                     | Set highlights per recap (default: 5)     |
-| `relego config kindle-email <address>`           | Set the Kindle delivery email address     |
-| `relego exclude highlight <id>`                  | Exclude a highlight from all recaps       |
-| `relego exclude book <title>`                    | Exclude all highlights from a book        |
-| `relego exclude author <name>`                   | Exclude all highlights from an author     |
-| `relego exclude remove highlight <id>`           | Re-include a highlight                    |
-| `relego exclude remove book <title>`             | Re-include a book                         |
-| `relego exclude remove author <name>`            | Re-include an author                      |
-| `relego exclude list`                            | List all exclusions                       |
-| `relego weight set <id> <1-5>`                   | Set highlight weight                      |
-| `relego weight list`                             | Show weighted highlights                  |
-| `relego version`                                 | Print version                             |
+|                   Command                              |              Description                                                     |
+|--------------------------------------------------------|------------------------------------------------------------------------------|
+| `relego`                                               | Open interactive TUI                                                         |
+| `relego import [path]`                                 | Import highlights from `My Clippings.txt`                                    |
+| `relego status`                                        | Show server status and next recap                                            |
+| `relego config show`                                   | Show all current server settings                                             |
+| `relego config schedule <daily\|weekly> [HH:MM]`       | Set recap schedule                                                           |
+| `relego config schedule show`                          | Show current schedule                                                        |
+| `relego config count show`                             | Show current highlights-per-recap setting                                    |
+| `relego config count <1-15>`                           | Set highlights per recap (default: 5)                                        |
+| `relego config kindle-email <address>`                 | Set the Kindle delivery email address                                        |
+| `relego config delivery-email <address>`               | Set an optional email address to send HTML recaps to (in addition to Kindle) |
+| `relego exclude add <highlight\|book\|author> <id>`    | Exclude an entity from future recaps                                         |
+| `relego exclude remove <highlight\|book\|author> <id>` | Re-include an excluded entity                                                |
+| `relego exclude list`                                  | List all exclusions                                                          |
+| `relego rename-book <id> <title>`                      | Rename a book                                                                |
+| `relego weight set <id> <1-5>`                         | Set highlight weight                                                         |
+| `relego weight list`                                   | Show weighted highlights                                                     |
+| `relego recap trigger`                                 | Trigger a recap immediately                                                  |
+| `relego --version`                                     | Print version                                                                |
 
 ---
 

--- a/specs/009-email-delivery/spec.md
+++ b/specs/009-email-delivery/spec.md
@@ -96,19 +96,19 @@ A new user who does not own a Kindle device can use Relego fully by configuring 
 
 ### User Story 6 — Test Email for Regular Channel (Priority: P2)
 
-The existing `POST /settings/test-email` endpoint is extended so the user can send a test email to their configured `delivery_email`. This verifies that the SMTP configuration works for the regular email channel, not just Kindle.
+The `POST /settings/test-email` endpoint has been replaced by two dedicated endpoints: `POST /settings/test-kindle-email` and `POST /settings/test-recap-email`. The TUI "T — Test email settings" shortcut calls both endpoints independently when both addresses are configured, reporting success or failure per channel.
 
 **Why this priority**: Test email verification is important for user confidence, but it is a support function — the core delivery must work first. Users can also validate by triggering a real recap in Development mode.
 
-**Independent Test**: Call the test-email endpoint with the `delivery_email` channel specified, and verify a plain-text test email (not a recap) is sent to that address.
+**Independent Test**: Call `POST /settings/test-kindle-email` and `POST /settings/test-recap-email` individually, and verify a plain-text test email is sent to the respective address.
 
 **Acceptance Scenarios**:
 
-1. **Given** `delivery_email` is configured and SMTP is functional, **When** the user triggers "Send test email" for the delivery channel, **Then** a plain-text test email is sent to `delivery_email` and a success response is returned.
-2. **Given** `delivery_email` is not configured, **When** the user triggers a test email for the delivery channel, **Then** an actionable validation error is returned and no email is sent.
-3. **Given** SMTP delivery fails for the test, **When** the user triggers the test email, **Then** an actionable error describing the SMTP failure is returned.
+1. **Given** `delivery_email` is configured and SMTP is functional, **When** `POST /settings/test-recap-email` is called, **Then** a plain-text test email is sent to `delivery_email` and a success response is returned.
+2. **Given** `delivery_email` is not configured, **When** `POST /settings/test-recap-email` is called, **Then** an actionable validation error is returned and no email is sent.
+3. **Given** SMTP delivery fails for the test, **When** the endpoint is called, **Then** an actionable error describing the SMTP failure is returned (`502 Bad Gateway`).
 4. **Given** the test email is sent, **When** the user receives it, **Then** the email body is plain-text (not HTML, not a recap) and contains no attachments.
-5. **Given** both channels are configured, **When** the user triggers a test email without specifying a channel, **Then** a test email is sent to BOTH addresses independently.
+5. **Given** both channels are configured, **When** the user presses **T** in the TUI settings screen, **Then** both `POST /settings/test-kindle-email` and `POST /settings/test-recap-email` are called independently; errors are collected and reported together.
 
 ---
 
@@ -136,21 +136,21 @@ The server composes a well-designed HTML email for the regular email channel. Th
 
 ### User Story 8 — CLI/TUI Settings Management (Priority: P2)
 
-The CLI `config` command and the TUI settings screen expose the new `delivery-email` setting alongside `kindle-email`. The TUI warning displayed when no email is configured is updated to check both fields — only showing the warning when NEITHER email is set.
+The CLI `config` command and the TUI settings screen expose the new `delivery-email` setting alongside `kindle-email`. The field is labelled **"Also Email Recap to (opt.)"** in the TUI and **"Also Email Recap to (opt.)"** in `relego config show` output to make its optional, additive nature explicit. The TUI warning always fires when Kindle email is not configured — the optional address does not suppress it.
 
 **Why this priority**: CLI/TUI integration makes the feature accessible and aligns with Relego's configuration UX, but the server-side delivery capability is more critical.
 
-**Independent Test**: Run `relego config set delivery-email user@example.com` and verify it works. Open the TUI settings page and verify the `delivery-email` field is present and editable.
+**Independent Test**: Run `relego config delivery-email user@example.com` and verify it works. Open the TUI settings page and verify the field is present and editable.
 
 **Acceptance Scenarios**:
 
-1. **Given** the user runs `relego config set delivery-email user@example.com`, **When** the command completes, **Then** the delivery email is persisted on the server.
-2. **Given** the user runs `relego config show`, **When** the output is displayed, **Then** both `kindle-email` and `delivery-email` are shown with their current values.
-3. **Given** the user navigates to the TUI settings page, **When** it renders, **Then** a "Delivery email" field is displayed alongside "Kindle email."
-4. **Given** the TUI settings page, **When** the user edits and saves the delivery email, **Then** the value is validated (email format) and sent to the server.
-5. **Given** NEITHER `kindle_email` nor `delivery_email` is configured, **When** the TUI renders, **Then** a persistent warning is shown: "No delivery email configured — recaps cannot be delivered."
-6. **Given** at least ONE of `kindle_email` or `delivery_email` is configured, **When** the TUI renders, **Then** no email warning is displayed.
-7. **Given** the user runs `relego config set delivery-email ""` (empty), **When** the command completes, **Then** the delivery email is cleared and the server no longer sends recaps to that channel.
+1. **Given** the user runs `relego config delivery-email user@example.com`, **When** the command completes, **Then** the delivery email is persisted on the server.
+2. **Given** the user runs `relego config show`, **When** the output is displayed, **Then** both `kindle-email` and the `Also Email Recap to (opt.)` row are shown with their current values.
+3. **Given** the user navigates to the TUI settings page, **When** it renders, **Then** an **"Also Email Recap to (opt.)"** field is displayed alongside **"Kindle Email"**.
+4. **Given** the TUI settings page, **When** the user edits and saves the delivery email, **Then** the value is validated (email format) and sent to the server; the screen refreshes automatically from server state.
+5. **Given** `kindle_email` is NOT configured, **When** the TUI renders, **Then** a persistent warning **"⚠ Kindle email not configured"** is shown — regardless of whether `delivery_email` is set.
+6. **Given** `kindle_email` IS configured, **When** the TUI renders, **Then** no email warning is displayed — regardless of whether `delivery_email` is set.
+7. **Given** the user runs `relego config delivery-email ""` (empty string), **When** the command completes, **Then** the delivery email is cleared and the server no longer sends recaps to that channel.
 
 ---
 
@@ -183,12 +183,12 @@ The CLI `config` command and the TUI settings screen expose the new `delivery-em
 - **FR-009-12**: The HTML email MUST contain: a branded header with Relego name/logo, recap date, highlights grouped by book with title/author/text, and a footer with "Sent by Relego" and a project link.
 - **FR-009-13**: The HTML email MUST use email-safe inline CSS (no external stylesheets, no JavaScript, limited CSS Grid/Flexbox usage) and be responsive for mobile and desktop clients.
 - **FR-009-14**: The plain-text email part MUST render all highlights with clear text-only formatting (book title, author, highlight text separated by whitespace).
-- **FR-009-15**: `POST /settings/test-email` MUST support an optional channel parameter to specify `kindle`, `delivery`, or `both` (default: `both` when both are configured, or whichever single channel is configured).
+- **FR-009-15**: `POST /settings/test-kindle-email` MUST send a plain-text test email to `kindle_email`. `POST /settings/test-recap-email` MUST send a plain-text test email to `delivery_email`. Both endpoints return `422` when the respective address is not configured.
 - **FR-009-16**: Test email for the delivery channel MUST send a plain-text email (not HTML, not a recap) to `delivery_email`.
 - **FR-009-17**: The CLI `config set` command MUST accept `delivery-email` as a setting key alongside `kindle-email`.
 - **FR-009-18**: The CLI `config show` command MUST display `delivery-email` alongside `kindle-email`.
-- **FR-009-19**: The TUI settings page MUST expose a "Delivery email" field alongside the existing "Kindle email" field.
-- **FR-009-20**: The TUI email warning MUST update to check both fields — displayed only when NEITHER `kindle_email` nor `delivery_email` is configured. The warning text MUST be generic: "No delivery email configured — recaps cannot be delivered."
+- **FR-009-19**: The TUI settings page MUST expose an **"Also Email Recap to (opt.)"** field alongside the existing **"Kindle Email"** field. The label width is computed dynamically from the longest field label.
+- **FR-009-20**: The TUI warning MUST fire when `kindle_email` is NOT configured, regardless of whether `delivery_email` is set. The warning text is **"⚠ Kindle email not configured"**. Configuring only `delivery_email` does not suppress this warning; Kindle email is the primary expected delivery channel.
 - **FR-009-21**: The `delivery_email` field MUST share the same email format validation as `kindle_email`.
 - **FR-009-22**: Each delivery outcome (success or failure, per channel) MUST be logged independently with channel identification.
 

--- a/src/Relego.Cli/Commands/Config/ConfigDeliveryEmailCommand.cs
+++ b/src/Relego.Cli/Commands/Config/ConfigDeliveryEmailCommand.cs
@@ -9,7 +9,7 @@ using Relego.Core.Contracts;
 namespace Relego.Cli.Commands.Config;
 
 /// <summary>
-/// Sets the regular delivery email address on the server.
+/// Sets the optional secondary email address for HTML recap delivery on the server.
 /// Usage: relego config delivery-email &lt;address&gt;
 /// </summary>
 public sealed partial class ConfigDeliveryEmailCommand(RelegoHttpClient client, ILogger<ConfigDeliveryEmailCommand> logger)
@@ -20,7 +20,7 @@ public sealed partial class ConfigDeliveryEmailCommand(RelegoHttpClient client, 
     public sealed class Settings : CommandSettings
     {
         [CommandArgument(0, "<address>")]
-        [Description("Regular delivery email address for HTML recap delivery.")]
+        [Description("Optional email address to also receive the HTML recap (in addition to Kindle).")]
         public string Address { get; set; } = string.Empty;
     }
 
@@ -50,11 +50,11 @@ public sealed partial class ConfigDeliveryEmailCommand(RelegoHttpClient client, 
 
         if (address.Length == 0)
         {
-            AnsiConsole.MarkupLine("[green]✓[/] Delivery email cleared.");
+            AnsiConsole.MarkupLine("[green]✓[/] Also Email Recap to address cleared.");
         }
         else
         {
-            AnsiConsole.MarkupLine($"[green]✓[/] Delivery email set to [bold]{Markup.Escape(response.DeliveryEmail ?? address)}[/].");
+            AnsiConsole.MarkupLine($"[green]✓[/] Also Email Recap to [bold]{Markup.Escape(response.DeliveryEmail ?? address)}[/] (optional, in addition to Kindle).");
         }
 
         return 0;

--- a/src/Relego.Cli/Commands/Config/ConfigShowCommand.cs
+++ b/src/Relego.Cli/Commands/Config/ConfigShowCommand.cs
@@ -41,7 +41,7 @@ public sealed class ConfigShowCommand(RelegoHttpClient client, ILogger<ConfigSho
         table.AddRow("Delivery Time", response.DeliveryTime);
         table.AddRow("Count", response.Count.ToString());
         table.AddRow("Kindle Email", response.KindleEmail);
-        table.AddRow("Delivery Email", response.DeliveryEmail ?? "[grey](not set)[/]");
+        table.AddRow("Also Email Recap to (opt.)", response.DeliveryEmail ?? "[grey](not set — optional)[/]");
         table.AddRow("Timezone", response.Timezone);
 
         AnsiConsole.Write(table);

--- a/src/Relego.Cli/Infrastructure/RelegoHttpClient.cs
+++ b/src/Relego.Cli/Infrastructure/RelegoHttpClient.cs
@@ -55,8 +55,11 @@ public sealed class RelegoHttpClient(HttpClient http)
     public async Task<ExclusionsResponse> GetExclusionsAsync(CancellationToken ct = default)
         => (await http.GetFromJsonAsync("/exclusions", RelegoJsonContext.Default.ExclusionsResponse, ct).ConfigureAwait(false))!;
 
-    public Task<HttpResponseMessage> PostTestEmailAsync(CancellationToken ct = default)
-        => http.PostAsync("/settings/test-email", null, ct);
+    public Task<HttpResponseMessage> PostTestKindleEmailAsync(CancellationToken ct = default)
+        => http.PostAsync("/settings/test-kindle-email", null, ct);
+
+    public Task<HttpResponseMessage> PostTestRecapEmailAsync(CancellationToken ct = default)
+        => http.PostAsync("/settings/test-recap-email", null, ct);
 
     public async Task<RecapTriggerResponse> TriggerRecapAsync(CancellationToken ct = default)
     {

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -105,7 +105,7 @@ app.Configure(config =>
         cfg.AddCommand<ConfigKindleEmailCommand>("kindle-email")
             .WithDescription("Set the Kindle delivery email address.");
         cfg.AddCommand<ConfigDeliveryEmailCommand>("delivery-email")
-            .WithDescription("Set the regular delivery email address for HTML recap delivery.");
+            .WithDescription("Set an optional \"Also Email Recap to\" address for HTML recap delivery (in addition to Kindle).");
         cfg.AddCommand<ConfigShowCommand>("show")
             .WithDescription("Display all current settings.");
     });

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.13.0</Version>
+    <Version>0.13.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Tui/SettingsScreen.cs
+++ b/src/Relego.Cli/Tui/SettingsScreen.cs
@@ -11,7 +11,6 @@ namespace Relego.Cli.Tui;
 
 public sealed class SettingsScreen : IScreen
 {
-    private const int LabelColumnWidth = 22;
     private const int HorizontalPadding = 2;
     private const int MinWeight = 1;
     private const int MaxWeight = 15;
@@ -364,8 +363,12 @@ public sealed class SettingsScreen : IScreen
             CancelEdit();
             SetStatus($"{field.Label} updated.", isError: false);
 
-            if ((field.FieldId == "kindleEmail" || field.FieldId == "deliveryEmail") && _refreshChromeAsync is not null)
-                _ = Task.Run(() => _refreshChromeAsync(CancellationToken.None));
+            if (field.FieldId == "kindleEmail" || field.FieldId == "deliveryEmail")
+            {
+                await HandleRefreshAsync(CancellationToken.None).ConfigureAwait(false);
+                if (_refreshChromeAsync is not null)
+                    _ = Task.Run(() => _refreshChromeAsync(CancellationToken.None));
+            }
         }
         catch (HttpRequestException ex)
         {
@@ -375,37 +378,62 @@ public sealed class SettingsScreen : IScreen
 
     private async Task<ScreenResult> HandleTestEmailAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(_settings?.KindleEmail) && string.IsNullOrWhiteSpace(_settings?.DeliveryEmail))
+        var hasKindle = !string.IsNullOrWhiteSpace(_settings?.KindleEmail);
+        var hasRecap = !string.IsNullOrWhiteSpace(_settings?.DeliveryEmail);
+
+        if (!hasKindle && !hasRecap)
         {
-            SetStatus("No delivery email configured. Please set a Kindle or delivery email first.", isError: true);
+            SetStatus("No email configured. Please set a Kindle or \"Also Email Recap to\" address first.", isError: true);
             return ScreenResult.Stay();
         }
 
-        SetStatus("Sending test email...", isError: false);
+        SetStatus("Sending test email(s)...", isError: false);
         UpdateViewStateIfCreated();
 
-        try
-        {
-            using var response = await _client.PostTestEmailAsync(cancellationToken).ConfigureAwait(false);
+        var errors = new List<string>();
 
-            if (response.IsSuccessStatusCode)
-            {
-                SetStatus("Test email sent successfully.", isError: false);
-            }
-            else
-            {
-                var message = response.StatusCode switch
-                {
-                    System.Net.HttpStatusCode.BadGateway => "SMTP delivery failed. Check your server SMTP configuration.",
-                    _ => "Test email failed. Check server configuration."
-                };
-                SetStatus(message, isError: true);
-            }
-        }
-        catch (HttpRequestException ex)
+        if (hasKindle)
         {
-            SetStatus($"Test email failed: {ex.Message}", isError: true);
+            try
+            {
+                using var response = await _client.PostTestKindleEmailAsync(cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var msg = response.StatusCode == System.Net.HttpStatusCode.BadGateway
+                        ? "SMTP failed for Kindle email."
+                        : "Test failed for Kindle email.";
+                    errors.Add(msg);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                errors.Add($"Kindle email: {ex.Message}");
+            }
         }
+
+        if (hasRecap)
+        {
+            try
+            {
+                using var response = await _client.PostTestRecapEmailAsync(cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var msg = response.StatusCode == System.Net.HttpStatusCode.BadGateway
+                        ? "SMTP failed for recap email."
+                        : "Test failed for recap email.";
+                    errors.Add(msg);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                errors.Add($"Recap email: {ex.Message}");
+            }
+        }
+
+        if (errors.Count == 0)
+            SetStatus("Test email(s) sent successfully.", isError: false);
+        else
+            SetStatus(string.Join(" ", errors), isError: true);
 
         return ScreenResult.Stay();
     }
@@ -493,8 +521,8 @@ public sealed class SettingsScreen : IScreen
 
         _fields.Add(new SettingsField("Kindle Email", _settings.KindleEmail, "kindleEmail", FieldKind.Editable,
             Hint: "Insert a valid email address"));
-        _fields.Add(new SettingsField("Delivery Email", _settings.DeliveryEmail ?? "", "deliveryEmail", FieldKind.Editable,
-            Hint: "Insert a valid email address"));
+        _fields.Add(new SettingsField("Also Email Recap to (opt.)", _settings.DeliveryEmail ?? "", "deliveryEmail", FieldKind.Editable,
+            Hint: "Optional — leave blank to skip. HTML recap sent here in addition to Kindle."));
         _fields.Add(new SettingsField("Schedule", _settings.Schedule, "schedule", FieldKind.Editable,
             Hint: "◀ ▶ to change, Enter to confirm", Options: ScheduleOptions));
 
@@ -559,9 +587,12 @@ public sealed class SettingsScreen : IScreen
         if (_fieldRows is not null)
         {
             _fieldRows.Clear();
+            var labelWidth = _fields.Any(f => f.Kind == FieldKind.Editable)
+                ? _fields.Where(f => f.Kind == FieldKind.Editable).Max(f => f.Label.Length) + 2
+                : 22;
             foreach (var field in _fields)
             {
-                _fieldRows.Add(FormatField(field));
+                _fieldRows.Add(FormatField(field, labelWidth));
             }
         }
 
@@ -586,12 +617,12 @@ public sealed class SettingsScreen : IScreen
         }
     }
 
-    private static string FormatField(SettingsField field)
+    private static string FormatField(SettingsField field, int labelWidth)
     {
         if (field.Kind == FieldKind.Action)
             return $"  {field.Label}";
 
-        var label = field.Label.PadRight(LabelColumnWidth);
+        var label = field.Label.PadRight(labelWidth);
         var displayValue = field.DisplaySuffix is not null ? $"{field.Value} {field.DisplaySuffix}" : field.Value;
         return $"  {label}{displayValue}";
     }

--- a/src/Relego.Cli/Tui/StatusChrome.cs
+++ b/src/Relego.Cli/Tui/StatusChrome.cs
@@ -27,6 +27,7 @@ public sealed class StatusChrome(string serverUrl, string version)
 
     public bool IsConnected { get; private set; }
     public bool KindleEmailConfigured { get; private set; }
+    public bool DeliveryEmailConfigured { get; private set; }
     public string? NextRecap { get; private set; }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Views are owned by the parent container hierarchy")]
@@ -128,6 +129,7 @@ public sealed class StatusChrome(string serverUrl, string version)
     {
         IsConnected = false;
         KindleEmailConfigured = false;
+        DeliveryEmailConfigured = false;
     }
 
     public async Task RefreshAsync(RelegoHttpClient client, CancellationToken ct = default)
@@ -139,11 +141,13 @@ public sealed class StatusChrome(string serverUrl, string version)
             {
                 var status = await client.GetStatusAsync(ct).ConfigureAwait(false);
                 KindleEmailConfigured = status.KindleEmailConfigured;
+                DeliveryEmailConfigured = status.DeliveryEmailConfigured;
                 NextRecap = status.NextRecap;
             }
             else
             {
                 KindleEmailConfigured = false;
+                DeliveryEmailConfigured = false;
                 NextRecap = null;
             }
         }

--- a/src/Relego.Tests/Tui/SettingsScreenTests.cs
+++ b/src/Relego.Tests/Tui/SettingsScreenTests.cs
@@ -266,7 +266,7 @@ public sealed class SettingsScreenTests
         using var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
             .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
-        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
+        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-kindle-email")
             .Respond(HttpStatusCode.UnprocessableEntity, "application/json", "{\"errors\":{\"kindleEmail\":[\"Kindle email must be configured.\"]}}");
         using var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 
@@ -382,7 +382,7 @@ public sealed class SettingsScreenTests
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(HttpMethod.Get, "http://localhost/settings")
             .Respond("application/json", JsonSerializer.Serialize(settings, CamelCaseOptions));
-        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-email")
+        mockHttp.When(HttpMethod.Post, "http://localhost/settings/test-kindle-email")
             .Respond(HttpStatusCode.OK, "application/json", "{\"message\":\"Test email sent successfully.\"}");
         var httpClient = new HttpClient(mockHttp, disposeHandler: false) { BaseAddress = new Uri("http://localhost") };
 


### PR DESCRIPTION
Introduce support for an optional secondary email for HTML recap delivery, update CLI/TUI settings, and improve UI elements to reflect these changes. Bump version to 0.13.1.