### PR TITLE
Update import command to support renamed Kindle and Kobo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ docker compose --profile server up -d
 
 It's time to import the highlights from your device.
 
-> **Using the sample data in `docs/examples`?** Append the local path to the `import` command shown in this section
+> **Using the sample data `docs/examples/kindle-highlights.txt`?** Append the local path to the `import` command shown in this section
 
 <details>
   <summary>Docker (no install)</summary>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ The CLI imports through an open source registry rather than a closed source-type
 
 Current sources:
 
-- `KindleClippingsSource`: detects and reads `My Clippings.txt` using the existing Kindle detector and parser.
+- `KindleClippingsSource`: reads Kindle `.txt` clippings exports. Explicit file paths are accepted by `.txt` extension; auto-detection uses the existing Kindle detector to probe for `My Clippings.txt` on mounted devices.
 - `KoboReaderSource`: detects and reads `.kobo/KoboReader.sqlite`. It copies the SQLite database to a temp file, validates the SQLite header, opens the copy read-only, and deletes the copy afterward so the mounted device database is never modified.
 
 Adding a future integration is intentionally small: implement `IHighlightSource` and register one `AddSingleton<IHighlightSource, NewSource>()` line in `Program.cs`. Do not add a central enum, and do not edit the resolver, import workflow, or command surface for source-specific branching. `SourceDescriptor` is a reporting/logging label only.

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -126,7 +126,7 @@ relego config email inbox you@example.com
 relego import /Volumes/KOBOeReader/.kobo/KoboReader.sqlite
 ```
 
-If no path is specified, `relego import` probes the default Kindle and Kobo mount locations. Passing a mounted device root is also valid; each registered source owns its own detection rules.
+If no path is specified, `relego import` probes the default Kindle and Kobo mount locations. Passing a mounted device root is also valid; each registered source owns its own detection rules. For explicit Kindle file paths, Relego routes any existing `.txt` file to the Kindle parser; the `My Clippings.txt` filename is only required for device auto-detection.
 
 Total time to first recap: ~2 minutes.
 
@@ -268,7 +268,7 @@ Errors are actionable — they tell the user exactly what to do.
 ```
 ⚠ No highlights found in the source file.
   This can happen if the source is empty or in an unexpected format.
-  Expected format: Kindle My Clippings.txt or Kobo KoboReader.sqlite
+  Expected format: Kindle clippings text export (.txt) or Kobo KoboReader.sqlite
 ```
 
 ---
@@ -300,7 +300,7 @@ Errors are actionable — they tell the user exactly what to do.
 
 ## Decisions
 
-- `relego import` auto-detects Kindle and Kobo sources on macOS, Linux, and Windows. Each source owns its own detection rules, and the resolver imports every detected source with per-source failure isolation.
+- `relego import` auto-detects Kindle and Kobo sources on macOS, Linux, and Windows. Explicit Kindle file paths are routed by `.txt` extension, while auto-detection still probes the device's `My Clippings.txt` path. Each source owns its own detection rules, and the resolver imports every detected source with per-source failure isolation.
 - Server authentication is not required — the server is assumed to be on a trusted local network.
 
 ---

--- a/specs/016-kobo/contracts/kobo-sqlite-read.md
+++ b/specs/016-kobo/contracts/kobo-sqlite-read.md
@@ -135,7 +135,7 @@ public interface IHighlightSource
 
 | Type | `Descriptor` | Reads |
 |------|--------------|-------|
-| `KindleClippingsSource` | `("kindle", "Kindle")` | `My Clippings.txt` (delegates to `ClippingsParser`) |
+| `KindleClippingsSource` | `("kindle", "Kindle")` | Kindle `.txt` clippings export (delegates to `ClippingsParser`) |
 | `KoboReaderSource` | `("kobo", "Kobo")` | `KoboReader.sqlite` (this contract, §1) |
 
 ---
@@ -147,7 +147,7 @@ returns a `SourceResolution` with **every** detected source (no per-source branc
 
 | Input | Resolved sources |
 |-------|------------------|
-| File named `My Clippings.txt` | Kindle |
+| Existing `.txt` file, including `My Clippings.txt` | Kindle |
 | File named `KoboReader.sqlite` | Kobo |
 | File with SQLite header, other name | Kobo |
 | Directory containing `.kobo/KoboReader.sqlite` | Kobo |

--- a/src/Relego.Cli/Commands/ImportCommand.cs
+++ b/src/Relego.Cli/Commands/ImportCommand.cs
@@ -8,7 +8,7 @@ using Relego.Cli.Import;
 namespace Relego.Cli.Commands;
 
 /// <summary>
-/// Parses a Kindle clippings file and imports highlights to the server.
+/// Parses a highlight source file and imports highlights to the server.
 /// </summary>
 public sealed class ImportCommand(ClippingsImportWorkflow workflow, ILogger<ImportCommand> logger) : ServerCommand<ImportCommand.Settings>
 {
@@ -17,7 +17,7 @@ public sealed class ImportCommand(ClippingsImportWorkflow workflow, ILogger<Impo
     public sealed class Settings : CommandSettings
     {
         [CommandArgument(0, "[path]")]
-        [Description("Path to My Clippings.txt. Auto-detected if omitted.")]
+        [Description("Path to a Kindle .txt export or Kobo SQLite database. Auto-detected if omitted.")]
         public string? Path { get; set; }
     }
 
@@ -57,7 +57,7 @@ public sealed class ImportCommand(ClippingsImportWorkflow workflow, ILogger<Impo
     {
         AnsiConsole.MarkupLine("[yellow]Kindle not found at default paths.[/]");
         var path = AnsiConsole.Prompt(
-            new TextPrompt<string>("[grey]Enter the path to My Clippings.txt, or press Enter to cancel:[/]")
+            new TextPrompt<string>("[grey]Enter the source path, or press Enter to cancel:[/]")
                 .AllowEmpty());
 
         return string.IsNullOrWhiteSpace(path) ? null : path;

--- a/src/Relego.Cli/Program.cs
+++ b/src/Relego.Cli/Program.cs
@@ -96,7 +96,7 @@ app.Configure(config =>
     config.SetApplicationVersion(version);
 
     config.AddCommand<ImportCommand>("import")
-        .WithDescription("Parse and import highlights from My Clippings.txt to the server.");
+        .WithDescription("Parse and import highlights from a Kindle or Kobo source to the server.");
 
     config.AddCommand<StatusCommand>("status")
         .WithDescription("Display server health and aggregate state.");

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.15.2</Version>
+    <Version>0.15.3</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Cli/Sources/KindleClippingsSource.cs
+++ b/src/Relego.Cli/Sources/KindleClippingsSource.cs
@@ -7,12 +7,13 @@ namespace Relego.Cli.Sources;
 /// <summary>
 /// <see cref="IHighlightSource"/> adapter over the existing static
 /// <see cref="ClippingsParser"/>. Adds no parsing logic (FR-011); exists so the
-/// resolver can treat every source uniformly. Owns the <c>My Clippings.txt</c>
-/// detection rules and the <see cref="KindleDetector"/> device probe.
+/// resolver can treat every source uniformly. Owns explicit <c>.txt</c> file routing,
+/// <c>My Clippings.txt</c> auto-detection, and the <see cref="KindleDetector"/> device probe.
 /// </summary>
 public sealed class KindleClippingsSource : IHighlightSource
 {
     private const string ClippingsFileName = "My Clippings.txt";
+    private const string ClippingsFileExtension = ".txt";
 
     /// <inheritdoc />
     public SourceDescriptor Descriptor { get; } = new("kindle", "Kindle");
@@ -29,10 +30,10 @@ public sealed class KindleClippingsSource : IHighlightSource
 
         userPath = userPath.Trim();
 
-        // Explicit file named "My Clippings.txt".
-        if (IsClippingsFileName(userPath))
+        // Explicit Kindle text export. Auto-detection remains filename-based below.
+        if (IsClippingsTextFile(userPath))
         {
-            return new SourceProbe(File.Exists(userPath) ? userPath : null, [userPath]);
+            return new SourceProbe(userPath, [userPath]);
         }
 
         // Directory (a mounted device root): try documents/ then the directory itself.
@@ -57,7 +58,7 @@ public sealed class KindleClippingsSource : IHighlightSource
             return new SourceProbe(null, probed);
         }
 
-        // An explicit path that is neither a "My Clippings.txt" file nor a directory.
+        // An explicit path that is neither a Kindle .txt file nor a directory.
         return new SourceProbe(null, [userPath]);
     }
 
@@ -68,6 +69,7 @@ public sealed class KindleClippingsSource : IHighlightSource
         CancellationToken cancellationToken = default)
         => ClippingsParser.ParseAsync(path, logger);
 
-    private static bool IsClippingsFileName(string path)
-        => string.Equals(Path.GetFileName(path), ClippingsFileName, StringComparison.OrdinalIgnoreCase);
+    private static bool IsClippingsTextFile(string path)
+        => File.Exists(path)
+            && string.Equals(Path.GetExtension(path), ClippingsFileExtension, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Relego.Cli/Tui/BookListScreen.cs
+++ b/src/Relego.Cli/Tui/BookListScreen.cs
@@ -49,7 +49,7 @@ public sealed class BookListScreen(
     private const string SearchPlaceholderIdle = "type / to search";
     private const string SearchPlaceholderFocused = "Press Esc to return to the list";
     private const string SyncPlaceholderDetected = "Press Enter to import or edit the path";
-    private const string SyncPlaceholderManual = "Enter the path to My Clippings.txt";
+    private const string SyncPlaceholderManual = "Enter a Kindle .txt or Kobo SQLite path";
 
     private readonly RelegoHttpClient _client = client;
     private readonly ClippingsImportWorkflow _syncWorkflow = syncWorkflow;
@@ -651,7 +651,7 @@ public sealed class BookListScreen(
         var resolvedPath = filePath ?? _syncPathInput;
         if (string.IsNullOrWhiteSpace(resolvedPath))
         {
-            SetFeedback("Enter a path to My Clippings.txt or press Esc to cancel.", isError: true);
+            SetFeedback("Enter a Kindle .txt or Kobo SQLite path, or press Esc to cancel.", isError: true);
             return ClippingsImportOutcome.Cancelled();
         }
 

--- a/src/Relego.Tests/Cli/ImportCommandTests.cs
+++ b/src/Relego.Tests/Cli/ImportCommandTests.cs
@@ -42,6 +42,21 @@ public sealed class ImportCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Import_WithRenamedTxtFile_ReturnsZero()
+    {
+        var filePath = CreateClippingsFile(SampleClippings, "kindle-export.txt");
+
+        _mockHttp.When(HttpMethod.Post, "http://localhost:5000/highlights/import")
+            .Respond("application/json", """
+                {"newHighlights":5,"duplicateHighlights":2,"newBooks":3,"newAuthors":2}
+                """);
+
+        var exitCode = await RunImportCommand(filePath);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
     public async Task Import_WithEmptyFile_ReturnsZero()
     {
         var filePath = CreateClippingsFile("");
@@ -100,9 +115,9 @@ public sealed class ImportCommandTests : IDisposable
         return await app.RunAsync(["import", filePath]);
     }
 
-    private string CreateClippingsFile(string content)
+    private string CreateClippingsFile(string content, string fileName = "My Clippings.txt")
     {
-        var filePath = Path.Combine(_tempDir, "My Clippings.txt");
+        var filePath = Path.Combine(_tempDir, fileName);
         File.WriteAllText(filePath, content);
         return filePath;
     }

--- a/src/Relego.Tests/Sources/HighlightSourceResolverTests.cs
+++ b/src/Relego.Tests/Sources/HighlightSourceResolverTests.cs
@@ -54,6 +54,21 @@ public sealed class HighlightSourceResolverTests : IDisposable
     }
 
     [Fact]
+    public void Resolve_RenamedTxtFile_RoutesToKindle()
+    {
+        var dir = NewTempDir();
+        var clippings = Path.Combine(dir, "kindle-export.txt");
+        File.WriteAllText(clippings, "ignored");
+
+        var resolution = CreateResolver().Resolve(clippings);
+
+        Assert.True(resolution.Found);
+        var resolved = Assert.Single(resolution.Sources);
+        Assert.Equal("kindle", resolved.Source.Descriptor.Id);
+        Assert.Equal(clippings, resolved.ResolvedPath);
+    }
+
+    [Fact]
     public void Resolve_DirectoryWithDocumentsClippings_RoutesToKindle()
     {
         var dir = NewTempDir();

--- a/src/Relego.Tests/Sources/KindleClippingsSourceTests.cs
+++ b/src/Relego.Tests/Sources/KindleClippingsSourceTests.cs
@@ -118,6 +118,19 @@ public sealed class KindleClippingsSourceTests : IDisposable
     }
 
     [Fact]
+    public void Locate_ExistingRenamedTxtFile_ReturnsThatPath()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "kindle-export.txt");
+        File.WriteAllText(path, "ignored");
+
+        var probe = new KindleClippingsSource().Locate(path);
+
+        Assert.Equal(path, probe.FoundPath);
+        Assert.Equal(new[] { path }, probe.ProbedLocations);
+    }
+
+    [Fact]
     public void Locate_MissingClippingsFileByName_ReturnsNullButProbesIt()
     {
         var path = Path.Combine(NewTempDir(), ClippingsFileName);

--- a/src/Relego.Tests/Tui/BookListScreenTests.cs
+++ b/src/Relego.Tests/Tui/BookListScreenTests.cs
@@ -236,7 +236,9 @@ public sealed class BookListScreenTests : IDisposable
         var outcome = await screen.SubmitImportAsync(string.Empty);
 
         Assert.Equal(ClippingsImportStatus.Cancelled, outcome.Status);
-        Assert.Equal("Enter a path to My Clippings.txt or press Esc to cancel.", screen.FeedbackMessage);
+        Assert.Equal(
+            "Enter a Kindle .txt or Kobo SQLite path, or press Esc to cancel.",
+            screen.FeedbackMessage);
         Assert.True(screen.FeedbackIsError);
         Assert.True(screen.IsImportPromptActive);
     }
@@ -301,6 +303,58 @@ public sealed class BookListScreenTests : IDisposable
         Assert.False(screen.IsImportPromptActive);
         Assert.False(screen.FeedbackIsError);
         Assert.Contains("Import complete.", screen.FeedbackMessage);
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task SubmitImportAsync_WithRenamedTxtFile_ImportsAndClosesPrompt()
+    {
+        using var mockHttp = new MockHttpMessageHandler(BackendDefinitionBehavior.Always);
+
+        mockHttp.Expect(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+            .Respond("application/json", """
+                {
+                  "total": 0,
+                  "page": 1,
+                  "pageSize": 100,
+                  "items": []
+                }
+                """);
+
+        mockHttp.Expect(HttpMethod.Post, "http://localhost:5000/highlights/import")
+            .Respond("application/json", """
+                {
+                  "newHighlights": 1,
+                  "duplicateHighlights": 0,
+                  "newBooks": 1,
+                  "newAuthors": 1
+                }
+                """);
+
+        mockHttp.Expect(HttpMethod.Get, "http://localhost:5000/highlights?page=1&pageSize=100")
+            .Respond("application/json", """
+                {
+                  "total": 0,
+                  "page": 1,
+                  "pageSize": 100,
+                  "items": []
+                }
+                """);
+
+        ConfigureSupplementaryEndpoints(mockHttp);
+
+        var releClient = CreateRelegoClient(mockHttp);
+        var workflow = CreateSyncWorkflow(releClient);
+        var screen = new BookListScreen(releClient, workflow);
+        await screen.InitializeAsync(CancellationToken.None);
+
+        var filePath = CreateClippingsFile("kindle-export.txt");
+        SetSyncPromptState(screen, detectedPath: filePath, syncPathInput: filePath);
+        var outcome = await screen.SubmitImportAsync(filePath);
+
+        Assert.Equal(ClippingsImportStatus.Succeeded, outcome.Status);
+        Assert.False(screen.IsImportPromptActive);
+        Assert.False(screen.FeedbackIsError);
         mockHttp.VerifyNoOutstandingExpectation();
     }
 
@@ -539,9 +593,9 @@ public sealed class BookListScreenTests : IDisposable
                 """);
     }
 
-    private string CreateClippingsFile()
+    private string CreateClippingsFile(string fileName = "My Clippings.txt")
     {
-        var filePath = Path.Combine(_tempDir, "My Clippings.txt");
+        var filePath = Path.Combine(_tempDir, fileName);
         File.WriteAllText(filePath, SampleClippings);
         return filePath;
     }


### PR DESCRIPTION
Enhance the import command to recognize and handle renamed Kindle and Kobo files. Update documentation and tests to reflect these changes. 

Close #386