### PR TITLE
Fix token permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,13 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -6,12 +6,14 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tag-components:
     name: Tag changed components
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/publish-cli-image.yaml
+++ b/.github/workflows/publish-cli-image.yaml
@@ -10,6 +10,9 @@ name: Publish CLI Image
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   check-tag:
     name: Check tag prefix
@@ -42,6 +45,6 @@ jobs:
       image_name: ghcr.io/krusty93/relego.cli
       dockerfile: Dockerfile.cli
       version: ${{ needs.check-tag.outputs.version }}
-      description: Periodic notes recaps, on your Kindle
+      description: Learn from your highlights. For free.
       authors: Krusty93
     secrets: inherit

--- a/.github/workflows/publish-image-reusable.yaml
+++ b/.github/workflows/publish-image-reusable.yaml
@@ -19,6 +19,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-server-image.yaml
+++ b/.github/workflows/publish-server-image.yaml
@@ -10,6 +10,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   check-tag:
     name: Check tag prefix
@@ -34,7 +37,6 @@ jobs:
     if: needs.check-tag.outputs.is-server == 'true'
     uses: ./.github/workflows/publish-image-reusable.yaml
     permissions:
-      contents: read
       packages: write
       id-token: write
       attestations: write
@@ -42,6 +44,6 @@ jobs:
       image_name: ghcr.io/krusty93/relego.server
       dockerfile: Dockerfile.server
       version: ${{ needs.check-tag.outputs.version }}
-      description: Periodic notes recaps, on your Kindle
+      description: Learn from your highlights. For free.
       authors: Krusty93
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       - 'server/v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   metadata:
@@ -94,6 +94,9 @@ jobs:
     needs: [metadata, build-cli]
     if: always() && needs.metadata.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/version-bump-check.yaml
+++ b/.github/workflows/version-bump-check.yaml
@@ -10,12 +10,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   version-bump-check:
     name: Version Bump Check
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Adjust permissions for various jobs to ensure appropriate access levels, specifically changing `contents` permissions from `write` to `read` where necessary and ensuring `pull-requests` permissions are correctly set for relevant jobs.

Close #395