### PR TITLE
Sign CLI release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,13 +89,69 @@ jobs:
           name: cli-${{ matrix.rid }}
           path: publish/relego-*
 
+  prepare-cli-release-assets:
+    name: Prepare CLI release assets
+    needs: [metadata, build-cli]
+    if: startsWith(github.ref, 'refs/tags/cli/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      hashes: ${{ steps.sign.outputs.hashes }}
+    steps:
+      - name: Download CLI Artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: cli-*
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Generate Signatures and Provenance Subjects
+        id: sign
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          pushd artifacts >/dev/null
+          mapfile -t binaries < <(find . -maxdepth 1 -type f -print | sed 's#^./##' | sort)
+
+          if [ "${#binaries[@]}" -eq 0 ]; then
+            echo "No CLI artifacts found." >&2
+            exit 1
+          fi
+
+          : > ../subjects.txt
+
+          for binary in "${binaries[@]}"; do
+            sha256sum "$binary" >> ../subjects.txt
+            cosign sign-blob --yes --bundle "${binary}.sigstore" "$binary"
+          done
+
+          cp ../subjects.txt "relego-${VERSION}-checksums.sha256"
+          popd >/dev/null
+
+          echo "hashes=$(base64 -w0 subjects.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload CLI Release Assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-release-assets
+          path: artifacts/*
+
   create-release:
     name: Create GitHub Release
-    needs: [metadata, build-cli]
+    needs: [metadata, build-cli, prepare-cli-release-assets]
     if: always() && needs.metadata.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      publish: ${{ steps.notes.outputs.publish }}
 
     steps:
       - name: Checkout
@@ -108,12 +164,11 @@ jobs:
         id: discover
         uses: ./.github/actions/discover-versioned-components
 
-      - name: Download CLI Artifacts
+      - name: Download CLI Release Assets
         uses: actions/download-artifact@v8
         with:
-          pattern: cli-*
+          name: cli-release-assets
           path: artifacts/
-          merge-multiple: true
         continue-on-error: true
 
       - name: Generate Release Notes
@@ -204,7 +259,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: steps.notes.outputs.publish == 'true'
+        if: steps.notes.outputs.publish == 'true' && (needs.metadata.outputs.component != 'cli' || needs.prepare-cli-release-assets.result == 'success')
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.metadata.outputs.tag }}
@@ -214,3 +269,18 @@ jobs:
           prerelease: false
           files: artifacts/*
           token: ${{ secrets.RELEASE_TOKEN }}
+
+  cli-provenance:
+    name: Generate CLI SLSA Provenance
+    needs: [metadata, prepare-cli-release-assets, create-release]
+    if: startsWith(github.ref, 'refs/tags/cli/') && needs.create-release.outputs.publish == 'true'
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.prepare-cli-release-assets.outputs.hashes }}
+      upload-assets: true
+      upload-tag-name: ${{ needs.metadata.outputs.tag }}
+      provenance-name: relego-${{ needs.metadata.outputs.version }}.intoto.jsonl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,11 +165,11 @@ jobs:
         uses: ./.github/actions/discover-versioned-components
 
       - name: Download CLI Release Assets
+        if: needs.metadata.outputs.component == 'cli'
         uses: actions/download-artifact@v8
         with:
           name: cli-release-assets
           path: artifacts/
-        continue-on-error: true
 
       - name: Generate Release Notes
         id: notes


### PR DESCRIPTION
Adds signed and provenance-bearing CLI release assets so OpenSSF Scorecard can detect signed releases.

Changes:
- Adds a CLI release asset preparation job that signs every CLI binary with keyless Cosign and uploads `*.sigstore` bundles.
- Generates SHA-256 subjects and uploads checksums beside the release binaries.
- Adds SLSA generic provenance upload for CLI releases as `*.intoto.jsonl`.
- Keeps top-level workflow permissions read-only and uses job-level write/OIDC permissions only where needed.
- Prevents CLI release publication if signed asset preparation fails.

Validation:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yaml"); puts "YAML OK"'`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yaml`

Closes #397