### PR TITLE
[Feature 015] Phase 2–4 — Server endpoints: imports, library, recap history, SMTP, CORS

### DIFF
--- a/src/Relego.Core/Contracts/BooksResponse.cs
+++ b/src/Relego.Core/Contracts/BooksResponse.cs
@@ -1,0 +1,49 @@
+namespace Relego.Core.Contracts;
+
+/// <summary>
+/// Paginated list of books in the library.
+/// </summary>
+public sealed record BooksResponse
+{
+    /// <summary>Total number of books matching the current filter.</summary>
+    public int Total { get; set; }
+
+    /// <summary>Current page number (1-based).</summary>
+    public int Page { get; set; }
+
+    /// <summary>Number of items per page.</summary>
+    public int PageSize { get; set; }
+
+    /// <summary>Books on the current page.</summary>
+    public List<BookItemDto> Items { get; set; } = [];
+}
+
+/// <summary>
+/// A single book in the library list.
+/// </summary>
+public sealed record BookItemDto
+{
+    /// <summary>Book identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Book title.</summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Author identifier.</summary>
+    public int AuthorId { get; set; }
+
+    /// <summary>Author display name.</summary>
+    public string AuthorName { get; set; } = string.Empty;
+
+    /// <summary>Number of highlights stored for the book.</summary>
+    public int HighlightCount { get; set; }
+
+    /// <summary>Number of the book's highlights that are individually excluded.</summary>
+    public int ExcludedHighlightCount { get; set; }
+
+    /// <summary>Indicates whether the book itself is excluded from recaps.</summary>
+    public bool Excluded { get; set; }
+
+    /// <summary>Indicates whether the book's author is excluded from recaps.</summary>
+    public bool AuthorExcluded { get; set; }
+}

--- a/src/Relego.Core/Contracts/ImportResponse.cs
+++ b/src/Relego.Core/Contracts/ImportResponse.cs
@@ -1,0 +1,40 @@
+namespace Relego.Core.Contracts;
+
+/// <summary>
+/// Outcome of a file upload import (<c>POST /imports</c>).
+/// </summary>
+public sealed record ImportResponse
+{
+    /// <summary>Source that produced the file: <c>kindle</c> or <c>kobo</c>.</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Human-readable source name, e.g. <c>Kindle</c>.</summary>
+    public string SourceName { get; set; } = string.Empty;
+
+    /// <summary>Original file name as uploaded.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Number of distinct books found in the uploaded file.</summary>
+    public int BooksParsed { get; set; }
+
+    /// <summary>Number of highlights found in the uploaded file after in-file deduplication.</summary>
+    public int HighlightsParsed { get; set; }
+
+    /// <summary>Number of raw entries the parser processed.</summary>
+    public int EntriesProcessed { get; set; }
+
+    /// <summary>Number of entries dropped as duplicates within the file itself.</summary>
+    public int DuplicatesInFile { get; set; }
+
+    /// <summary>Number of highlights stored as new records.</summary>
+    public int NewHighlights { get; set; }
+
+    /// <summary>Number of highlights skipped because they already existed.</summary>
+    public int DuplicateHighlights { get; set; }
+
+    /// <summary>Number of new book records created.</summary>
+    public int NewBooks { get; set; }
+
+    /// <summary>Number of new author records created.</summary>
+    public int NewAuthors { get; set; }
+}

--- a/src/Relego.Core/Contracts/RecapHistoryResponse.cs
+++ b/src/Relego.Core/Contracts/RecapHistoryResponse.cs
@@ -1,0 +1,37 @@
+namespace Relego.Core.Contracts;
+
+/// <summary>
+/// Recent recap delivery attempts, newest first.
+/// </summary>
+public sealed record RecapHistoryResponse
+{
+    /// <summary>Delivery attempts on the current page.</summary>
+    public List<RecapHistoryItemDto> Items { get; set; } = [];
+}
+
+/// <summary>
+/// A single recap delivery attempt.
+/// </summary>
+public sealed record RecapHistoryItemDto
+{
+    /// <summary>Recap job identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Slot the recap was scheduled for, in UTC.</summary>
+    public DateTimeOffset ScheduledFor { get; set; }
+
+    /// <summary>Delivery state: <c>pending</c>, <c>delivered</c>, or <c>failed</c>.</summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>Number of delivery attempts made.</summary>
+    public int AttemptCount { get; set; }
+
+    /// <summary>Failure detail when <c>status</c> is <c>failed</c>; otherwise <c>null</c>.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>When the recap was delivered. <c>null</c> when it was not.</summary>
+    public DateTimeOffset? DeliveredAt { get; set; }
+
+    /// <summary>When the job record was created.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/Relego.Core/Contracts/SmtpSettingsResponse.cs
+++ b/src/Relego.Core/Contracts/SmtpSettingsResponse.cs
@@ -1,0 +1,86 @@
+namespace Relego.Core.Contracts;
+
+/// <summary>
+/// Effective outgoing mail server configuration. The password is never returned.
+/// </summary>
+public sealed record SmtpSettingsResponse
+{
+    /// <summary>SMTP host name.</summary>
+    public string Host { get; set; } = string.Empty;
+
+    /// <summary>SMTP port.</summary>
+    public int Port { get; set; }
+
+    /// <summary>Address recaps are sent from.</summary>
+    public string FromAddress { get; set; } = string.Empty;
+
+    /// <summary>SMTP user name. Empty when the server does not require authentication.</summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether a password is stored. The password itself is write-only and
+    /// is never sent to a client.
+    /// </summary>
+    public bool PasswordSet { get; set; }
+
+    /// <summary>
+    /// Where the effective values come from: <c>database</c> once saved from a client,
+    /// <c>environment</c> while the values still come from configuration, or
+    /// <c>default</c> when nothing has been configured.
+    /// </summary>
+    public string Source { get; set; } = "default";
+
+    /// <summary>When the stored configuration was last saved. <c>null</c> when never saved.</summary>
+    public DateTimeOffset? UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Partial update for the outgoing mail server configuration.
+/// Omitted properties keep their current value.
+/// </summary>
+public sealed record UpdateSmtpSettingsRequest
+{
+    /// <summary>SMTP host name.</summary>
+    public string? Host { get; set; }
+
+    /// <summary>SMTP port. Must be between 1 and 65535.</summary>
+    public int? Port { get; set; }
+
+    /// <summary>Address recaps are sent from. Must be a valid email address.</summary>
+    public string? FromAddress { get; set; }
+
+    /// <summary>
+    /// SMTP user name. Pass <c>""</c> to clear it and connect without authentication.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// SMTP password. Omit to keep the stored password, pass <c>""</c> to clear it.
+    /// Write-only: it is never returned by <c>GET /settings/smtp</c>.
+    /// </summary>
+    public string? Password { get; set; }
+}
+
+/// <summary>
+/// Result of an outgoing mail server connection test.
+/// </summary>
+public sealed record SmtpTestResponse
+{
+    /// <summary>Indicates whether the test message was delivered to the SMTP server.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Actionable description of the outcome.</summary>
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Optional body for <c>POST /settings/smtp/test</c>.
+/// </summary>
+public sealed record SmtpTestRequest
+{
+    /// <summary>
+    /// Address to send the test message to. Defaults to the configured delivery email,
+    /// then the Kindle email, then the sender address.
+    /// </summary>
+    public string? ToAddress { get; set; }
+}

--- a/src/Relego.Server/Data/BookRepository.cs
+++ b/src/Relego.Server/Data/BookRepository.cs
@@ -1,10 +1,66 @@
 using System.Data;
 using Dapper;
+using Relego.Core.Contracts;
 
 namespace Relego.Server.Data;
 
 public sealed class BookRepository(IDbConnection connection)
 {
+    /// <summary>
+    /// Returns a page of books with their highlight counts and exclusion state.
+    /// </summary>
+    public async Task<BooksResponse> GetBooksAsync(int userId, int page, int pageSize, string? query)
+    {
+        var normalizedQuery = string.IsNullOrWhiteSpace(query) ? null : $"%{query.Trim()}%";
+
+        const string filter =
+            """
+            FROM books b
+            JOIN authors a ON a.id = b.author_id
+            WHERE b.user_id = @UserId
+              AND (@Query IS NULL OR b.title LIKE @Query OR a.name LIKE @Query)
+            """;
+
+        var total = await connection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) " + filter,
+            new { UserId = userId, Query = normalizedQuery }).ConfigureAwait(false);
+
+        var items = await connection.QueryAsync<BookItemDto>(
+            $"""
+             SELECT
+                 b.id    AS Id,
+                 b.title AS Title,
+                 a.id    AS AuthorId,
+                 a.name  AS AuthorName,
+                 (SELECT COUNT(*) FROM highlights h
+                  WHERE h.book_id = b.id AND h.user_id = @UserId) AS HighlightCount,
+                 (SELECT COUNT(*) FROM highlights h
+                  WHERE h.book_id = b.id AND h.user_id = @UserId AND h.excluded = 1) AS ExcludedHighlightCount,
+                 EXISTS (SELECT 1 FROM excluded_books eb
+                         WHERE eb.book_id = b.id AND eb.user_id = @UserId) AS Excluded,
+                 EXISTS (SELECT 1 FROM excluded_authors ea
+                         WHERE ea.author_id = a.id AND ea.user_id = @UserId) AS AuthorExcluded
+             {filter}
+             ORDER BY b.title COLLATE NOCASE
+             LIMIT @PageSize OFFSET @Offset
+             """,
+            new
+            {
+                UserId = userId,
+                Query = normalizedQuery,
+                PageSize = pageSize,
+                Offset = (page - 1) * pageSize,
+            }).ConfigureAwait(false);
+
+        return new BooksResponse
+        {
+            Total = total,
+            Page = page,
+            PageSize = pageSize,
+            Items = [.. items],
+        };
+    }
+
     /// <summary>
     /// Renames a book title.
     /// Returns <see langword="true"/> when the book was found and updated,

--- a/src/Relego.Server/Data/RecapRepository.cs
+++ b/src/Relego.Server/Data/RecapRepository.cs
@@ -1,5 +1,7 @@
-﻿using System.Data;
+using System.Data;
+using System.Globalization;
 using Dapper;
+using Relego.Core.Contracts;
 using Relego.Server.Models;
 using Relego.Server.Services;
 
@@ -75,6 +77,38 @@ public sealed class RecapRepository(IDbConnection connection)
             new { UserId = userId });
     }
 
+    public async Task<IReadOnlyList<RecapHistoryItemDto>> GetHistoryAsync(int userId, int limit)
+    {
+        var rows = await connection.QueryAsync<HistoryRow>(
+            """
+            SELECT id AS Id, scheduled_for AS ScheduledForText, status AS Status,
+                   attempt_count AS AttemptCount, error_message AS ErrorMessage,
+                   created_at AS CreatedAtText, delivered_at AS DeliveredAtText
+            FROM recap_jobs
+            WHERE user_id = @UserId
+            ORDER BY scheduled_for DESC
+            LIMIT @Limit
+            """,
+            new { UserId = userId, Limit = limit }).ConfigureAwait(false);
+
+        return
+        [
+            .. rows.Select(r => new RecapHistoryItemDto
+            {
+                Id = (int)r.Id,
+                ScheduledFor = ParseTimestamp(r.ScheduledForText),
+                Status = r.Status,
+                AttemptCount = (int)r.AttemptCount,
+                ErrorMessage = r.ErrorMessage,
+                CreatedAt = ParseTimestamp(r.CreatedAtText),
+                DeliveredAt = r.DeliveredAtText is null ? null : ParseTimestamp(r.DeliveredAtText),
+            }),
+        ];
+    }
+
+    private static DateTimeOffset ParseTimestamp(string value)
+        => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+
     public async Task<IReadOnlyList<SelectionCandidate>> SelectCandidatesAsync(int userId, CancellationToken cancellationToken = default)
     {
         var rows = await connection.QueryAsync<SelectionCandidateRow>(new CommandDefinition(
@@ -136,5 +170,17 @@ public sealed class RecapRepository(IDbConnection connection)
         public long Weight { get; set; }
         public string? LastSeenText { get; set; }
         public string CreatedAtText { get; set; } = "";
+    }
+
+    // Raw row type for the recap history projection.
+    private sealed class HistoryRow
+    {
+        public long Id { get; set; }
+        public string ScheduledForText { get; set; } = "";
+        public string Status { get; set; } = "";
+        public long AttemptCount { get; set; }
+        public string? ErrorMessage { get; set; }
+        public string CreatedAtText { get; set; } = "";
+        public string? DeliveredAtText { get; set; }
     }
 }

--- a/src/Relego.Server/Data/SmtpSettingsRepository.cs
+++ b/src/Relego.Server/Data/SmtpSettingsRepository.cs
@@ -1,0 +1,91 @@
+using System.Data;
+using Dapper;
+using Relego.Server.Infrastructure.Smtp;
+
+namespace Relego.Server.Data;
+
+/// <summary>
+/// Single-row store for the outgoing mail server configuration.
+/// </summary>
+/// <remarks>
+/// Environment variables seed this table on first boot; once a client saves settings the
+/// stored row wins, so the web UI is authoritative without losing an existing env-only setup.
+/// </remarks>
+public sealed class SmtpSettingsRepository(IDbConnection connection)
+{
+    public async Task<StoredSmtpSettings?> GetAsync()
+    {
+        var row = await connection.QuerySingleOrDefaultAsync<Row>(
+            """
+            SELECT host AS Host, port AS Port, from_address AS FromAddress,
+                   username AS Username, password AS Password, updated_at AS UpdatedAtText
+            FROM smtp_settings WHERE id = 1
+            """).ConfigureAwait(false);
+
+        return row is null
+            ? null
+            : new StoredSmtpSettings(
+                row.Host,
+                (int)row.Port,
+                row.FromAddress,
+                row.Username,
+                row.Password,
+                DateTimeOffset.Parse(row.UpdatedAtText, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    public async Task<StoredSmtpSettings> UpsertAsync(SmtpSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var updatedAt = DateTimeOffset.UtcNow;
+
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO smtp_settings (id, host, port, from_address, username, password, updated_at)
+            VALUES (1, @Host, @Port, @FromAddress, @Username, @Password, @UpdatedAt)
+            ON CONFLICT(id) DO UPDATE SET
+                host = excluded.host,
+                port = excluded.port,
+                from_address = excluded.from_address,
+                username = excluded.username,
+                password = excluded.password,
+                updated_at = excluded.updated_at
+            """,
+            new
+            {
+                settings.Host,
+                settings.Port,
+                settings.FromAddress,
+                settings.Username,
+                settings.Password,
+                UpdatedAt = updatedAt.UtcDateTime.ToString("O"),
+            }).ConfigureAwait(false);
+
+        return new StoredSmtpSettings(
+            settings.Host,
+            settings.Port,
+            settings.FromAddress,
+            settings.Username,
+            settings.Password,
+            updatedAt);
+    }
+
+    private sealed class Row
+    {
+        public string Host { get; set; } = string.Empty;
+        public long Port { get; set; }
+        public string FromAddress { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string UpdatedAtText { get; set; } = string.Empty;
+    }
+}
+
+/// <summary>The persisted mail server configuration and when it was saved.</summary>
+public sealed record StoredSmtpSettings(
+    string Host,
+    int Port,
+    string FromAddress,
+    string Username,
+    string Password,
+    DateTimeOffset UpdatedAt);

--- a/src/Relego.Server/Endpoints/BookEndpoints.cs
+++ b/src/Relego.Server/Endpoints/BookEndpoints.cs
@@ -8,6 +8,37 @@ public static class BookEndpoints
 {
     public static WebApplication MapBookEndpoints(this WebApplication app)
     {
+        app.MapGet("/books", async (
+            [FromServices] UserRepository userRepo,
+            [FromServices] BookRepository bookRepo,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 100,
+            [FromQuery] string? q = null) =>
+        {
+            if (page < 1)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "page", ["page must be greater than or equal to 1."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            if (pageSize is < 1 or > 500)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { { "pageSize", ["pageSize must be between 1 and 500."] } },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var userId = await userRepo.EnsureUserAsync();
+            var result = await bookRepo.GetBooksAsync(userId, page, pageSize, q);
+            return Results.Ok(result);
+        })
+        .WithTags("Books")
+        .WithSummary("List books.")
+        .WithDescription("Returns a paginated, optionally filtered list of books with highlight counts and exclusion state.")
+        .Produces<BooksResponse>(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
+
         app.MapPut("/books/{id:int}/title", async (
             int id,
             [FromBody] RenameBookRequest request,

--- a/src/Relego.Server/Endpoints/ImportEndpoints.cs
+++ b/src/Relego.Server/Endpoints/ImportEndpoints.cs
@@ -1,0 +1,120 @@
+using Microsoft.AspNetCore.Mvc;
+using Relego.Core.Contracts;
+using Relego.Server.Data;
+using Relego.Server.Services;
+
+namespace Relego.Server.Endpoints;
+
+public static class ImportEndpoints
+{
+    public static WebApplication MapImportEndpoints(this WebApplication app)
+    {
+        app.MapPost("/imports", async (
+            HttpRequest request,
+            [FromServices] UserRepository userRepo,
+            [FromServices] SyncRepository syncRepo,
+            [FromServices] UploadImportService importService,
+            CancellationToken cancellationToken) =>
+        {
+            if (!request.HasFormContentType)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]>
+                    {
+                        ["file"] = ["Send the export as multipart/form-data with a 'file' field."],
+                    },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            IFormFile? file;
+            try
+            {
+                var form = await request.ReadFormAsync(cancellationToken);
+                file = form.Files["file"] ?? form.Files.FirstOrDefault();
+            }
+            catch (Exception ex) when (ex is InvalidDataException or IOException)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]>
+                    {
+                        ["file"] = ["The upload could not be read. Send the export as multipart/form-data with a 'file' field."],
+                    },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            if (file is null || file.Length == 0)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]>
+                    {
+                        ["file"] = ["Attach a Kindle 'My Clippings.txt' or a Kobo 'KoboReader.sqlite'."],
+                    },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            if (file.Length > UploadImportService.MaxUploadBytes)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]>
+                    {
+                        ["file"] = [$"The file is larger than {UploadImportService.MaxUploadBytes / (1024 * 1024)} MB."],
+                    },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            UploadImportResult parsed;
+            try
+            {
+                await using var content = file.OpenReadStream();
+                parsed = await importService.ParseAsync(content, file.FileName, cancellationToken);
+            }
+            catch (UploadImportException ex)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { ["file"] = [ex.Message] },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var parseResult = parsed.ParseResult;
+            var highlightsParsed = parseResult.Books.Sum(book => book.Highlights.Count);
+
+            var response = new ImportResponse
+            {
+                Source = parsed.Source.Id,
+                SourceName = parsed.Source.DisplayName,
+                FileName = Path.GetFileName(file.FileName),
+                BooksParsed = parseResult.Books.Count,
+                HighlightsParsed = highlightsParsed,
+                EntriesProcessed = parseResult.TotalEntriesProcessed,
+                DuplicatesInFile = parseResult.DuplicatesRemoved,
+            };
+
+            if (parseResult.Books.Count > 0)
+            {
+                var userId = await userRepo.EnsureUserAsync();
+                var syncResponse = await syncRepo.ImportAsync(
+                    userId,
+                    UploadImportService.ToSyncRequest(parseResult));
+
+                response.NewHighlights = syncResponse.NewHighlights;
+                response.DuplicateHighlights = syncResponse.DuplicateHighlights;
+                response.NewBooks = syncResponse.NewBooks;
+                response.NewAuthors = syncResponse.NewAuthors;
+            }
+
+            return Results.Ok(response);
+        })
+        .DisableAntiforgery()
+        .WithTags("Import")
+        .WithSummary("Import highlights from an uploaded export file.")
+        .WithDescription(
+            "Accepts a Kindle 'My Clippings.txt' or a Kobo 'KoboReader.sqlite' as multipart/form-data, " +
+            "detects the format from the file's contents, parses it server-side, and stores the result. " +
+            "Highlights that already exist are reported as duplicates rather than re-imported.")
+        .Accepts<IFormFile>("multipart/form-data")
+        .Produces<ImportResponse>(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
+
+        return app;
+    }
+}

--- a/src/Relego.Server/Endpoints/RecapEndpoints.cs
+++ b/src/Relego.Server/Endpoints/RecapEndpoints.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Relego.Core.Contracts;
 using Relego.Server.Data;
 using Relego.Server.Services;
 
@@ -8,6 +9,28 @@ public static class RecapEndpoints
 {
     public static WebApplication MapRecapEndpoints(this WebApplication app)
     {
+        app.MapGet("/recaps", async (
+            [FromServices] UserRepository userRepo,
+            [FromServices] RecapRepository recapRepo,
+            [FromQuery] int limit = 20) =>
+        {
+            if (limit is < 1 or > 100)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { ["limit"] = ["limit must be between 1 and 100."] },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var userId = await userRepo.EnsureUserAsync();
+            var items = await recapRepo.GetHistoryAsync(userId, limit);
+            return Results.Ok(new RecapHistoryResponse { Items = [.. items] });
+        })
+        .WithTags("Recap")
+        .WithSummary("List recent recap deliveries.")
+        .WithDescription("Returns the most recent recap delivery attempts, newest first, with their status and any failure detail.")
+        .Produces<RecapHistoryResponse>(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
+
         app.MapPost("/recaps", async (
             [FromServices] UserRepository userRepo,
             [FromServices] IRecapService recapService,

--- a/src/Relego.Server/Endpoints/SmtpSettingsEndpoints.cs
+++ b/src/Relego.Server/Endpoints/SmtpSettingsEndpoints.cs
@@ -1,0 +1,156 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Relego.Core.Contracts;
+using Relego.Server.Data;
+using Relego.Server.Infrastructure.Smtp;
+using Relego.Server.Services;
+
+namespace Relego.Server.Endpoints;
+
+/// <summary>
+/// Outgoing mail server configuration. Kept separate from <see cref="SettingsEndpoints"/>
+/// because these values are server-wide infrastructure, not per-user recap preferences.
+/// </summary>
+public static partial class SmtpSettingsEndpoints
+{
+    public static WebApplication MapSmtpSettingsEndpoints(this WebApplication app)
+    {
+        app.MapGet("/settings/smtp", async ([FromServices] SmtpConfigurationService smtp) =>
+        {
+            var effective = await smtp.GetEffectiveAsync();
+            return Results.Ok(SmtpConfigurationService.ToResponse(effective));
+        })
+        .WithTags("Settings")
+        .WithSummary("Get the outgoing mail server configuration.")
+        .WithDescription(
+            "Returns the mail server settings currently in effect and where they come from. " +
+            "The password is write-only and is reported only as a boolean.")
+        .Produces<SmtpSettingsResponse>(StatusCodes.Status200OK);
+
+        app.MapPut("/settings/smtp", async (
+            UpdateSmtpSettingsRequest? request,
+            [FromServices] SmtpConfigurationService smtp) =>
+        {
+            if (request is null)
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]> { ["request"] = ["A request body is required."] },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var errors = new Dictionary<string, string[]>();
+
+            if (request.Host is not null && string.IsNullOrWhiteSpace(request.Host))
+                errors["host"] = ["Host must not be empty."];
+
+            if (request.Port is { } port && port is < 1 or > 65535)
+                errors["port"] = ["Port must be between 1 and 65535."];
+
+            if (request.FromAddress is not null && !IsValidEmail(request.FromAddress))
+                errors["fromAddress"] = ["From address must be a valid email address."];
+
+            if (errors.Count > 0)
+                return Results.ValidationProblem(errors, statusCode: StatusCodes.Status422UnprocessableEntity);
+
+            var saved = await smtp.SaveAsync(request);
+            return Results.Ok(SmtpConfigurationService.ToResponse(saved));
+        })
+        .WithTags("Settings")
+        .WithSummary("Save the outgoing mail server configuration.")
+        .WithDescription(
+            "Stores the mail server settings in the database. Once saved, the stored values take " +
+            "precedence over the SMTP_* environment variables. Omit 'password' to keep the stored " +
+            "password; send an empty string to clear it.")
+        .Accepts<UpdateSmtpSettingsRequest>("application/json")
+        .Produces<SmtpSettingsResponse>(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity);
+
+        app.MapPost("/settings/smtp/test", async (
+            SmtpTestRequest? request,
+            [FromServices] SmtpConfigurationService smtp,
+            [FromServices] UserRepository userRepo,
+            [FromServices] IMailDeliveryService mailService) =>
+        {
+            var effective = await smtp.GetEffectiveAsync();
+
+            if (string.IsNullOrWhiteSpace(effective.Settings.Host) ||
+                string.IsNullOrWhiteSpace(effective.Settings.FromAddress))
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]>
+                    {
+                        ["smtp"] = ["Set a host and a from address before sending a test message."],
+                    },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var userId = await userRepo.EnsureUserAsync();
+            var user = await userRepo.GetByIdAsync(userId);
+
+            var toAddress = FirstNonEmpty(
+                request?.ToAddress,
+                user.DeliveryEmail,
+                user.KindleEmail,
+                effective.Settings.FromAddress);
+
+            if (toAddress is null || !IsValidEmail(toAddress))
+            {
+                return Results.ValidationProblem(
+                    new Dictionary<string, string[]>
+                    {
+                        ["toAddress"] = ["Provide a valid address to send the test message to."],
+                    },
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
+            }
+
+            try
+            {
+                await mailService.SendTestEmailAsync(toAddress);
+                return Results.Ok(new SmtpTestResponse
+                {
+                    Success = true,
+                    Message = $"Test message sent to {toAddress}.",
+                });
+            }
+            catch (Exception ex) when (IsSmtpException(ex))
+            {
+                return Results.Problem(
+                    detail: ex.Message,
+                    title: "The mail server rejected the connection.",
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        })
+        .WithTags("Settings")
+        .WithSummary("Send a test message using the stored mail server configuration.")
+        .WithDescription(
+            "Sends a short plain-text message to verify the mail server settings. Defaults to the " +
+            "configured delivery email, then the Kindle email, then the sender address.")
+        .Accepts<SmtpTestRequest>("application/json")
+        .Produces<SmtpTestResponse>(StatusCodes.Status200OK)
+        .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
+        .ProducesProblem(StatusCodes.Status502BadGateway);
+
+        return app;
+    }
+
+    private static string? FirstNonEmpty(params string?[] candidates)
+        => candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c))?.Trim();
+
+    private static bool IsValidEmail(string value)
+        => !string.IsNullOrWhiteSpace(value) && EmailRegex().IsMatch(value.Trim());
+
+    [GeneratedRegex(
+        "^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex EmailRegex();
+
+    private static bool IsSmtpException(Exception ex) => ex switch
+    {
+        MailKit.Net.Smtp.SmtpCommandException or
+        MailKit.Net.Smtp.SmtpProtocolException or
+        MailKit.Security.AuthenticationException or
+        System.Net.Sockets.SocketException or
+        IOException => true,
+        _ => false,
+    };
+}

--- a/src/Relego.Server/Infrastructure/Database/SchemaBootstrap.cs
+++ b/src/Relego.Server/Infrastructure/Database/SchemaBootstrap.cs
@@ -70,6 +70,16 @@ public sealed class SchemaBootstrap
             delivered_at  TEXT    NULL
         );
 
+        CREATE TABLE IF NOT EXISTS smtp_settings (
+            id           INTEGER PRIMARY KEY CHECK (id = 1),
+            host         TEXT    NOT NULL,
+            port         INTEGER NOT NULL,
+            from_address TEXT    NOT NULL,
+            username     TEXT    NOT NULL DEFAULT '',
+            password     TEXT    NOT NULL DEFAULT '',
+            updated_at   TEXT    NOT NULL
+        );
+
         CREATE UNIQUE INDEX IF NOT EXISTS uq_authors_name
             ON authors(name);
 

--- a/src/Relego.Server/Infrastructure/Smtp/SmtpConfigurationService.cs
+++ b/src/Relego.Server/Infrastructure/Smtp/SmtpConfigurationService.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.Options;
+using Relego.Core.Contracts;
+using Relego.Server.Data;
+
+namespace Relego.Server.Infrastructure.Smtp;
+
+/// <summary>
+/// Resolves the mail server configuration that a send should actually use.
+/// </summary>
+/// <remarks>
+/// Precedence is deliberate and documented in the UI: a row saved from a client wins,
+/// otherwise the values bound from configuration (which include the <c>SMTP_*</c>
+/// environment variables) are used. That makes environment variables a first-boot seed
+/// rather than a permanent override.
+/// </remarks>
+public sealed class SmtpConfigurationService(
+    SmtpSettingsRepository repository,
+    IOptions<SmtpSettings> configured)
+{
+    /// <summary>Returns the settings a send should use, plus where they came from.</summary>
+    public async Task<EffectiveSmtpSettings> GetEffectiveAsync()
+    {
+        var stored = await repository.GetAsync().ConfigureAwait(false);
+
+        if (stored is not null)
+        {
+            return new EffectiveSmtpSettings(
+                new SmtpSettings
+                {
+                    Host = stored.Host,
+                    Port = stored.Port,
+                    FromAddress = stored.FromAddress,
+                    Username = stored.Username,
+                    Password = stored.Password,
+                },
+                SmtpSettingsOrigin.Database,
+                stored.UpdatedAt);
+        }
+
+        var fromConfig = configured.Value;
+        var origin = string.IsNullOrWhiteSpace(fromConfig.FromAddress)
+            ? SmtpSettingsOrigin.Default
+            : SmtpSettingsOrigin.Environment;
+
+        return new EffectiveSmtpSettings(
+            new SmtpSettings
+            {
+                Host = fromConfig.Host,
+                Port = fromConfig.Port,
+                FromAddress = fromConfig.FromAddress,
+                Username = fromConfig.Username,
+                Password = fromConfig.Password,
+            },
+            origin,
+            UpdatedAt: null);
+    }
+
+    /// <summary>
+    /// Applies a partial update on top of the current effective settings and persists it.
+    /// A <see langword="null"/> password keeps the stored one; an empty password clears it.
+    /// </summary>
+    public async Task<EffectiveSmtpSettings> SaveAsync(UpdateSmtpSettingsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var current = await GetEffectiveAsync().ConfigureAwait(false);
+
+        var merged = new SmtpSettings
+        {
+            Host = request.Host?.Trim() ?? current.Settings.Host,
+            Port = request.Port ?? current.Settings.Port,
+            FromAddress = request.FromAddress?.Trim() ?? current.Settings.FromAddress,
+            Username = request.Username?.Trim() ?? current.Settings.Username,
+            Password = request.Password ?? current.Settings.Password,
+        };
+
+        var stored = await repository.UpsertAsync(merged).ConfigureAwait(false);
+        return new EffectiveSmtpSettings(merged, SmtpSettingsOrigin.Database, stored.UpdatedAt);
+    }
+
+    /// <summary>Projects the effective settings into the API shape, without the password.</summary>
+    public static SmtpSettingsResponse ToResponse(EffectiveSmtpSettings effective)
+    {
+        ArgumentNullException.ThrowIfNull(effective);
+
+        return new SmtpSettingsResponse
+        {
+            Host = effective.Settings.Host,
+            Port = effective.Settings.Port,
+            FromAddress = effective.Settings.FromAddress,
+            Username = effective.Settings.Username,
+            PasswordSet = !string.IsNullOrEmpty(effective.Settings.Password),
+            Source = effective.Origin switch
+            {
+                SmtpSettingsOrigin.Database => "database",
+                SmtpSettingsOrigin.Environment => "environment",
+                _ => "default",
+            },
+            UpdatedAt = effective.UpdatedAt,
+        };
+    }
+}
+
+/// <summary>Where the effective mail server configuration came from.</summary>
+public enum SmtpSettingsOrigin
+{
+    /// <summary>Nothing has been configured yet; built-in defaults are in effect.</summary>
+    Default,
+
+    /// <summary>Values come from configuration or the <c>SMTP_*</c> environment variables.</summary>
+    Environment,
+
+    /// <summary>Values were saved by a client and are stored in the database.</summary>
+    Database,
+}
+
+/// <summary>The mail server configuration in effect, and its provenance.</summary>
+public sealed record EffectiveSmtpSettings(
+    SmtpSettings Settings,
+    SmtpSettingsOrigin Origin,
+    DateTimeOffset? UpdatedAt);

--- a/src/Relego.Server/Program.cs
+++ b/src/Relego.Server/Program.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Dapper;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi;
 using Quartz;
 using Serilog;
@@ -13,6 +14,8 @@ using Relego.Server.Infrastructure.Logging;
 using Relego.Server.Infrastructure.Smtp;
 using Relego.Server.Jobs;
 using Relego.Server.Services;
+
+const string WebUiCorsPolicy = "relego-web-ui";
 
 SqlMapper.AddTypeHandler(new DateTimeOffsetTypeHandler());
 
@@ -28,6 +31,27 @@ if (smtpEnvironmentOverrides.Count > 0)
     builder.Configuration.AddInMemoryCollection(smtpEnvironmentOverrides);
 
 builder.Services.Configure<SmtpSettings>(builder.Configuration.GetSection("Smtp"));
+
+// The web UI runs in its own container on a different origin, so it needs an explicit
+// allow-list. RELEGO_CORS_ORIGINS is a comma-separated list of origins; when it is unset
+// no cross-origin request is allowed and only same-origin clients (the CLI) can call the API.
+var corsOrigins = (Environment.GetEnvironmentVariable("RELEGO_CORS_ORIGINS") ?? string.Empty)
+    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    .Distinct(StringComparer.OrdinalIgnoreCase)
+    .ToArray();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(WebUiCorsPolicy, policy =>
+    {
+        if (corsOrigins.Contains("*"))
+            policy.AllowAnyOrigin();
+        else
+            policy.WithOrigins(corsOrigins);
+
+        policy.AllowAnyHeader().AllowAnyMethod();
+    });
+});
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
@@ -71,6 +95,9 @@ builder.Services.AddScoped<WeightRepository>();
 builder.Services.AddScoped<RecapRepository>();
 builder.Services.AddScoped<HighlightRepository>();
 builder.Services.AddScoped<BookRepository>();
+builder.Services.AddScoped<SmtpSettingsRepository>();
+builder.Services.AddScoped<SmtpConfigurationService>();
+builder.Services.AddScoped<UploadImportService>();
 
 builder.Services.AddQuartz(q =>
 {
@@ -121,10 +148,14 @@ if (app.Environment.IsDevelopment())
     });
 }
 
+app.UseCors(WebUiCorsPolicy);
+
 app.MapRecapEndpoints();
 app.MapProbeEndpoints();
 app.MapSyncEndpoints();
+app.MapImportEndpoints();
 app.MapSettingsEndpoints();
+app.MapSmtpSettingsEndpoints();
 app.MapStatusEndpoints();
 app.MapExclusionEndpoints();
 app.MapWeightEndpoints();
@@ -134,6 +165,24 @@ app.MapBookEndpoints();
 var schemaBootstrap = new SchemaBootstrap();
 await schemaBootstrap.ApplyAsync(dbPath);
 await QuartzSchemaInitializer.ApplyAsync(connectionString);
+
+// Seed the mail server configuration from SMTP_* on first boot only. Once a client saves
+// settings the stored row wins, so the environment is a starting point rather than a lock.
+{
+    await using var scope = app.Services.CreateAsyncScope();
+    var smtpRepo = scope.ServiceProvider.GetRequiredService<SmtpSettingsRepository>();
+
+    if (await smtpRepo.GetAsync() is null)
+    {
+        var seed = scope.ServiceProvider.GetRequiredService<IOptions<SmtpSettings>>().Value;
+
+        if (!string.IsNullOrWhiteSpace(seed.FromAddress) && !string.IsNullOrWhiteSpace(seed.Host))
+        {
+            await smtpRepo.UpsertAsync(seed);
+            Log.Information("Seeded mail server configuration from the environment ({Host}:{Port}).", seed.Host, seed.Port);
+        }
+    }
+}
 
 // Schedule recap trigger only on first run (persistent store preserves it across restarts)
 {

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.17.1</Version>
+    <Version>0.18.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Server/Services/MailDeliveryService.cs
+++ b/src/Relego.Server/Services/MailDeliveryService.cs
@@ -1,25 +1,16 @@
-﻿using MailKit.Net.Smtp;
-using Microsoft.Extensions.Options;
+using MailKit.Net.Smtp;
 using MimeKit;
 using Relego.Server.Infrastructure.Smtp;
 
 namespace Relego.Server.Services;
 
-public sealed class MailDeliveryService : IMailDeliveryService
+public sealed class MailDeliveryService(
+    SmtpConfigurationService configuration,
+    ILogger<MailDeliveryService> logger) : IMailDeliveryService
 {
-    private readonly SmtpSettings _settings;
-    private readonly ILogger<MailDeliveryService> _logger;
-
-    public MailDeliveryService(IOptions<SmtpSettings> settings, ILogger<MailDeliveryService> logger)
-    {
-        _settings = settings.Value;
-        _logger = logger;
-    }
-
     public async Task SendRecapAsync(string toAddress, byte[] epubContent, string fileName, CancellationToken cancellationToken = default)
     {
         using var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
         message.To.Add(MailboxAddress.Parse(toAddress));
         message.Subject = "Your Relego Recap";
 
@@ -36,16 +27,14 @@ public sealed class MailDeliveryService : IMailDeliveryService
             FileName = fileName
         };
 
-        var multipart = new Multipart("mixed") { body, attachment };
-        message.Body = multipart;
+        message.Body = new Multipart("mixed") { body, attachment };
 
-        await SendEmailAsync(message!, cancellationToken);
+        await SendEmailAsync(message, cancellationToken);
     }
 
     public async Task SendTestEmailAsync(string toAddress, CancellationToken cancellationToken = default)
     {
         using var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
         message.To.Add(MailboxAddress.Parse(toAddress));
         message.Subject = "Relego - Test Email";
         message.Body = new TextPart("plain")
@@ -53,7 +42,7 @@ public sealed class MailDeliveryService : IMailDeliveryService
             Text = "This is a test email from Relego. If you received this, your SMTP configuration is working correctly."
         };
 
-        await SendEmailAsync(message!, cancellationToken);
+        await SendEmailAsync(message, cancellationToken);
     }
 
     public async Task SendHtmlRecapAsync(
@@ -70,27 +59,31 @@ public sealed class MailDeliveryService : IMailDeliveryService
         };
 
         using var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("Relego", _settings.FromAddress));
         message.To.Add(MailboxAddress.Parse(toAddress));
         message.Subject = subject;
         message.Body = bodyBuilder.ToMessageBody();
 
-        await SendEmailAsync(message!, cancellationToken);
+        await SendEmailAsync(message, cancellationToken);
 
-        _logger.LogInformation("HTML recap sent to {ToAddress}", toAddress);
+        logger.LogInformation("HTML recap sent to {ToAddress}", toAddress);
     }
 
+    // The sender address and credentials are resolved per send so a change saved from a
+    // client takes effect immediately, without restarting the server.
     private async Task SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
     {
+        var settings = (await configuration.GetEffectiveAsync()).Settings;
+        message.From.Add(new MailboxAddress("Relego", settings.FromAddress));
+
         using var client = new SmtpClient();
 
         try
         {
-            await client.ConnectAsync(_settings.Host, _settings.Port, useSsl: true, cancellationToken);
+            await client.ConnectAsync(settings.Host, settings.Port, useSsl: true, cancellationToken);
 
-            if (!string.IsNullOrEmpty(_settings.Username))
+            if (!string.IsNullOrEmpty(settings.Username))
             {
-                await client.AuthenticateAsync(_settings.Username, _settings.Password, cancellationToken);
+                await client.AuthenticateAsync(settings.Username, settings.Password, cancellationToken);
             }
 
             await client.SendAsync(message, cancellationToken);

--- a/src/Relego.Server/Services/UploadImportService.cs
+++ b/src/Relego.Server/Services/UploadImportService.cs
@@ -1,0 +1,192 @@
+using Relego.Core.Contracts;
+using Relego.Core.Parsing;
+using Relego.Core.Sources;
+
+namespace Relego.Server.Services;
+
+/// <summary>
+/// Parses an uploaded highlight export and turns it into a <see cref="SyncRequest"/>.
+/// </summary>
+/// <remarks>
+/// The upload is untrusted: it is written to a temp file, routed by content sniffing
+/// rather than by the client-supplied file name, and the temp file is always deleted.
+/// The parsers themselves are the same ones the CLI uses (<see cref="Relego.Core.Sources"/>),
+/// so an upload and a device import produce identical results.
+/// </remarks>
+public sealed class UploadImportService(ILogger<UploadImportService> logger)
+{
+    /// <summary>Largest upload accepted, in bytes.</summary>
+    public const long MaxUploadBytes = 64L * 1024 * 1024;
+
+    // "SQLite format 3\0" — the 16-byte magic header every SQLite database starts with.
+    private static readonly byte[] SqliteHeader = "SQLite format 3\u0000"u8.ToArray();
+
+    /// <summary>
+    /// Reads <paramref name="content"/> into a temp file, detects its format, and parses it.
+    /// </summary>
+    /// <exception cref="UploadImportException">The upload is empty, too large, or not a supported format.</exception>
+    public async Task<UploadImportResult> ParseAsync(
+        Stream content,
+        string fileName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var tempPath = Path.Combine(
+            Path.GetTempPath(),
+            "relego-upload-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var written = await WriteToTempAsync(content, tempPath, cancellationToken).ConfigureAwait(false);
+
+            if (written == 0)
+            {
+                throw new UploadImportException("The uploaded file is empty.");
+            }
+
+            var descriptor = DetectSource(tempPath);
+            IHighlightSource source = descriptor.Id == "kobo"
+                ? new KoboReaderSource()
+                : new KindleClippingsSource();
+
+            ParseResult parseResult;
+            try
+            {
+                parseResult = descriptor.Id == "kobo"
+                    ? await source.ReadAsync(tempPath, logger, cancellationToken).ConfigureAwait(false)
+                    : await ClippingsParser.ParseAsync(tempPath, logger).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is InvalidDataException or FormatException or IOException)
+            {
+                throw new UploadImportException(
+                    $"'{fileName}' could not be read as a {descriptor.DisplayName} export: {ex.Message}",
+                    ex);
+            }
+
+            return new UploadImportResult(descriptor, parseResult);
+        }
+        finally
+        {
+            TryDelete(tempPath);
+        }
+    }
+
+    /// <summary>Converts a parse result into the shared bulk-import request shape.</summary>
+    public static SyncRequest ToSyncRequest(ParseResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new SyncRequest
+        {
+            Books = [.. result.Books.Select(book => new SyncBookRequest
+            {
+                Title = book.Title,
+                Author = book.Author,
+                Highlights = [.. book.Highlights.Select(highlight => new SyncHighlightRequest
+                {
+                    Text = highlight.Text,
+                    AddedOn = highlight.AddedOn,
+                })],
+            })],
+        };
+    }
+
+    private static async Task<long> WriteToTempAsync(Stream content, string tempPath, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[81920];
+        long written = 0;
+
+        await using var file = new FileStream(
+            tempPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: buffer.Length,
+            useAsync: true);
+
+        int read;
+        while ((read = await content.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            written += read;
+
+            if (written > MaxUploadBytes)
+            {
+                throw new UploadImportException(
+                    $"The uploaded file is larger than {MaxUploadBytes / (1024 * 1024)} MB.");
+            }
+
+            await file.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+        }
+
+        return written;
+    }
+
+    private static SourceDescriptor DetectSource(string path)
+    {
+        if (HasSqliteHeader(path))
+        {
+            return new SourceDescriptor("kobo", "Kobo");
+        }
+
+        if (LooksLikeText(path))
+        {
+            return new SourceDescriptor("kindle", "Kindle");
+        }
+
+        throw new UploadImportException(
+            "Unrecognised file. Upload a Kindle 'My Clippings.txt' or a Kobo 'KoboReader.sqlite'.");
+    }
+
+    private static bool HasSqliteHeader(string path)
+    {
+        Span<byte> header = stackalloc byte[16];
+        using var stream = File.OpenRead(path);
+        var read = stream.ReadAtLeast(header, header.Length, throwOnEndOfStream: false);
+        return read >= header.Length && header.SequenceEqual(SqliteHeader);
+    }
+
+    private static bool LooksLikeText(string path)
+    {
+        Span<byte> sample = stackalloc byte[512];
+        using var stream = File.OpenRead(path);
+        var read = stream.ReadAtLeast(sample, sample.Length, throwOnEndOfStream: false);
+
+        // A NUL byte in the first block means binary; Kindle exports are UTF-8 text.
+        return !sample[..read].Contains((byte)0);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a leftover temp file is harmless.
+        }
+    }
+}
+
+/// <summary>A parsed upload together with the source it was recognised as.</summary>
+public sealed record UploadImportResult(SourceDescriptor Source, ParseResult ParseResult);
+
+/// <summary>An upload that cannot be accepted. The message is safe to show to the user.</summary>
+public sealed class UploadImportException : Exception
+{
+    public UploadImportException(string message) : base(message)
+    {
+    }
+
+    public UploadImportException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public UploadImportException()
+    {
+    }
+}

--- a/src/Relego.Tests/Api/BookListEndpointTests.cs
+++ b/src/Relego.Tests/Api/BookListEndpointTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Net.Http.Json;
+using Relego.Core.Contracts;
+
+namespace Relego.Tests.Api;
+
+public sealed class BookListEndpointTests : IDisposable
+{
+    private readonly RelegoTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public BookListEndpointTests()
+    {
+        _factory = new RelegoTestApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task GetBooks_EmptyLibrary_ReturnsEmptyPage()
+    {
+        var response = await _client.GetFromJsonAsync<BooksResponse>("/books");
+
+        Assert.NotNull(response);
+        Assert.Equal(0, response.Total);
+        Assert.Empty(response.Items);
+    }
+
+    [Fact]
+    public async Task GetBooks_ReturnsTitlesAuthorsAndHighlightCounts()
+    {
+        await SeedLibraryAsync();
+
+        var response = await _client.GetFromJsonAsync<BooksResponse>("/books");
+
+        Assert.NotNull(response);
+        Assert.Equal(3, response.Total);
+
+        var alpha = response.Items.Single(b => b.Title == "Alpha");
+        Assert.Equal("Author Alpha", alpha.AuthorName);
+        Assert.Equal(2, alpha.HighlightCount);
+        Assert.False(alpha.Excluded);
+        Assert.False(alpha.AuthorExcluded);
+    }
+
+    [Fact]
+    public async Task GetBooks_SortsByTitleCaseInsensitively()
+    {
+        await SeedLibraryAsync();
+
+        var response = await _client.GetFromJsonAsync<BooksResponse>("/books");
+
+        Assert.NotNull(response);
+        Assert.Equal(["Alpha", "beta", "Gamma"], response.Items.Select(b => b.Title));
+    }
+
+    [Fact]
+    public async Task GetBooks_QueryMatchesTitleOrAuthor()
+    {
+        await SeedLibraryAsync();
+
+        var byTitle = await _client.GetFromJsonAsync<BooksResponse>("/books?q=gam");
+        var byAuthor = await _client.GetFromJsonAsync<BooksResponse>("/books?q=Author%20Alpha");
+
+        Assert.NotNull(byTitle);
+        Assert.Equal("Gamma", Assert.Single(byTitle.Items).Title);
+
+        Assert.NotNull(byAuthor);
+        Assert.Equal(2, byAuthor.Total);
+    }
+
+    [Fact]
+    public async Task GetBooks_ReflectsBookAndAuthorExclusions()
+    {
+        await SeedLibraryAsync();
+
+        var books = await _client.GetFromJsonAsync<BooksResponse>("/books");
+        Assert.NotNull(books);
+        var alpha = books.Items.Single(b => b.Title == "Alpha");
+
+        (await _client.PostAsync($"/books/{alpha.Id}/exclusions", null)).EnsureSuccessStatusCode();
+        (await _client.PostAsync($"/authors/{alpha.AuthorId}/exclusions", null)).EnsureSuccessStatusCode();
+
+        var after = await _client.GetFromJsonAsync<BooksResponse>("/books");
+        Assert.NotNull(after);
+
+        var updated = after.Items.Single(b => b.Title == "Alpha");
+        Assert.True(updated.Excluded);
+        Assert.True(updated.AuthorExcluded);
+
+        // "Gamma" shares "Author Alpha", so it inherits the author exclusion but not the book one.
+        var gamma = after.Items.Single(b => b.Title == "Gamma");
+        Assert.False(gamma.Excluded);
+        Assert.True(gamma.AuthorExcluded);
+    }
+
+    [Fact]
+    public async Task GetBooks_Paginates()
+    {
+        await SeedLibraryAsync();
+
+        var page2 = await _client.GetFromJsonAsync<BooksResponse>("/books?page=2&pageSize=2");
+
+        Assert.NotNull(page2);
+        Assert.Equal(3, page2.Total);
+        Assert.Equal(2, page2.Page);
+        Assert.Equal("Gamma", Assert.Single(page2.Items).Title);
+    }
+
+    [Theory]
+    [InlineData("/books?page=0")]
+    [InlineData("/books?pageSize=0")]
+    [InlineData("/books?pageSize=501")]
+    public async Task GetBooks_InvalidPaging_Returns422(string url)
+    {
+        var response = await _client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    private async Task SeedLibraryAsync()
+    {
+        var response = await _client.PostAsJsonAsync("/highlights/import", new SyncRequest
+        {
+            Books =
+            [
+                new SyncBookRequest
+                {
+                    Title = "Alpha",
+                    Author = "Author Alpha",
+                    Highlights =
+                    [
+                        new SyncHighlightRequest { Text = "Alpha highlight 1" },
+                        new SyncHighlightRequest { Text = "Alpha highlight 2" },
+                    ],
+                },
+                new SyncBookRequest
+                {
+                    Title = "Gamma",
+                    Author = "Author Alpha",
+                    Highlights = [new SyncHighlightRequest { Text = "Gamma highlight 1" }],
+                },
+                new SyncBookRequest
+                {
+                    Title = "beta",
+                    Author = "Author Beta",
+                    Highlights = [new SyncHighlightRequest { Text = "Beta highlight 1" }],
+                },
+            ],
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Relego.Tests/Api/ImportEndpointTests.cs
+++ b/src/Relego.Tests/Api/ImportEndpointTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using Relego.Core.Contracts;
+using Relego.Tests.Sources.Support;
+
+namespace Relego.Tests.Api;
+
+public sealed class ImportEndpointTests : IDisposable
+{
+    private readonly RelegoTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public ImportEndpointTests()
+    {
+        _factory = new RelegoTestApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task PostImports_KindleClippings_ParsesAndStores()
+    {
+        var response = await UploadAsync(
+            File.ReadAllBytes(TestFixtures.KindleFixturePath()),
+            "My Clippings.txt");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<ImportResponse>();
+        Assert.NotNull(result);
+        Assert.Equal("kindle", result.Source);
+        Assert.Equal("My Clippings.txt", result.FileName);
+        Assert.True(result.BooksParsed > 0);
+        Assert.True(result.HighlightsParsed > 0);
+        Assert.Equal(result.HighlightsParsed, result.NewHighlights);
+        Assert.Equal(result.BooksParsed, result.NewBooks);
+    }
+
+    [Fact]
+    public async Task PostImports_KoboDatabase_IsDetectedByContentNotFileName()
+    {
+        // The file name is deliberately wrong: format detection reads the SQLite header.
+        var response = await UploadAsync(
+            File.ReadAllBytes(TestFixtures.KoboFixturePath()),
+            "renamed-export.dat");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<ImportResponse>();
+        Assert.NotNull(result);
+        Assert.Equal("kobo", result.Source);
+        Assert.True(result.HighlightsParsed > 0);
+    }
+
+    [Fact]
+    public async Task PostImports_SameFileTwice_ReportsDuplicatesOnSecondRun()
+    {
+        var bytes = File.ReadAllBytes(TestFixtures.KindleFixturePath());
+
+        var first = await (await UploadAsync(bytes, "My Clippings.txt")).Content.ReadFromJsonAsync<ImportResponse>();
+        var second = await (await UploadAsync(bytes, "My Clippings.txt")).Content.ReadFromJsonAsync<ImportResponse>();
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(0, second.NewHighlights);
+        Assert.Equal(first.NewHighlights, second.DuplicateHighlights);
+        Assert.Equal(0, second.NewBooks);
+    }
+
+    [Fact]
+    public async Task PostImports_BinaryFileThatIsNotSqlite_Returns422()
+    {
+        var response = await UploadAsync([0x00, 0x01, 0x02, 0x03, 0x00], "photo.png");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+
+        var problem = await response.Content.ReadAsStringAsync();
+        Assert.Contains("My Clippings.txt", problem, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PostImports_EmptyFile_Returns422()
+    {
+        var response = await UploadAsync([], "My Clippings.txt");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostImports_TextWithNoHighlights_Returns200WithZeroCounts()
+    {
+        var response = await UploadAsync(
+            Encoding.UTF8.GetBytes("this file has no clipping separators at all"),
+            "notes.txt");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<ImportResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(0, result.BooksParsed);
+        Assert.Equal(0, result.NewHighlights);
+    }
+
+    [Fact]
+    public async Task PostImports_NoFileAttached_Returns422()
+    {
+        using var content = new MultipartFormDataContent();
+        var response = await _client.PostAsync("/imports", content);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> UploadAsync(byte[] bytes, string fileName)
+    {
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new ByteArrayContent(bytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "file", fileName);
+
+        return await _client.PostAsync("/imports", content);
+    }
+}
+

--- a/src/Relego.Tests/Api/RecapHistoryEndpointTests.cs
+++ b/src/Relego.Tests/Api/RecapHistoryEndpointTests.cs
@@ -1,0 +1,121 @@
+using System.Data;
+using System.Net;
+using System.Net.Http.Json;
+using Dapper;
+using Microsoft.Extensions.DependencyInjection;
+using Relego.Core.Contracts;
+
+namespace Relego.Tests.Api;
+
+public sealed class RecapHistoryEndpointTests : IDisposable
+{
+    private readonly RelegoTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public RecapHistoryEndpointTests()
+    {
+        _factory = new RelegoTestApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task GetRecaps_NoDeliveries_ReturnsEmptyList()
+    {
+        var response = await _client.GetFromJsonAsync<RecapHistoryResponse>("/recaps");
+
+        Assert.NotNull(response);
+        Assert.Empty(response.Items);
+    }
+
+    [Fact]
+    public async Task GetRecaps_ReturnsNewestFirstWithStatusAndError()
+    {
+        var userId = await EnsureUserAsync();
+
+        await InsertJobAsync(userId, "2026-01-01T18:00:00.0000000Z", "delivered", 1, null, "2026-01-01T18:00:04.0000000Z");
+        await InsertJobAsync(userId, "2026-01-08T18:00:00.0000000Z", "failed", 3, "Connection refused", null);
+
+        var response = await _client.GetFromJsonAsync<RecapHistoryResponse>("/recaps");
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Items.Count);
+
+        var newest = response.Items[0];
+        Assert.Equal("failed", newest.Status);
+        Assert.Equal(3, newest.AttemptCount);
+        Assert.Equal("Connection refused", newest.ErrorMessage);
+        Assert.Null(newest.DeliveredAt);
+
+        var oldest = response.Items[1];
+        Assert.Equal("delivered", oldest.Status);
+        Assert.NotNull(oldest.DeliveredAt);
+    }
+
+    [Fact]
+    public async Task GetRecaps_RespectsLimit()
+    {
+        var userId = await EnsureUserAsync();
+
+        for (var day = 1; day <= 5; day++)
+            await InsertJobAsync(userId, $"2026-02-0{day}T18:00:00.0000000Z", "delivered", 1, null, null);
+
+        var response = await _client.GetFromJsonAsync<RecapHistoryResponse>("/recaps?limit=2");
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Items.Count);
+    }
+
+    [Theory]
+    [InlineData("/recaps?limit=0")]
+    [InlineData("/recaps?limit=101")]
+    public async Task GetRecaps_InvalidLimit_Returns422(string url)
+    {
+        var response = await _client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    private async Task<int> EnsureUserAsync()
+    {
+        // /status creates the implicit user as a side effect.
+        (await _client.GetAsync("/status")).EnsureSuccessStatusCode();
+
+        using var scope = _factory.Services.CreateScope();
+        var connection = scope.ServiceProvider.GetRequiredService<IDbConnection>();
+        return await connection.QuerySingleAsync<int>("SELECT id FROM users LIMIT 1");
+    }
+
+    private async Task InsertJobAsync(
+        int userId,
+        string scheduledFor,
+        string status,
+        int attemptCount,
+        string? errorMessage,
+        string? deliveredAt)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var connection = scope.ServiceProvider.GetRequiredService<IDbConnection>();
+
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO recap_jobs (user_id, scheduled_for, status, attempt_count, error_message, created_at, delivered_at)
+            VALUES (@UserId, @ScheduledFor, @Status, @AttemptCount, @ErrorMessage, @CreatedAt, @DeliveredAt)
+            """,
+            new
+            {
+                UserId = userId,
+                ScheduledFor = scheduledFor,
+                Status = status,
+                AttemptCount = attemptCount,
+                ErrorMessage = errorMessage,
+                CreatedAt = scheduledFor,
+                DeliveredAt = deliveredAt,
+            });
+    }
+}

--- a/src/Relego.Tests/Api/SmtpSettingsEndpointTests.cs
+++ b/src/Relego.Tests/Api/SmtpSettingsEndpointTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Net.Http.Json;
+using Relego.Core.Contracts;
+
+namespace Relego.Tests.Api;
+
+public sealed class SmtpSettingsEndpointTests : IDisposable
+{
+    private readonly RelegoTestApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public SmtpSettingsEndpointTests()
+    {
+        _factory = new RelegoTestApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [Fact]
+    public async Task GetSmtp_BeforeAnySave_ReportsNonDatabaseSourceAndNoPassword()
+    {
+        var response = await _client.GetFromJsonAsync<SmtpSettingsResponse>("/settings/smtp");
+
+        Assert.NotNull(response);
+        Assert.NotEqual("database", response.Source);
+        Assert.False(response.PasswordSet);
+        Assert.Null(response.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task PutSmtp_SavesValuesAndSwitchesSourceToDatabase()
+    {
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            Host = "smtp.example.com",
+            Port = 465,
+            FromAddress = "relego@example.com",
+            Username = "relego",
+            Password = "hunter2",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var saved = await response.Content.ReadFromJsonAsync<SmtpSettingsResponse>();
+        Assert.NotNull(saved);
+        Assert.Equal("smtp.example.com", saved.Host);
+        Assert.Equal(465, saved.Port);
+        Assert.Equal("relego@example.com", saved.FromAddress);
+        Assert.Equal("database", saved.Source);
+        Assert.True(saved.PasswordSet);
+        Assert.NotNull(saved.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task GetSmtp_NeverReturnsThePassword()
+    {
+        await SaveValidSettingsAsync();
+
+        var raw = await _client.GetStringAsync("/settings/smtp");
+
+        Assert.DoesNotContain("hunter2", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"password\"", raw, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PutSmtp_OmittedPassword_KeepsTheStoredOne()
+    {
+        await SaveValidSettingsAsync();
+
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            Host = "smtp2.example.com",
+        });
+
+        var saved = await response.Content.ReadFromJsonAsync<SmtpSettingsResponse>();
+        Assert.NotNull(saved);
+        Assert.Equal("smtp2.example.com", saved.Host);
+        Assert.Equal("relego@example.com", saved.FromAddress);
+        Assert.True(saved.PasswordSet);
+    }
+
+    [Fact]
+    public async Task PutSmtp_EmptyPassword_ClearsIt()
+    {
+        await SaveValidSettingsAsync();
+
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            Password = string.Empty,
+        });
+
+        var saved = await response.Content.ReadFromJsonAsync<SmtpSettingsResponse>();
+        Assert.NotNull(saved);
+        Assert.False(saved.PasswordSet);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(70000)]
+    public async Task PutSmtp_PortOutOfRange_Returns422(int port)
+    {
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            Port = port,
+        });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutSmtp_InvalidFromAddress_Returns422()
+    {
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            FromAddress = "not-an-email",
+        });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutSmtp_EmptyHost_Returns422()
+    {
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            Host = "   ",
+        });
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostSmtpTest_WithoutConfiguredHost_Returns422()
+    {
+        // The test environment configures no SMTP host, so the guard must fire before any send.
+        var response = await _client.PostAsJsonAsync("/settings/smtp/test", new SmtpTestRequest());
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    private async Task SaveValidSettingsAsync()
+    {
+        var response = await _client.PutAsJsonAsync("/settings/smtp", new UpdateSmtpSettingsRequest
+        {
+            Host = "smtp.example.com",
+            Port = 465,
+            FromAddress = "relego@example.com",
+            Username = "relego",
+            Password = "hunter2",
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+}


### PR DESCRIPTION
New server surface for the web UI:

- `POST /imports` — parses an uploaded `My Clippings.txt` or `KoboReader.sqlite` server-side, routing by content sniffing, with a 64 MB cap
- `GET /books` — library list with title, author, highlight count, weight and excluded state
- `GET /recaps` — recent delivery attempts
- `GET/PUT /settings/smtp` and `POST /settings/smtp/test` — database-backed SMTP; `SMTP_*` env vars seed on first boot only; password is write-only
- CORS allow-list via `RELEGO_CORS_ORIGINS`

Closes #407
Closes #408

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
