### PR TITLE
Mark the TUI as deprecated in the docs and in its info box

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
   <img src="docs/assets/relego-logo-banner.png" alt="relego logo" width="720">
 </p>
 
@@ -257,7 +257,7 @@ If you've been using the demo mode, open `http://localhost:5000` to view the cap
 
 |                   Command                              |              Description                                                     |
 |--------------------------------------------------------|------------------------------------------------------------------------------|
-| `relego`                                               | Open interactive TUI                                                         |
+| `relego` (**deprecated**)                              | Open interactive TUI                                                         |
 | `relego import [path]`                                 | Import highlights from a detected Kindle or Kobo source                      |
 | `relego status`                                        | Show server status and next recap                                            |
 | `relego config show`                                   | Show all current server settings                                             |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Architecture — Relego
+﻿# Architecture — Relego
 
 **Version:** 0.2 — Draft
 **Date:** 2026-06-02
@@ -81,6 +81,8 @@ All sources are responsible for transforming raw source data into structured dat
   - Shared aggregation: `HighlightAggregator` performs deduplication and grouping for every source so Kindle and Kobo produce identical downstream shapes
 
 #### TUI subsystem (`Relego.Cli/Tui/`)
+
+> **Deprecated:** The TUI is deprecated in favour of the `relego.web` project. It will be removed in a future release.
 
 When invoked with no arguments in an interactive terminal (`relego`), the client enters **TUI mode** — a full-screen terminal UI powered by [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) (v2).
 

--- a/docs/DX.md
+++ b/docs/DX.md
@@ -1,4 +1,4 @@
-# Developer Experience Design — Relego
+﻿# Developer Experience Design — Relego
 
 **Version:** 1.0
 **Date:** 2026-08-07
@@ -285,7 +285,7 @@ Errors are actionable — they tell the user exactly what to do.
 
 |                   Command                              |              Description                                                     |
 |--------------------------------------------------------|------------------------------------------------------------------------------|
-| `relego`                                               | Open interactive TUI                                                         |
+| `relego` (**deprecated**)                              | Open interactive TUI                                                         |
 | `relego import [path]`                                 | Import highlights from a detected Kindle or Kobo source                      |
 | `relego status`                                        | Show server status and next recap                                            |
 | `relego config show`                                   | Show all current server settings                                             |

--- a/src/PackageVersions.props
+++ b/src/PackageVersions.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RelegoCoreVersion>0.8.0</RelegoCoreVersion>
-    <RelegoCliVersion>0.15.4</RelegoCliVersion>
+    <RelegoCliVersion>0.15.5</RelegoCliVersion>
     <RelegoServerVersion>0.18.0</RelegoServerVersion>
     <PollyVersion>8.6.6</PollyVersion>
     <MicrosoftDataSqliteVersion>10.0.5</MicrosoftDataSqliteVersion>

--- a/src/Relego.Cli/Tui/StatusChrome.cs
+++ b/src/Relego.Cli/Tui/StatusChrome.cs
@@ -19,11 +19,14 @@ public sealed class StatusChrome(string serverUrl, string version)
 
     public static Color Background => TuiTheme.Palette.Background;
 
+    internal const string DeprecationText = "⚠ TUI Deprecated — use the web UI";
+
     public const int LogoHeight = 7; // 6 logo + separator
 
     private Label? _connectionLabel;
     private Label? _nextRecapLabel;
     private Label? _warningLabel;
+    private Label _deprecationLabel = null!;
 
     public bool IsConnected { get; private set; }
     public bool KindleEmailConfigured { get; private set; }
@@ -77,7 +80,7 @@ public sealed class StatusChrome(string serverUrl, string version)
             X = Pos.AnchorEnd(frameContentWidth),
             Y = 0,
             Width = frameContentWidth,
-            Height = 6,
+            Height = 7,
             BorderStyle = LineStyle.Rounded
         };
         infoFrame.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.Border, bg)));
@@ -119,7 +122,17 @@ public sealed class StatusChrome(string serverUrl, string version)
         };
         versionLabel.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.TextMuted, bg)));
 
-        infoFrame.Add(_connectionLabel, _nextRecapLabel, _warningLabel, versionLabel);
+        _deprecationLabel = new Label
+        {
+            Text = DeprecationText,
+            X = 1,
+            Y = 4,
+            Width = Dim.Fill(1),
+            TextAlignment = Alignment.End
+        };
+        _deprecationLabel.SetScheme(new Scheme(new Terminal.Gui.Drawing.Attribute(palette.Warning, bg)));
+
+        infoFrame.Add(_connectionLabel, _nextRecapLabel, _warningLabel, versionLabel, _deprecationLabel);
         container.Add(infoFrame);
 
         return container;

--- a/src/Relego.Tests/Tui/BookListScreenTests.cs
+++ b/src/Relego.Tests/Tui/BookListScreenTests.cs
@@ -491,6 +491,13 @@ public sealed class BookListScreenTests : IDisposable
         mockHttp.VerifyNoOutstandingExpectation();
     }
 
+    [Fact]
+    public void StatusChrome_DeprecationText_ContainsDeprecatedAndWebUI()
+    {
+        Assert.Contains("Deprecated", StatusChrome.DeprecationText);
+        Assert.Contains("web UI", StatusChrome.DeprecationText);
+    }
+
     private async Task<BookListScreen> CreateScreenAsync(int total = 3, string? itemsJson = null)
     {
         return await CreateScreenAsync(_mockHttp, total, itemsJson).ConfigureAwait(false);


### PR DESCRIPTION
Mark the TUI as deprecated before its code is removed in #425.

## Changes
- `StatusChrome.cs`: adds a ⚠ deprecation label (styled in warning colour) to the info frame on every TUI screen
- `BookListScreenTests.cs`: new test asserting the deprecation constant text is present  
- `docs/ARCHITECTURE.md`, `docs/BRAND_COLORS.md`, `docs/DX.md`, `README.md`: deprecation callout added near each TUI mention

Closes #403
