### PR TITLE
Centralize component release versions

### DIFF
--- a/.github/actions/discover-versioned-components/action.yaml
+++ b/.github/actions/discover-versioned-components/action.yaml
@@ -1,9 +1,9 @@
 name: "Discover Versioned Components"
-description: "Discover versioned application components from csproj files under src."
+description: "Discover release components."
 
 outputs:
   components_json:
-    description: "JSON array of discovered components with name, projectPath, and csprojPath."
+    description: "JSON array of release components with their project paths and version property locations."
     value: ${{ steps.discover.outputs.components_json }}
 
 runs:
@@ -14,40 +14,48 @@ runs:
       run: |
         set -euo pipefail
 
-        mapfile -t csproj_files < <(find src -mindepth 2 -maxdepth 2 -name '*.csproj' -print | sort)
-
-        if [ ${#csproj_files[@]} -eq 0 ]; then
-          echo 'components_json=[]' >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
         components_json='[]'
+        version_file='src/PackageVersions.props'
 
-        for csproj_path in "${csproj_files[@]}"; do
-          version=$(grep -oPm1 '(?<=<Version>)[^<]+' "$csproj_path" || true)
+        for component in \
+          'core|src/Relego.Core|src/Relego.Core/Relego.Core.csproj|RelegoCoreVersion|src/Relego.Core' \
+          'cli|src/Relego.Cli|src/Relego.Cli/Relego.Cli.csproj|RelegoCliVersion|src/Relego.Cli' \
+          'server|src/Relego.Server|src/Relego.Server/Relego.Server.csproj|RelegoServerVersion|src/Relego.Server,src/relego.web'; do
+          IFS='|' read -r component_name project_path csproj_path version_property changed_paths <<< "$component"
+
+          if [ ! -f "$csproj_path" ]; then
+            echo "Release project not found: $csproj_path" >&2
+            exit 1
+          fi
+
+          if [ ! -f "$version_file" ]; then
+            echo "Centralized version file not found: $version_file" >&2
+            exit 1
+          fi
+
+          version=$(sed -nE "s|.*<${version_property}>([^<]+)</${version_property}>.*|\1|p" "$version_file" | head -1)
           if [ -z "$version" ]; then
-            echo "Skipping non-versioned project: $csproj_path"
-            continue
+            echo "Version property ${version_property} not found in ${version_file}" >&2
+            exit 1
           fi
-
-          project_path=$(dirname "$csproj_path")
-          project_dir=$(basename "$project_path")
-          csproj_name=$(basename "$csproj_path" .csproj)
-
-          raw_name="$project_dir"
-          raw_name="${raw_name#*.}"
-          if [ "$raw_name" = "$project_dir" ]; then
-            raw_name="$csproj_name"
-            raw_name="${raw_name#*.}"
-          fi
-
-          component_name=$(printf '%s' "$raw_name" | tr '[:upper:]' '[:lower:]')
 
           components_json=$(jq \
             --arg name "$component_name" \
             --arg projectPath "$project_path" \
             --arg csprojPath "$csproj_path" \
-            '. + [{ name: $name, projectPath: $projectPath, csprojPath: $csprojPath }]' \
+            --arg versionFile "$version_file" \
+            --arg versionProperty "$version_property" \
+            --arg version "$version" \
+            --argjson changedPaths "$(printf '%s' "$changed_paths" | jq -R 'split(",")')" \
+            '. + [{
+              name: $name,
+              projectPath: $projectPath,
+              csprojPath: $csprojPath,
+              versionFile: $versionFile,
+              versionProperty: $versionProperty,
+              version: $version,
+              changedPaths: $changedPaths
+            }]' \
             <<< "$components_json")
         done
 

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -39,14 +39,15 @@ jobs:
 
           while IFS= read -r component; do
             NAME=$(echo "$component" | jq -r '.name')
-            CSPROJ=$(echo "$component" | jq -r '.csprojPath')
+            VERSION_FILE=$(echo "$component" | jq -r '.versionFile')
+            VERSION_PROPERTY=$(echo "$component" | jq -r '.versionProperty')
 
             [ -z "$NAME" ] && continue
-            [ -z "$CSPROJ" ] || [ "$CSPROJ" = "null" ] && { echo "⚠️  $NAME: .csproj not configured, skipping"; continue; }
-            [ ! -f "$CSPROJ" ] && { echo "⚠️  $NAME: $CSPROJ not found, skipping"; continue; }
+            [ -z "$VERSION_FILE" ] || [ "$VERSION_FILE" = "null" ] && { echo "⚠️  $NAME: version file not configured, skipping"; continue; }
+            [ ! -f "$VERSION_FILE" ] && { echo "⚠️  $NAME: $VERSION_FILE not found, skipping"; continue; }
 
-            VERSION=$(grep -oP '(?<=<Version>)[^<]+' "$CSPROJ" || echo "")
-            [ -z "$VERSION" ] && { echo "⚠️  $NAME: <Version> not found, skipping"; continue; }
+            VERSION=$(sed -nE "s|.*<${VERSION_PROPERTY}>([^<]+)</${VERSION_PROPERTY}>.*|\1|p" "$VERSION_FILE" | head -1)
+            [ -z "$VERSION" ] && { echo "⚠️  $NAME: ${VERSION_PROPERTY} not found, skipping"; continue; }
 
             TAG="${NAME}/v${VERSION}"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,9 +200,9 @@ jobs:
           VERSION="${{ needs.metadata.outputs.version }}"
           TAG="${{ needs.metadata.outputs.tag }}"
 
-          COMP_PATH=$(printf '%s' "$COMPONENTS_JSON" | jq -r --arg name "$COMPONENT" '.[] | select(.name == $name) | .projectPath')
+          mapfile -t CHANGE_PATHS < <(printf '%s' "$COMPONENTS_JSON" | jq -r --arg name "$COMPONENT" '.[] | select(.name == $name) | .changedPaths[]')
 
-          if [ -z "$COMP_PATH" ] || [ "$COMP_PATH" = "null" ]; then
+          if [ "${#CHANGE_PATHS[@]}" -eq 0 ]; then
             echo "Unsupported component: $COMPONENT" >&2
             exit 1
           fi
@@ -219,7 +219,7 @@ jobs:
           if [ -z "$RELEASE_DATE" ]; then
             RELEASE_DATE=$(git log -1 --format=%cs "$TAG")
           fi
-          COMMITS=$(git log --reverse --format='%H' "$RANGE" -- "$COMP_PATH")
+          COMMITS=$(git log --reverse --format='%H' "$RANGE" -- "${CHANGE_PATHS[@]}")
           BODY=""
 
           while IFS= read -r sha; do

--- a/.github/workflows/version-bump-check.yaml
+++ b/.github/workflows/version-bump-check.yaml
@@ -55,27 +55,36 @@ jobs:
 
           while IFS= read -r component; do
             NAME=$(echo "$component" | jq -r '.name')
-            COMP_PATH=$(echo "$component" | jq -r '.projectPath')
-            CSPROJ=$(echo "$component" | jq -r '.csprojPath')
+            VERSION_FILE=$(echo "$component" | jq -r '.versionFile')
+            VERSION_PROPERTY=$(echo "$component" | jq -r '.versionProperty')
 
             [ -z "$NAME" ] && continue
 
-            if ! echo "$CHANGED" | grep -q "^${COMP_PATH}/"; then
+            MODIFIED=0
+            while IFS= read -r changed_path; do
+              if echo "$CHANGED" | grep -q "^${changed_path}/"; then
+                MODIFIED=1
+                break
+              fi
+            done < <(echo "$component" | jq -r '.changedPaths[]')
+
+            if [ "$MODIFIED" -eq 0 ]; then
               append_report_row "| \`${NAME}\` | - | - | ⏭️ Not modified |"
               continue
             fi
 
-            if [ -z "$CSPROJ" ] || [ "$CSPROJ" = "null" ] || [ ! -f "$CSPROJ" ]; then
-              append_report_row "| \`${NAME}\` | - | - | ❓ ${CSPROJ} not found |"
+            if [ -z "$VERSION_FILE" ] || [ "$VERSION_FILE" = "null" ] || [ ! -f "$VERSION_FILE" ]; then
+              append_report_row "| \`${NAME}\` | - | - | ❓ ${VERSION_FILE} not found |"
               FAILED=1; continue
             fi
 
-            PR_VERSION=$(grep -oP '(?<=<Version>)[^<]+' "$CSPROJ" || echo "")
-            MAIN_VERSION=$(git show origin/main:"$CSPROJ" 2>/dev/null \
-              | grep -oP '(?<=<Version>)[^<]+' || echo "0.0.0")
+            PR_VERSION=$(sed -nE "s|.*<${VERSION_PROPERTY}>([^<]+)</${VERSION_PROPERTY}>.*|\1|p" "$VERSION_FILE" | head -1)
+            MAIN_VERSION=$(git show origin/main:"$VERSION_FILE" 2>/dev/null \
+              | sed -nE "s|.*<${VERSION_PROPERTY}>([^<]+)</${VERSION_PROPERTY}>.*|\1|p" \
+              | head -1)
 
             if [ -z "$PR_VERSION" ]; then
-              append_report_row "| \`${NAME}\` | \`${MAIN_VERSION}\` | - | ❌ \`<Version>\` tag missing |"
+              append_report_row "| \`${NAME}\` | \`${MAIN_VERSION}\` | - | ❌ \`${VERSION_PROPERTY}\` missing |"
               FAILED=1; continue
             fi
 
@@ -83,7 +92,7 @@ jobs:
 
             if [ "$MAIN_VERSION" = "$PR_VERSION" ]; then
               append_report_row "| \`${NAME}\` | \`${MAIN_VERSION}\` | \`${PR_VERSION}\` | ❌ Not bumped |"
-              MISSING_BUMPS="${MISSING_BUMPS}# bump ${NAME} before opening PR — edit <Version> in ${CSPROJ}\n"
+              MISSING_BUMPS="${MISSING_BUMPS}# bump ${NAME} before opening PR — edit ${VERSION_PROPERTY} in ${VERSION_FILE}\n"
               FAILED=1
             elif [ "$LOWER" = "$PR_VERSION" ]; then
               append_report_row "| \`${NAME}\` | \`${MAIN_VERSION}\` | \`${PR_VERSION}\` | ❌ Version regressed |"
@@ -98,7 +107,7 @@ jobs:
             HINT=""
           else
             SUMMARY="❌ **One or more modified components are missing a version bump.**"
-            HINT="\n\nFor each failing component, edit the \`<Version>\` tag in the relevant \`.csproj\` file to a higher semver value, then push again:\n\`\`\`bash\n${MISSING_BUMPS}\`\`\`"
+            HINT="\n\nFor each failing component, increase its centralized version property in \`src/PackageVersions.props\`, then push again:\n\`\`\`bash\n${MISSING_BUMPS}\`\`\`"
           fi
 
           BODY="### 🔖 Version Bump Check\n\n${SUMMARY}${HINT}\n\n| Component | Version on \`main\` | Version in PR | Status |\n|---|---|---|---|\n${REPORT}\n\n---\n*Updated automatically on every push to this PR.*"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -8,27 +8,29 @@ Tag creation and GitHub Releases are fully automated for CLI and server projects
 
 ### 1. In your feature branch, bump the version in each modified component
 
-Open the `.csproj` of every component you changed and update `<Version>`:
+Update the centralized version property for every modified component in `src/PackageVersions.props`:
 
 ```xml
-<Version>1.3.0</Version>
+<RelegoCliVersion>1.3.0</RelegoCliVersion>
 ```
 
 Relevant files:
 
-| Component | File                                               |
-|-----------|----------------------------------------------------|
-| `core`    | `src/Relego.Core/Relego.Core.csproj`     |
-| `cli`     | `src/Relego.Cli/Relego.Cli.csproj`       |
-| `server`  | `src/Relego.Server/Relego.Server.csproj` |
+| Component | Central property      |
+|-----------|-----------------------|
+| `core`    | `RelegoCoreVersion`   |
+| `cli`     | `RelegoCliVersion`    |
+| `server`  | `RelegoServerVersion` |
 
 Decide the bump level yourself (patch / minor / major) — no commit message format is required.
 Bump the version whenever you modify a component, even if the change is not user-facing (e.g. refactor, bug fix, internal API change) — this ensures accurate version tracking and release notes.
 
+The embedded web UI (`src/relego.web/`) ships with Server, so web UI changes require a `RelegoServerVersion` bump. Its private npm metadata remains fixed at version `1.0.0` and is not independently released or tagged.
+
 ### 2. Commit and open a PR
 
 ```bash
-git add src/Relego.Cli/Relego.Cli.csproj
+git add src/PackageVersions.props
 git commit -m "your commit message"
 git push origin feature/your-branch
 ```
@@ -39,7 +41,7 @@ The CI will check that every modified component has a bumped version and post a 
 
 After the merge:
 
-- `post-merge.yml` discovers projects under `src/` that declare an explicit `<Version>` in their `.csproj` and creates a git tag for each component whose bumped version does not yet have a matching tag (format: `<component>/v<version>`)
+- `post-merge.yml` resolves the central version properties for `core`, `cli`, and `server` and creates a git tag for each component whose bumped version does not yet have a matching tag (format: `<component>/v<version>`)
 - The tag push triggers `release.yml`, which publishes one GitHub Release per component tag using the squash-merge commit titles since the previous component tag, with a link to the originating PR when available
 - The published GitHub Release triggers `deploy-cli.yml` (Docker image) and `deploy-server.yml` (Docker image)
 
@@ -57,10 +59,10 @@ server/v2.0.0
 
 ## Adding a new component
 
-1. Create `src/<Name>/<Name>.csproj` with `<Version>0.1.0</Version>`
+1. Add a `<Name>Version` property to `src/PackageVersions.props` and reference it from `src/<Name>/<Name>.csproj` with `<Version>$(<Name>Version)</Version>`
 2. Add `dotnet sln src/Relego.slnx add src/<Name>/<Name>.csproj`
-3. Ensure the project folder and `.csproj` file use the `Relego.<Component>` naming pattern so the workflow discovery action derives the correct component tag name
-4. Ensure the `.csproj` declares an explicit `<Version>` value; projects without `<Version>` are ignored by the release automation
+3. Ensure the project folder and `.csproj` file use the `Relego.<Component>` naming pattern so the release metadata remains consistent
+4. Add the component to `.github/actions/discover-versioned-components/action.yaml`, including its centralized version property; only listed components are released or tagged
 5. If the component should be publish a GitHub Release page, update triggers in `.github/workflows/release.yaml` to include it
 6. Create the deployment workflow for the specific component, following the triggers in `deploy-server.yml`
 

--- a/src/PackageVersions.props
+++ b/src/PackageVersions.props
@@ -1,6 +1,9 @@
 <Project>
 
   <PropertyGroup>
+    <RelegoCoreVersion>0.8.0</RelegoCoreVersion>
+    <RelegoCliVersion>0.15.4</RelegoCliVersion>
+    <RelegoServerVersion>0.18.0</RelegoServerVersion>
     <PollyVersion>8.6.6</PollyVersion>
     <MicrosoftDataSqliteVersion>10.0.5</MicrosoftDataSqliteVersion>
   </PropertyGroup>

--- a/src/Relego.Cli/Relego.Cli.csproj
+++ b/src/Relego.Cli/Relego.Cli.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.15.4</Version>
+    <Version>$(RelegoCliVersion)</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Relego.Core/Relego.Core.csproj
+++ b/src/Relego.Core/Relego.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\PackageVersions.props" />
 
   <PropertyGroup>
-    <Version>0.8.0</Version>
+    <Version>$(RelegoCoreVersion)</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Relego.Server/Relego.Server.csproj
+++ b/src/Relego.Server/Relego.Server.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.18.0</Version>
+    <Version>$(RelegoServerVersion)</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/relego.web/package-lock.json
+++ b/src/relego.web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@relego/web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@relego/web",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@fontsource/playfair-display": "^5.3.0",
         "@tanstack/react-query": "^5.90.5",

--- a/src/relego.web/package.json
+++ b/src/relego.web/package.json
@@ -2,7 +2,7 @@
   "name": "@relego/web",
   "private": true,
   "type": "module",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",
     "build": "tsc --noEmit && vite build",

--- a/src/relego.web/relego.web.esproj
+++ b/src/relego.web/relego.web.esproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.6311650">
 
+  <Import Project="..\PackageVersions.props" />
+
   <PropertyGroup>
+    <Version>$(RelegoServerVersion)</Version>
     <BuildOutputFolder>$(MSBuildProjectDirectory)\dist</BuildOutputFolder>
     <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
     <ShouldRunNpmAudit>false</ShouldRunNpmAudit>


### PR DESCRIPTION
## Summary
- centralize Core, CLI, and Server release versions in `src/PackageVersions.props`
- bind embedded web UI versioning to Server without an independent npm release
- resolve centralized versions in discovery, bump checks, tagging, and release-note paths

Closes #431