### PR TITLE
Add read permission for contents in publish server image workflow

### DIFF
--- a/.github/workflows/publish-server-image.yaml
+++ b/.github/workflows/publish-server-image.yaml
@@ -37,6 +37,7 @@ jobs:
     if: needs.check-tag.outputs.is-server == 'true'
     uses: ./.github/workflows/publish-image-reusable.yaml
     permissions:
+      contents: read
       packages: write
       id-token: write
       attestations: write


### PR DESCRIPTION
Grant read permission for contents in the publish server image workflow to ensure proper access during the image publishing process.

Close #433